### PR TITLE
Add raw-field diagnostic for order/deal callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,56 @@
 
 *zmq fast-path；约 30% 请求会撞 QMT 的 GIL 调度尖峰（~500ms）。
 
+### FormulaServer 直连快速路径（只读行情，默认开启）
+
+大 QMT 的 `58600` 端口是 **FormulaServer**——QMT 内置的 C++ 行情/参考数据服务（端口取自
+`config/formulaserver/formulaserver.ini` 的 `[server_formula] address`）。QMT 自带 Python
+的 `qmt_api` 包就是它的客户端。
+
+客户端对这些方法会**绕开整条 RPC 链路**（不经过 QMT 的 python 策略线程，也不抢 GIL），
+实测 **p50 0.07ms**，穿过完整客户端栈是 **0.145ms/次**：
+
+| 对比 | p50 |
+|------|-----|
+| redis RPC | ~13ms |
+| zmq RPC | ~0.7ms（30% 撞 500ms GIL 尖峰）|
+| **FormulaServer 直连** | **0.07ms**（无 GIL 竞争）|
+
+直连覆盖 10 个方法：`get_instrument` / `get_instrument_detail` / `get_instrumentdetail` /
+`get_last_volume` / `get_total_share` / `get_contract_multiplier` / `get_main_contract` /
+`get_weight_in_index` / `get_stock_list_in_sector` / `get_market_data_ex`。
+
+**能力边界（重要）**：FormulaServer 只有行情/参考数据。所有账户、持仓、委托、成交、下单
+方法一律返回 `ErrorID 200005 未找到该服务`，`getFullTick`/`getQuote` 也不存在。所以它是
+**只读快速路径，不是 RPC 桥的替代品**——交易、账户查询、五档盘口仍然走 RPC。
+
+以下方法**刻意不走**直连，因为参数语义与我们的调用方不一致，宁慢勿错：
+
+- `get_trading_dates` —— FormulaServer 要**股票代码**（`000001.SZ`），传市场代码（`SH`）静默返回 `[]`，而我们的调用方传的是市场。
+- `get_divid_factors` / `get_risk_free_rate` —— 参数语义不同（区间 vs 单日、index vs timetag）。
+- **复权 K 线** —— 实测 `dividendType` 传 `none` 和 `front` 返回完全相同，复权未生效。因此只有
+  `dividend_type="none"` 才走直连，其余回退 RPC，避免静默返回未复权价格。
+
+配置（客户端侧，默认就是开启，通常不用写）：
+
+```python
+BIGQMT_REDIS_CONFIG = {
+    "formula_server": {
+        "enabled": True,              # 或环境变量 BIGQMT_FORMULA_ENABLED=0 关闭
+        # "host": "127.0.0.1",        # 默认本机；FormulaServer 绑 0.0.0.0，跨机需放行防火墙
+        # "port": 58600,              # 不写则从 qmt_root 的 ini 读，再退回 58600
+        # "qmt_root": r"D:\国金证券QMT交易端",
+        # "timeout_seconds": 3.0,
+        # "methods": ["get_instrument"],       # 只路由白名单里的方法
+        # "failure_cooldown_seconds": 30.0,    # 连不上后停用多久再重试
+    },
+}
+```
+
+**失败一律自动回退 RPC**：方法未映射、参数translate 不了、服务没起、连接断——都退回原路径，
+所以连不上 58600 的客户端行为与改动前完全一致。BSON 编解码内置了无依赖实现（可选用
+pymongo 的 `bson`，两者输出实测逐字节一致），客户端不需要额外装包。
+
 ### 独立 ZMQ 回测桥接
 
 `bigqmt_backtest` 与实盘 RPC 桥接完全分离，提供两个明确隔离的后端：
@@ -439,6 +489,7 @@ python -m pytest tests/bigqmt_signal_trader/ -q
 ## 相关文档
 
 - [docs/RPC_API_REFERENCE.md](docs/RPC_API_REFERENCE.md) — **全部 RPC 方法参考**（参数、返回值、别名、大 QMT 能力边界）
+- [docs/FORMULA_SERVER_FASTPATH.md](docs/FORMULA_SERVER_FASTPATH.md) — FormulaServer(58600) 直连快速路径：协议、映射表、能力边界与回退行为
 - [docs/BIG_QMT_REDIS_RPC.md](docs/BIG_QMT_REDIS_RPC.md) — Redis RPC 协议与入口脚本详解
 - [docs/RPC_TRANSPORTS.md](docs/RPC_TRANSPORTS.md) — 可插拔传输层完整说明
 - [docs/XTQUANT_COMPAT_REPLACEMENT.md](docs/XTQUANT_COMPAT_REPLACEMENT.md) — 用兼容层替换旧 xtquant 的步骤
@@ -449,6 +500,8 @@ python -m pytest tests/bigqmt_signal_trader/ -q
 
 ## 为什么不直接连大 QMT
 
-官方 `xtquant.xttrader.XtQuantTrader` 依赖客户端侧 XtQuantServer 通道。当前国金大 QMT 环境中直接连 `connect()` 返回 `-1`；大 QMT 的 `58600` 端口是 FormulaServer 不是行情服务。
+官方 `xtquant.xttrader.XtQuantTrader` 依赖客户端侧 XtQuantServer 通道。当前国金大 QMT 环境中直接连 `connect()` 返回 `-1`，**交易能力**因此必须放在大 QMT 内部策略进程里，外部通过 RPC 驱动。
 
-因此本仓库把真实接口调用放在大 QMT 内部策略进程，外部通过 RPC 驱动。如果后续券商开通 XtQuantServer 权限且 `connect()==0`，可再加直连模式。
+**但只读行情不必走 RPC。** `58600` 是 FormulaServer，它同时就是行情/参考数据服务——QMT 自带 Python 里的 `qmt_api` 包（`bin.x64/Lib/site-packages/qmt_api`）正是它的客户端。本仓库已接入这条直连快速路径，见上文「FormulaServer 直连快速路径」。
+
+如果后续券商开通 XtQuantServer 权限且 `connect()==0`，可再加交易直连模式。

--- a/docs/FORMULA_SERVER_FASTPATH.md
+++ b/docs/FORMULA_SERVER_FASTPATH.md
@@ -1,0 +1,168 @@
+# FormulaServer 直连快速路径（58600）
+
+## 这是什么
+
+大 QMT 的 `58600` 端口是 **FormulaServer** —— QMT 内置的 C++ 行情/参考数据服务。端口取自
+QMT 安装目录的 `config/formulaserver/formulaserver.ini`：
+
+```ini
+[server_formula]
+address = 0.0.0.0:58600
+```
+
+QMT 自带 Python 里就有它的官方客户端：`bin.x64/Lib/site-packages/qmt_api`。协议是
+**BSON over TCP**，帧格式在 `qmt_api/net/RPCBase.py`：
+
+```
+| packLen(uint32 BE) | seq(uint32 BE) | cmd(uint16 BE) | tag(uint16 BE) | BSON body |
+```
+
+`cmd = 3`（`NET_CMD_RPC`），body 是 `{"func": <名字>, "params": {...}}`，
+响应 `{"status": 0, "params": {...}}`，`status != 0` 时 `params` 里带 `ErrorID`/`ErrorMsg`。
+`tag & 7` 标记 zlib 压缩，`tag >> 8` 的低 4 位是 seq 的高位。
+
+## 为什么值得接
+
+原来所有只读请求都要绕一整圈：
+
+```
+客户端 → redis/zmq → QMT python 策略线程 → ContextInfo → 原路返回
+```
+
+这不只是慢，还要和策略自己抢 QMT 主线程的 GIL —— zmq 传输约 30% 的请求会撞上 ~500ms 的
+调度尖峰，就是这么来的。
+
+直连 FormulaServer 完全绕开策略进程：
+
+| 路径 | p50 |
+|------|-----|
+| redis RPC | ~13ms |
+| zmq RPC | ~0.7ms（30% 撞 500ms GIL 尖峰）|
+| **FormulaServer 直连** | **0.07ms**，无 GIL 竞争 |
+
+穿过完整客户端栈（`BigQmtRpcClient.call`）实测 **0.145ms/次**，比 redis 快约 90 倍。
+
+## 能力边界
+
+**FormulaServer 只有行情/参考数据。** 实测所有账户/交易类方法一律返回
+`ErrorID 200005 未找到该服务`：
+
+```
+getAsset / getPositions / getAccountDetail / passorder   -> 200005
+getFullTick / getQuote                                   -> 200005
+```
+
+所以它是**只读快速路径，不是 RPC 桥的替代品**。交易、账户查询、持仓、委托、成交、
+五档盘口全部仍然走 RPC。
+
+### 已接入的方法（10 个）
+
+| 我们的方法 | FormulaServer func |
+|---|---|
+| `get_instrument` / `get_instrument_detail` / `get_instrumentdetail` | `getInstrumentDetail` |
+| `get_last_volume` | `getLastVolume` |
+| `get_total_share` | `getTotalShare` |
+| `get_contract_multiplier` | `getContractMultiplier` |
+| `get_main_contract` | `getMainContract` |
+| `get_weight_in_index` | `getWeightInIndex` |
+| `get_stock_list_in_sector` | `getStockListInSector` |
+| `get_market_data_ex` | `getMarketData` |
+
+### 刻意不接的方法，以及原因
+
+宁可慢，不能悄悄给错数据。以下几项参数语义与我们的调用方不一致：
+
+- **`get_trading_dates`** —— FormulaServer 要的是**股票代码**。实测：
+  ```
+  {'stockCode': 'SH',        ...} -> {'result': []}          # 静默空
+  {'stockCode': '000001.SZ', ...} -> ['20260630', '20260701', ...]
+  ```
+  而 `market_bigqmt.get_trading_dates(market, ...)` 的调用方传的是市场代码。传错了不报错、
+  只给空列表，交易日历错了后果太重。
+
+- **`get_divid_factors`** —— 我们是 `(stock_code, start_time, end_time)` 区间，
+  FormulaServer 是 `(stockCode, date)` 单日。
+
+- **`get_risk_free_rate`** —— 我们传 `index=-1`，FormulaServer 要 `timetag`。语义不同。
+
+- **复权 K 线** —— 实测 `dividendType` 传 `none` 和 `front` 返回**完全相同**的价格，
+  说明复权没有生效。因此只有 `dividend_type="none"`（或空）才走直连，其他复权类型直接
+  判为 unroutable 回退 RPC。否则策略要前复权、拿到的却是不复权价格，且毫无提示。
+
+### 字段名坑
+
+FormulaServer 的 `getInstrumentDetail` 返回 **`FloatVolumn` / `TotalVolumn`**（官方拼写错误），
+而原生 xtdata SDK 用的是 `FloatVolume` / `TotalVolume`。下游代码按 SDK 拼写读，直接透传会
+静默读到 `None`。所以 `_instrument_result` 做了别名归一化，两种拼写都保留。
+
+### 尚未验证
+
+`qmt_api/api.py` 的 `getMarketData` 支持 `fields=['quoter']`，注释说会返回
+`askPrice/askVol/bidPrice/bidVol`（level1 五档 / level2 十档）。**如果这在盘中可用，
+`get_full_tick` 也能走直连** —— 这是热路径，收益很大。
+
+但收盘时段实测返回空，无法确认。需要**盘中**再测一次：
+
+```python
+c.request('getMarketData', {'fields': ['quoter'], 'stockCodes': ['000001.SZ'],
+                            'startTime': '', 'endTime': '', 'period': 'tick',
+                            'dividendType': 'none', 'count': -1})
+```
+
+在确认之前不要接 —— 没验证就上映射，正是订单方向判定踩过的坑。
+
+## 失败行为
+
+**任何失败都自动回退 RPC**，所以连不上 58600 的客户端行为与改动前完全一致：
+
+| 情况 | 行为 |
+|---|---|
+| 方法不在映射表 | `supports()` 返回 False，直接走 RPC |
+| 参数 translate 不了 | `Unroutable`，走 RPC，**不**触发熔断（这是单次调用的问题） |
+| 服务连不上 / IO 失败 | `Unroutable` + 熔断 `failure_cooldown_seconds`（默认 30s），期间全部走 RPC |
+| 服务端回 `200005` | 该方法永久标记 unimplemented，只停这一个方法，不影响其他 |
+| socket 断了（QMT 重启） | 自动重连重试一次 |
+
+## 依赖
+
+**不需要装任何东西。** BSON 编解码内置了无依赖实现；如果环境里有 pymongo 的 `bson`
+或 QMT 的 `xtquant.xtbson`，会优先用（更快、更久经考验）。两条路径的输出实测逐字节一致，
+测试里有对拍用例。
+
+## 配置
+
+客户端侧，默认开启，通常不用写：
+
+```python
+BIGQMT_FORMULA_SERVER_CONFIG = {
+    "enabled": True,            # 或环境变量 BIGQMT_FORMULA_ENABLED=0 关闭
+    # "host": "127.0.0.1",     # 绑的是 0.0.0.0，跨机可达（需放行防火墙）
+    # "port": 58600,           # 不写则从 qmt_root 的 ini 读，再退回 58600
+    # "qmt_root": r"D:\国金证券QMT交易端",
+    # "timeout_seconds": 3.0,
+    # "methods": ["get_instrument"],      # 只路由白名单
+    # "failure_cooldown_seconds": 30.0,
+}
+```
+
+也可以写在 `BIGQMT_REDIS_CONFIG["formula_server"]` 里，后者优先级更高。
+
+## 排查
+
+```python
+client._formula_router().stats()
+# {'enabled': True, 'hits': 202, 'misses': 0, 'available': True,
+#  'unimplemented': [], 'methods': [...]}
+```
+
+启动时会打一行：
+
+```
+[bigqmt_formula] active at 127.0.0.1:58600 (10 methods routed direct)
+```
+
+熔断时：
+
+```
+[bigqmt_formula] unavailable, falling back to RPC for 30s: connect 127.0.0.1:58600 failed: ...
+```

--- a/src/bigqmt_signal_trader/exec_events.py
+++ b/src/bigqmt_signal_trader/exec_events.py
@@ -131,6 +131,85 @@ def _extract_direction(obj):
     return _attr(obj, ["order_type"])
 
 
+# Fields we care about when diagnosing a direction misread. Anything starting
+# with "m_" is captured automatically; these are the MiniQMT-style names that
+# do not match that prefix.
+_RAW_SNAPSHOT_EXTRA_FIELDS = (
+    "stock_code",
+    "order_type",
+    "direction",
+    "offset_flag",
+    "order_status",
+    "order_volume",
+    "traded_volume",
+    "price",
+    "order_id",
+    "order_sysid",
+    "order_sys_id",
+    "trade_id",
+    "traded_id",
+    "strategy_name",
+    "order_remark",
+)
+
+
+def raw_field_snapshot(obj, max_repr=120):
+    """Capture every readable field of a live QMT callback object.
+
+    Direction extraction rests on an assumption about what ``m_nDirection`` and
+    ``m_nOffsetFlag`` actually carry in live order_callback/deal_callback — an
+    assumption nothing in this repo has ever observed. This dumps the raw object
+    so one live order settles it.
+
+    Returns ``{name: "<type> <value>"}``. Never raises: a callback that dies
+    while being diagnosed would be worse than no diagnosis.
+    """
+    snapshot = {}
+    try:
+        if isinstance(obj, dict):
+            names = list(obj.keys())
+        else:
+            names = [name for name in dir(obj) if name.startswith("m_")]
+            names.extend(_RAW_SNAPSHOT_EXTRA_FIELDS)
+    except Exception:
+        return {"__error__": "dir() failed"}
+    seen = set()
+    for name in names:
+        key = str(name)
+        if key in seen or key.startswith("__"):
+            continue
+        seen.add(key)
+        try:
+            if isinstance(obj, dict):
+                if key not in obj:
+                    continue
+                value = obj[key]
+            else:
+                if not hasattr(obj, key):
+                    continue
+                value = getattr(obj, key)
+            if callable(value):
+                continue
+            text = repr(value)
+            if len(text) > max_repr:
+                text = text[:max_repr] + "..."
+            snapshot[key] = "%s %s" % (type(value).__name__, text)
+        except Exception as exc:  # noqa: BLE001 - diagnostics must not break callbacks
+            snapshot[key] = "<unreadable: %s>" % exc.__class__.__name__
+    return snapshot
+
+
+def format_raw_snapshot(kind, obj):
+    """One-line, GBK-safe rendering of :func:`raw_field_snapshot` for the QMT panel."""
+    snapshot = raw_field_snapshot(obj)
+    parts = ["%s=%s" % (name, snapshot[name]) for name in sorted(snapshot)]
+    return "[bigqmt_exec_raw] %s type=%s %s" % (
+        kind,
+        type(obj).__name__,
+        " | ".join(parts) or "<no fields>",
+    )
+
+
 def normalize_order_event(order, account_id=""):
     """Build a JSON-able order event dict from a Big QMT orderInfo object."""
     direction = _extract_direction(order)

--- a/src/bigqmt_signal_trader/formula_server.py
+++ b/src/bigqmt_signal_trader/formula_server.py
@@ -1,0 +1,710 @@
+"""Direct client for the Big QMT FormulaServer RPC (default port 58600).
+
+Why this exists
+---------------
+The RPC bridge in :mod:`redis_rpc` routes every read through the QMT *strategy*
+process: client -> redis/zmq -> QMT python thread -> ContextInfo -> back. That
+costs ~13ms (redis) or ~0.7ms-with-500ms-GIL-spikes (zmq), and every read
+competes for the QMT main-thread GIL against the strategy itself.
+
+FormulaServer is the C++ quote/reference-data service inside the same QMT
+terminal, listening on the port named in ``config/formulaserver/formulaserver.ini``
+(``[server_formula] address``, default 58600). QMT ships its own client for it at
+``bin.x64/Lib/site-packages/qmt_api``. Talking to it directly bypasses the
+strategy process entirely: measured p50 **0.07ms**, and zero GIL contention.
+
+What it can and cannot do
+-------------------------
+FormulaServer serves market/reference data ONLY. Every account, position, order
+and trade method answers ``ErrorID 200005 未找到该服务``, as do ``getFullTick``
+and ``getQuote``. So this is a read fast-path, never a replacement for the RPC
+bridge — trading, account queries and 五档 snapshots stay on it.
+
+Deliberately NOT routed here, despite FormulaServer exposing something similar:
+
+* ``get_trading_dates`` — FormulaServer wants a *stock code* (``000001.SZ``);
+  passing a market (``SH``) silently returns ``[]``. Our callers pass markets.
+* ``get_divid_factors`` / ``get_risk_free_rate`` — parameter semantics differ
+  (range vs single date, index vs timetag). A wrong calendar or dividend factor
+  is worse than a slow one.
+* Adjusted bars — see :func:`_market_data_params`; ``dividendType`` appears to
+  be ignored by the server, so only unadjusted requests are routed.
+
+Every failure here is non-fatal: :class:`FormulaServerRouter` reports the method
+as unroutable and the caller falls back to the normal RPC path.
+"""
+
+import os
+import socket
+import struct
+import threading
+import time
+import zlib
+
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 58600
+DEFAULT_TIMEOUT_SECONDS = 3.0
+# After a transport failure, stop trying for this long so a dead/absent
+# FormulaServer costs one timeout rather than one per call.
+DEFAULT_FAILURE_COOLDOWN_SECONDS = 30.0
+
+NET_CMD_RPC = 3
+COMPRESS_ZLIB = 1
+COMPRESS_DOUBLE_ZLIB = 2
+
+# FormulaServer's "method not found" code. Distinct from a transport failure:
+# it means the server is healthy and simply does not implement the call.
+ERROR_METHOD_NOT_FOUND = 200005
+
+
+class FormulaServerError(RuntimeError):
+    """FormulaServer answered with a non-zero status (bad params, no such method)."""
+
+    def __init__(self, message, error_id=None):
+        RuntimeError.__init__(self, message)
+        self.error_id = error_id
+
+
+class FormulaServerUnavailable(RuntimeError):
+    """The FormulaServer could not be reached (connect/IO/protocol failure)."""
+
+
+# ---------------------------------------------------------------------------
+# BSON codec
+# ---------------------------------------------------------------------------
+# FormulaServer frames BSON documents. pymongo's ``bson`` is used when present
+# (faster, battle-tested); otherwise the minimal codec below covers the types
+# this wire actually carries. Keeping a built-in path means an external client
+# needs no pymongo just to read market data.
+
+def _load_bson():
+    for module_name in ("bson", "xtquant.xtbson.bson36"):
+        try:
+            module = __import__(module_name, fromlist=["BSON"])
+        except Exception:
+            continue
+        if hasattr(module, "BSON"):
+            return module
+    return None
+
+
+_BSON = _load_bson()
+
+
+def _encode_document(pairs):
+    body = b"".join(_encode_element(str(key), value) for key, value in pairs)
+    return struct.pack("<i", len(body) + 5) + body + b"\x00"
+
+
+def _encode_element(name, value):
+    key = name.encode("utf-8") + b"\x00"
+    if value is None:
+        return b"\x0a" + key
+    # bool before int: bool is an int subclass.
+    if isinstance(value, bool):
+        return b"\x08" + key + (b"\x01" if value else b"\x00")
+    if isinstance(value, int):
+        if -2147483648 <= value <= 2147483647:
+            return b"\x10" + key + struct.pack("<i", value)
+        return b"\x12" + key + struct.pack("<q", value)
+    if isinstance(value, float):
+        return b"\x01" + key + struct.pack("<d", value)
+    if isinstance(value, bytes):
+        return b"\x05" + key + struct.pack("<i", len(value)) + b"\x00" + value
+    if isinstance(value, str):
+        raw = value.encode("utf-8") + b"\x00"
+        return b"\x02" + key + struct.pack("<i", len(raw)) + raw
+    if isinstance(value, (list, tuple)):
+        return b"\x04" + key + _encode_document(
+            (str(index), item) for index, item in enumerate(value)
+        )
+    if isinstance(value, dict):
+        return b"\x03" + key + _encode_document(value.items())
+    raise TypeError("cannot BSON-encode %s" % type(value).__name__)
+
+
+def _decode_document(data, pos):
+    size = struct.unpack_from("<i", data, pos)[0]
+    end = pos + size
+    pos += 4
+    out = {}
+    while pos < end - 1:
+        type_byte = data[pos] if isinstance(data[pos], int) else ord(data[pos])
+        pos += 1
+        terminator = data.index(b"\x00", pos)
+        name = data[pos:terminator].decode("utf-8", "replace")
+        pos = terminator + 1
+        out[name], pos = _decode_element(type_byte, data, pos)
+    return out, end
+
+
+def _decode_element(type_byte, data, pos):
+    if type_byte == 0x01:
+        return struct.unpack_from("<d", data, pos)[0], pos + 8
+    if type_byte == 0x02:
+        length = struct.unpack_from("<i", data, pos)[0]
+        pos += 4
+        return data[pos:pos + length - 1].decode("utf-8", "replace"), pos + length
+    if type_byte == 0x03:
+        return _decode_document(data, pos)
+    if type_byte == 0x04:
+        doc, end = _decode_document(data, pos)
+        try:
+            ordered = sorted(doc, key=lambda key: int(key))
+        except (TypeError, ValueError):
+            ordered = sorted(doc)
+        return [doc[key] for key in ordered], end
+    if type_byte == 0x05:
+        length = struct.unpack_from("<i", data, pos)[0]
+        pos += 5  # int32 length + 1 subtype byte
+        return data[pos:pos + length], pos + length
+    if type_byte == 0x08:
+        flag = data[pos] if isinstance(data[pos], int) else ord(data[pos])
+        return bool(flag), pos + 1
+    if type_byte in (0x09, 0x12):
+        return struct.unpack_from("<q", data, pos)[0], pos + 8
+    if type_byte == 0x0A:
+        return None, pos
+    if type_byte == 0x10:
+        return struct.unpack_from("<i", data, pos)[0], pos + 4
+    if type_byte == 0x11:
+        return struct.unpack_from("<Q", data, pos)[0], pos + 8
+    raise ValueError("unsupported BSON type byte 0x%02x" % type_byte)
+
+
+def bson_encode(document):
+    if _BSON is not None:
+        return _BSON.BSON.encode(document)
+    return _encode_document(document.items())
+
+
+def bson_decode(payload):
+    if _BSON is not None:
+        return _BSON.BSON(payload).decode()
+    return _decode_document(payload, 0)[0]
+
+
+# ---------------------------------------------------------------------------
+# Address discovery
+# ---------------------------------------------------------------------------
+
+def read_formulaserver_port(qmt_root):
+    """Read ``[server_formula] address`` from a QMT install's formulaserver.ini.
+
+    ``qmt_root`` is the terminal directory (the one holding ``bin.x64`` and
+    ``config``). Returns the port int, or None when the file is absent or
+    unparsable — callers then fall back to :data:`DEFAULT_PORT`.
+    """
+    if not qmt_root:
+        return None
+    path = os.path.join(str(qmt_root), "config", "formulaserver", "formulaserver.ini")
+    try:
+        try:
+            import configparser
+        except ImportError:  # pragma: no cover - py2 safety net
+            import ConfigParser as configparser
+        parser = configparser.ConfigParser()
+        if not parser.read(path):
+            return None
+        address = parser.get("server_formula", "address")
+    except Exception:
+        return None
+    if ":" not in str(address):
+        return None
+    try:
+        return int(str(address).rsplit(":", 1)[1])
+    except (TypeError, ValueError):
+        return None
+
+
+def resolve_address(config=None):
+    """Resolve (host, port) for the FormulaServer.
+
+    Priority: explicit ``host``/``port`` > ``formulaserver.ini`` under
+    ``qmt_root`` > ``BIGQMT_FORMULA_HOST``/``BIGQMT_FORMULA_PORT`` > defaults.
+    The address binds ``0.0.0.0`` in QMT's shipped config, so a remote client
+    can reach it too when the firewall allows.
+    """
+    config = dict(config or {})
+    host = str(config.get("host") or os.environ.get("BIGQMT_FORMULA_HOST") or DEFAULT_HOST)
+    port = config.get("port")
+    if not port:
+        port = read_formulaserver_port(config.get("qmt_root"))
+    if not port:
+        port = os.environ.get("BIGQMT_FORMULA_PORT")
+    try:
+        port = int(port)
+    except (TypeError, ValueError):
+        port = DEFAULT_PORT
+    return host, port
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+class FormulaServerClient(object):
+    """Thread-safe BSON-over-TCP client for FormulaServer.
+
+    One socket is shared under a lock. FormulaServer matches responses by
+    sequence number, so concurrent use of a single socket would require
+    demultiplexing; serializing is simpler and, at 0.07ms per call, ample.
+    """
+
+    def __init__(
+        self,
+        host=DEFAULT_HOST,
+        port=DEFAULT_PORT,
+        timeout_seconds=DEFAULT_TIMEOUT_SECONDS,
+        print_prefix="[bigqmt_formula]",
+    ):
+        self.host = str(host or DEFAULT_HOST)
+        self.port = int(port or DEFAULT_PORT)
+        self.timeout_seconds = float(timeout_seconds or DEFAULT_TIMEOUT_SECONDS)
+        self.print_prefix = print_prefix
+        self._lock = threading.Lock()
+        self._socket = None
+        self._seq = 0
+
+    # -- wire ------------------------------------------------------------
+    def _connect_locked(self):
+        if self._socket is not None:
+            return self._socket
+        try:
+            sock = socket.create_connection((self.host, self.port), self.timeout_seconds)
+            sock.settimeout(self.timeout_seconds)
+        except Exception as exc:
+            raise FormulaServerUnavailable(
+                "connect %s:%s failed: %s" % (self.host, self.port, exc)
+            )
+        self._socket = sock
+        return sock
+
+    def _close_locked(self):
+        if self._socket is not None:
+            try:
+                self._socket.close()
+            except Exception:
+                pass
+            self._socket = None
+
+    def close(self):
+        with self._lock:
+            self._close_locked()
+
+    def _recv_exactly(self, sock, length):
+        chunks = []
+        remaining = length
+        while remaining > 0:
+            more = sock.recv(remaining)
+            if not more:
+                raise FormulaServerUnavailable("socket closed mid-message")
+            chunks.append(more)
+            remaining -= len(more)
+        return b"".join(chunks)
+
+    def _request_locked(self, func, params):
+        sock = self._connect_locked()
+        self._seq += 1
+        seq = self._seq
+        body = bson_encode({"func": str(func), "params": dict(params or {})})
+        tag = ((seq >> 32) & 0x0F) << 8
+        packet = struct.pack(
+            "!IIHH%ds" % len(body),
+            len(body) + 12,
+            seq & 0xFFFFFFFF,
+            NET_CMD_RPC,
+            tag,
+            body,
+        )
+        try:
+            sock.sendall(packet)
+        except Exception as exc:
+            raise FormulaServerUnavailable("send failed: %s" % exc)
+        # Subscription pushes share the socket; skip anything that is not our seq.
+        while True:
+            try:
+                header = self._recv_exactly(sock, 4)
+                pack_len = struct.unpack_from("!I", header, 0)[0]
+                rest = self._recv_exactly(sock, pack_len - 4)
+            except FormulaServerUnavailable:
+                raise
+            except Exception as exc:
+                raise FormulaServerUnavailable("recv failed: %s" % exc)
+            raw = header + rest
+            try:
+                got_seq, _cmd, got_tag, payload_bytes = struct.unpack_from(
+                    "!IHH%ds" % (pack_len - 12), raw, 4
+                )
+                if (got_tag & 7) in (COMPRESS_ZLIB, COMPRESS_DOUBLE_ZLIB):
+                    payload_bytes = zlib.decompress(payload_bytes)
+                got_seq = ((got_tag >> 8) & 0x0F) << 32 | got_seq
+                payload = bson_decode(payload_bytes)
+            except Exception as exc:
+                raise FormulaServerUnavailable("decode failed: %s" % exc)
+            if got_seq != seq:
+                continue
+            if payload.get("status") == 0:
+                return payload.get("params")
+            detail = payload.get("params")
+            error_id = None
+            if isinstance(detail, dict):
+                error_id = detail.get("ErrorID")
+            raise FormulaServerError(
+                "%s failed: %r" % (func, detail), error_id=error_id
+            )
+
+    def request(self, func, params=None):
+        """Call ``func`` and return its ``params`` payload.
+
+        Retries once on a transport failure, since QMT restarts (or an idle
+        socket reaped by the server) show up as a dead socket on first use.
+        """
+        with self._lock:
+            try:
+                return self._request_locked(func, params)
+            except FormulaServerError:
+                raise
+            except FormulaServerUnavailable:
+                self._close_locked()
+                return self._request_locked(func, params)
+
+    def ping(self):
+        """Cheap liveness probe. True when FormulaServer answers at all.
+
+        A ``FormulaServerError`` still counts as alive — the server replied.
+        """
+        try:
+            self.request("getLastVolume", {"stockCode": "000001.SZ"})
+            return True
+        except FormulaServerError:
+            return True
+        except FormulaServerUnavailable:
+            return False
+
+    def __repr__(self):
+        return "<FormulaServerClient %s:%s>" % (self.host, self.port)
+
+
+# ---------------------------------------------------------------------------
+# Method mapping
+# ---------------------------------------------------------------------------
+# FormulaServer misspells two instrument fields relative to the xtdata SDK
+# (``FloatVolume``/``TotalVolume``). Downstream code reads the SDK spelling, so
+# alias them rather than let the lookup silently miss.
+_INSTRUMENT_ALIASES = (
+    ("FloatVolumn", "FloatVolume"),
+    ("TotalVolumn", "TotalVolume"),
+)
+
+
+def _first(params, names, default=None):
+    for name in names:
+        if name in params and params[name] is not None:
+            return params[name]
+    return default
+
+
+def _require_code(params, names):
+    code = _first(params, names)
+    text = str(code or "").strip()
+    if not text:
+        raise ValueError("a stock code is required (one of %s)" % ", ".join(names))
+    return text
+
+
+def _instrument_params(params):
+    return {"strOptionCode": _require_code(params, ("code", "stock_code", "stockcode"))}
+
+
+def _instrument_result(raw, params):
+    detail = (raw or {}).get("result")
+    if not isinstance(detail, dict):
+        return detail or {}
+    out = dict(detail)
+    for wire_name, sdk_name in _INSTRUMENT_ALIASES:
+        if wire_name in out and sdk_name not in out:
+            out[sdk_name] = out[wire_name]
+    return out
+
+
+def _scalar_result(raw, params):
+    return (raw or {}).get("result")
+
+
+def _list_result(raw, params):
+    return (raw or {}).get("result") or []
+
+
+def _last_volume_params(params):
+    return {"stockCode": _require_code(params, ("stock", "code", "stock_code", "stockcode"))}
+
+
+def _total_share_params(params):
+    return {"stockCode": _require_code(params, ("stockcode", "code", "stock_code", "stock"))}
+
+
+def _contract_multiplier_params(params):
+    return {"contractCode": _require_code(params, ("stockcode", "code", "stock_code", "contract_code"))}
+
+
+def _main_contract_params(params):
+    return {"codeMarket": _require_code(params, ("code_market", "codeMarket", "code"))}
+
+
+def _sector_params(params):
+    name = str(_first(params, ("sector_name", "sectorName", "sector"), "") or "").strip()
+    if not name:
+        raise ValueError("sector_name is required")
+    # ContextInfo's real_timetag defaults to -1; FormulaServer's realtime
+    # defaults to 0. Both return identical constituents (verified), so normalize
+    # the sentinel rather than forward a value the server never documents.
+    realtime = _first(params, ("real_timetag", "realtime"), 0)
+    try:
+        realtime = int(realtime)
+    except (TypeError, ValueError):
+        realtime = 0
+    if realtime < 0:
+        realtime = 0
+    return {"sectorName": name, "realtime": realtime}
+
+
+def _weight_in_index_params(params):
+    index_code = _first(params, ("mtkindexcode", "index_code", "indexCode"))
+    stock_code = _first(params, ("stockcode", "stock_code", "code"))
+    if not index_code or not stock_code:
+        raise ValueError("mtkindexcode and stockcode are required")
+    return {"indexCode": str(index_code), "stockCode": str(stock_code)}
+
+
+def _market_data_params(params):
+    fields = list(_first(params, ("field_list", "fields"), None) or [])
+    codes = list(_first(params, ("stock_list", "stock_code", "stockCodes"), None) or [])
+    if not fields or not codes:
+        raise ValueError("field_list and stock_list are required")
+    dividend_type = str(params.get("dividend_type") or "none").lower()
+    # FormulaServer returns byte-identical bars for dividendType none/front, so
+    # adjustment is not applied here. Serving an adjusted request from this path
+    # would silently hand back unadjusted prices — refuse and let RPC answer.
+    if dividend_type not in ("", "none"):
+        raise ValueError("adjusted bars (dividend_type=%s) are not served here" % dividend_type)
+    period = str(params.get("period") or "1d")
+    count = params.get("count", -1)
+    try:
+        count = int(count)
+    except (TypeError, ValueError):
+        count = -1
+    return {
+        "fields": [str(field) for field in fields],
+        "stockCodes": [str(code) for code in codes],
+        "startTime": str(params.get("start_time") or ""),
+        "endTime": str(params.get("end_time") or ""),
+        "period": period,
+        "dividendType": "none",
+        "count": count,
+    }
+
+
+def _market_data_result(raw, params):
+    """Translate FormulaServer's flat bar list into the RPC path's payload.
+
+    Wire shape is ``[code, [time, [field, value, ...], time, [...]], code, ...]``.
+    We emit the same ``__bigqmt_type__: DataFrame`` envelope the QMT-side adapter
+    builds, so the client's ``_restore_jsonable`` rebuilds identical DataFrames
+    whichever path answered.
+    """
+    flat = (raw or {}).get("result") or []
+    fields = [str(field) for field in (_first(params, ("field_list", "fields"), None) or [])]
+    columns = list(fields)
+    if columns and "stime" not in columns:
+        columns.insert(0, "stime")
+
+    parsed = {}
+    for index in range(0, len(flat) - 1, 2):
+        code = str(flat[index])
+        timeline = flat[index + 1] or []
+        records = []
+        for offset in range(0, len(timeline) - 1, 2):
+            stamp = timeline[offset]
+            pairs = timeline[offset + 1] or []
+            record = {"stime": stamp}
+            for cursor in range(0, len(pairs) - 1, 2):
+                record[str(pairs[cursor])] = pairs[cursor + 1]
+            records.append(record)
+        parsed[code] = records
+
+    requested = [str(code) for code in (_first(params, ("stock_list", "stock_code"), None) or [])]
+    for code in parsed:
+        if code not in requested:
+            requested.append(code)
+    return {
+        code: {
+            "__bigqmt_type__": "DataFrame",
+            "columns": columns,
+            "records": parsed.get(code) or [],
+        }
+        for code in requested
+    }
+
+
+# our RPC method -> (FormulaServer func, param builder, result adapter)
+METHOD_MAP = {
+    "get_instrument": ("getInstrumentDetail", _instrument_params, _instrument_result),
+    "get_instrumentdetail": ("getInstrumentDetail", _instrument_params, _instrument_result),
+    "get_instrument_detail": ("getInstrumentDetail", _instrument_params, _instrument_result),
+    "get_last_volume": ("getLastVolume", _last_volume_params, _scalar_result),
+    "get_total_share": ("getTotalShare", _total_share_params, _scalar_result),
+    "get_contract_multiplier": ("getContractMultiplier", _contract_multiplier_params, _scalar_result),
+    "get_main_contract": ("getMainContract", _main_contract_params, _scalar_result),
+    "get_weight_in_index": ("getWeightInIndex", _weight_in_index_params, _scalar_result),
+    "get_stock_list_in_sector": ("getStockListInSector", _sector_params, _list_result),
+    "get_market_data_ex": ("getMarketData", _market_data_params, _market_data_result),
+}
+
+SUPPORTED_METHODS = tuple(sorted(METHOD_MAP))
+
+
+class Unroutable(Exception):
+    """This call cannot be served by FormulaServer — use the RPC bridge."""
+
+
+class FormulaServerRouter(object):
+    """Routes supported read methods to FormulaServer, or declines.
+
+    :meth:`call` raises :class:`Unroutable` for anything it cannot serve —
+    method not mapped, params that do not translate, server down, feature
+    disabled. Callers treat that as "fall back to RPC".
+    """
+
+    def __init__(
+        self,
+        client=None,
+        enabled=True,
+        methods=None,
+        failure_cooldown_seconds=DEFAULT_FAILURE_COOLDOWN_SECONDS,
+        print_prefix="[bigqmt_formula]",
+        config=None,
+    ):
+        self.enabled = bool(enabled)
+        self.print_prefix = print_prefix
+        self.failure_cooldown_seconds = float(
+            failure_cooldown_seconds or DEFAULT_FAILURE_COOLDOWN_SECONDS
+        )
+        if client is None and self.enabled:
+            host, port = resolve_address(config)
+            timeout = float((config or {}).get("timeout_seconds") or DEFAULT_TIMEOUT_SECONDS)
+            client = FormulaServerClient(
+                host=host, port=port, timeout_seconds=timeout, print_prefix=print_prefix
+            )
+        self.client = client
+        if methods:
+            self.methods = set(str(name) for name in methods) & set(METHOD_MAP)
+        else:
+            self.methods = set(METHOD_MAP)
+        self._unavailable_until = 0.0
+        self._announced = False
+        # Methods the server itself rejected as unimplemented — never retried.
+        self._unimplemented = set()
+        self.hits = 0
+        self.misses = 0
+
+    def _available(self):
+        if not self.enabled or self.client is None:
+            return False
+        return time.time() >= self._unavailable_until
+
+    def _mark_unavailable(self, reason):
+        self._unavailable_until = time.time() + self.failure_cooldown_seconds
+        print(
+            "%s unavailable, falling back to RPC for %.0fs: %s"
+            % (self.print_prefix, self.failure_cooldown_seconds, reason)
+        )
+
+    def supports(self, method):
+        return (
+            str(method) in self.methods
+            and str(method) not in self._unimplemented
+            and self._available()
+        )
+
+    def call(self, method, params=None):
+        """Serve ``method`` from FormulaServer, or raise :class:`Unroutable`."""
+        method = str(method)
+        if not self.supports(method):
+            raise Unroutable(method)
+        func, build_params, adapt_result = METHOD_MAP[method]
+        try:
+            wire_params = build_params(dict(params or {}))
+        except Exception as exc:
+            # Params that do not translate are a per-call condition, not a
+            # server fault — do not trip the breaker.
+            self.misses += 1
+            raise Unroutable("%s: %s" % (method, exc))
+        try:
+            raw = self.client.request(func, wire_params)
+        except FormulaServerError as exc:
+            self.misses += 1
+            if exc.error_id == ERROR_METHOD_NOT_FOUND:
+                self._unimplemented.add(method)
+                print(
+                    "%s %s not implemented by this terminal, using RPC from now on"
+                    % (self.print_prefix, method)
+                )
+            raise Unroutable("%s: %s" % (method, exc))
+        except FormulaServerUnavailable as exc:
+            self.misses += 1
+            self._mark_unavailable(str(exc))
+            raise Unroutable("%s: %s" % (method, exc))
+        except Exception as exc:
+            self.misses += 1
+            self._mark_unavailable("%s: %s" % (exc.__class__.__name__, exc))
+            raise Unroutable("%s: %s" % (method, exc))
+        try:
+            result = adapt_result(raw, dict(params or {}))
+        except Exception as exc:
+            self.misses += 1
+            raise Unroutable("%s: result adaptation failed: %s" % (method, exc))
+        self.hits += 1
+        if not self._announced:
+            self._announced = True
+            print(
+                "%s active at %s:%s (%d methods routed direct)"
+                % (self.print_prefix, self.client.host, self.client.port, len(self.methods))
+            )
+        return result
+
+    def stats(self):
+        return {
+            "enabled": self.enabled,
+            "hits": self.hits,
+            "misses": self.misses,
+            "available": self._available(),
+            "unimplemented": sorted(self._unimplemented),
+            "methods": sorted(self.methods),
+        }
+
+    def close(self):
+        if self.client is not None:
+            self.client.close()
+
+
+def build_router(config=None, print_prefix="[bigqmt_formula]"):
+    """Build a router from a ``formula_server`` config dict.
+
+    Recognised keys: ``enabled`` (default True), ``host``, ``port``,
+    ``qmt_root``, ``timeout_seconds``, ``methods``, ``failure_cooldown_seconds``.
+    ``enabled=False`` yields a router that declines everything, so callers need
+    no None checks.
+    """
+    config = dict(config or {})
+    enabled = config.get("enabled", True)
+    if isinstance(enabled, str):
+        enabled = enabled.strip().lower() not in ("0", "false", "no", "off")
+    return FormulaServerRouter(
+        enabled=bool(enabled),
+        methods=config.get("methods"),
+        failure_cooldown_seconds=config.get("failure_cooldown_seconds"),
+        print_prefix=print_prefix,
+        config=config,
+    )

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -161,6 +161,8 @@ def load_client_config(module_name=None):
         for key in ("local_cache_enabled", "local_cache_dir", "local_cache_fallback_rpc", "local_cache_format"):
             if key in redis_config:
                 local_cache_config[key.replace("local_cache_", "")] = redis_config[key]
+        formula_server_config = dict(getattr(module, "BIGQMT_FORMULA_SERVER_CONFIG", {}) or {})
+        formula_server_config.update(dict(redis_config.get("formula_server") or {}))
         return {
             "module": candidate,
             "account_id": account_id,
@@ -168,6 +170,7 @@ def load_client_config(module_name=None):
             "timeout_seconds": timeout_seconds,
             "full_tick_cache_config": full_tick_cache_config,
             "local_cache_config": local_cache_config,
+            "formula_server_config": formula_server_config,
         }
     return {}
 
@@ -366,6 +369,19 @@ class BigQmtRpcClient:
         self.zmq_config = dict(merged_redis_config.get("zmq") or {})
         self.mysql_config = dict(merged_redis_config.get("mysql") or {})
         self._transport_instance = None  # lazily built by _transport()
+        # FormulaServer read fast-path. QMT's C++ quote service (port 58600)
+        # answers reference/history reads in ~0.07ms without touching the QMT
+        # python thread. Enabled by default; every miss falls back to RPC, so a
+        # client that cannot reach it just runs as before.
+        formula_config = dict(
+            client_config.get("formula_server_config")
+            or merged_redis_config.get("formula_server")
+            or {}
+        )
+        if "enabled" not in formula_config:
+            formula_config["enabled"] = _env_bool("BIGQMT_FORMULA_ENABLED", True)
+        self.formula_server_config = formula_config
+        self._formula_router_instance = None  # lazily built by _formula_router()
 
     def _redis(self):
         if self.redis_client is None:
@@ -409,11 +425,43 @@ class BigQmtRpcClient:
             )
         return self._transport_instance
 
+    def _formula_router(self):
+        """Lazily build the FormulaServer router. Never raises — a router that
+        cannot be built simply means every read goes over RPC."""
+        if self._formula_router_instance is None:
+            try:
+                from .formula_server import build_router
+
+                self._formula_router_instance = build_router(
+                    self.formula_server_config, print_prefix="[bigqmt_formula]"
+                )
+            except Exception as exc:
+                print("[bigqmt_formula] disabled (%s: %s)" % (exc.__class__.__name__, exc))
+
+                class _Disabled(object):
+                    def supports(self, method):
+                        return False
+
+                self._formula_router_instance = _Disabled()
+        return self._formula_router_instance
+
     def call(self, method, params=None, account_id=None, timeout_seconds=None):
         target_account = str(account_id or self.account_id or "")
         if not target_account:
             raise ValueError("Big QMT account_id is required")
         wait_seconds = self.timeout_seconds if timeout_seconds is None else timeout_seconds
+        # Fast path: reference/history reads answered straight by QMT's
+        # FormulaServer, bypassing the strategy process and its GIL. Anything it
+        # declines (unmapped method, untranslatable params, server down) raises
+        # Unroutable and drops through to the RPC bridge below.
+        router = self._formula_router()
+        if router.supports(method):
+            from .formula_server import Unroutable
+
+            try:
+                return _restore_jsonable(router.call(method, params or {}))
+            except Unroutable:
+                pass
         transport = self._transport()
         if transport is not None:
             # Swappable transport path (zmq/mysql/...). Build the request

--- a/src/bigqmt_signal_trader_client_config.example.py
+++ b/src/bigqmt_signal_trader_client_config.example.py
@@ -45,3 +45,24 @@ BIGQMT_LOCAL_CACHE_CONFIG = {
     # One file per (period, dividend_type, code); switching format auto-migrates.
     "format": "auto",
 }
+
+# FormulaServer direct read fast-path (port 58600).
+#   Big QMT's built-in C++ quote/reference service. Routing reads straight to it
+#   bypasses the RPC bridge AND the QMT python thread's GIL: ~0.07ms vs ~13ms
+#   over redis. Enabled by default; you normally do not need this block.
+#
+#   Covers reference/history reads only. Account, position, order, trade and
+#   五档 (get_full_tick) calls are NOT served by FormulaServer and always go over
+#   RPC. Every miss — unmapped method, untranslatable params, server down —
+#   falls back to RPC automatically, so an unreachable 58600 changes nothing.
+BIGQMT_FORMULA_SERVER_CONFIG = {
+    "enabled": True,        # or set BIGQMT_FORMULA_ENABLED=0 in the environment
+    # "host": "127.0.0.1",  # FormulaServer binds 0.0.0.0, so cross-machine works
+    #                       # if the firewall allows it
+    # "port": 58600,        # unset -> read from qmt_root's formulaserver.ini,
+    #                       # then fall back to 58600
+    # "qmt_root": r"D:\国金证券QMT交易端",
+    # "timeout_seconds": 3.0,
+    # "methods": [...],     # restrict routing to a subset (default: all mapped)
+    # "failure_cooldown_seconds": 30.0,  # pause routing this long after a failure
+}

--- a/src/bigqmt_signal_trader_local_config.example.py
+++ b/src/bigqmt_signal_trader_local_config.example.py
@@ -55,4 +55,10 @@ BIGQMT_REDIS_CONFIG = {
     # Push order_callback/deal_callback details to Redis so clients get real-time
     # on_stock_order / on_stock_trade callbacks (MiniQMT style) instead of polling.
     "exec_events_enabled": True,
+    # Dump the raw order_callback/deal_callback object fields to the QMT output
+    # panel, and attach them to the published event as "raw_fields". Prints on
+    # every callback, so keep it off outside a diagnosis window. Turn it on to
+    # observe what m_nDirection / m_nOffsetFlag actually carry in live callbacks
+    # — the buy/sell mapping in exec_events.py currently assumes 48/49 there.
+    "exec_events_debug_raw_fields": False,
 }

--- a/src/bigqmt_signal_trader_redis_rpc_runtime.py
+++ b/src/bigqmt_signal_trader_redis_rpc_runtime.py
@@ -112,6 +112,11 @@ DOWNLOAD_JOB_TTL_SECONDS = 3600
 # Push order_callback/deal_callback details to Redis so clients get real-time
 # on_stock_order/on_stock_trade callbacks (MiniQMT style) instead of polling.
 EXEC_EVENTS_ENABLED = True
+# Dump the raw order_callback/deal_callback object fields to the QMT output panel
+# (and into the published event as "raw_fields"). Off by default — it prints on
+# every callback. Turn on to settle what m_nDirection/m_nOffsetFlag actually
+# carry live, which the buy/sell direction mapping currently assumes.
+EXEC_EVENTS_DEBUG_RAW_FIELDS = False
 
 try:
     from bigqmt_signal_trader_local_config import BIGQMT_ACCOUNT_ID, BIGQMT_REDIS_CONFIG
@@ -159,6 +164,9 @@ DOWNLOAD_JOB_MAX_WALL_SECONDS = float(
 )
 DOWNLOAD_JOB_TTL_SECONDS = int(BIGQMT_REDIS_CONFIG.get("download_job_ttl_seconds", DOWNLOAD_JOB_TTL_SECONDS))
 EXEC_EVENTS_ENABLED = bool(BIGQMT_REDIS_CONFIG.get("exec_events_enabled", EXEC_EVENTS_ENABLED))
+EXEC_EVENTS_DEBUG_RAW_FIELDS = bool(
+    BIGQMT_REDIS_CONFIG.get("exec_events_debug_raw_fields", EXEC_EVENTS_DEBUG_RAW_FIELDS)
+)
 
 
 def _apply_config(account_id):
@@ -219,6 +227,7 @@ def _apply_config(account_id):
         exec_events={
             "enabled": EXEC_EVENTS_ENABLED,
             "account_id": account_id,
+            "debug_raw_fields": EXEC_EVENTS_DEBUG_RAW_FIELDS,
         },
     )
 
@@ -228,7 +237,7 @@ def configure_runtime_account(account_id):
 
 
 def configure_runtime_redis(redis_config):
-    global REDIS_HOST, REDIS_PORT, REDIS_DB, REDIS_USERNAME, REDIS_PASSWORD, RPC_ALLOW_ORDER_METHODS, RPC_PROCESS_IN_LISTENER, RPC_BACKGROUND_THREADS, RPC_LISTENER_METHODS, SCHEDULE_ADJUST_ENABLED, SCHEDULE_ADJUST_INTERVAL, FULL_TICK_CACHE_ENABLED, FULL_TICK_DEMAND_TTL_SECONDS, FULL_TICK_CACHE_TTL_SECONDS, FULL_TICK_REFRESH_INTERVAL_SECONDS, FULL_TICK_MARKET_REFRESH_INTERVAL_SECONDS, FULL_TICK_REFRESH_MAX_WALL_SECONDS, FULL_TICK_MAX_REQUESTS, RPC_TRANSPORT, RPC_ZMQ_CONFIG, RPC_MYSQL_CONFIG, DOWNLOAD_JOBS_ENABLED, DOWNLOAD_JOB_CHUNK_SIZE, DOWNLOAD_JOB_MAX_WALL_SECONDS, DOWNLOAD_JOB_TTL_SECONDS, EXEC_EVENTS_ENABLED
+    global REDIS_HOST, REDIS_PORT, REDIS_DB, REDIS_USERNAME, REDIS_PASSWORD, RPC_ALLOW_ORDER_METHODS, RPC_PROCESS_IN_LISTENER, RPC_BACKGROUND_THREADS, RPC_LISTENER_METHODS, SCHEDULE_ADJUST_ENABLED, SCHEDULE_ADJUST_INTERVAL, FULL_TICK_CACHE_ENABLED, FULL_TICK_DEMAND_TTL_SECONDS, FULL_TICK_CACHE_TTL_SECONDS, FULL_TICK_REFRESH_INTERVAL_SECONDS, FULL_TICK_MARKET_REFRESH_INTERVAL_SECONDS, FULL_TICK_REFRESH_MAX_WALL_SECONDS, FULL_TICK_MAX_REQUESTS, RPC_TRANSPORT, RPC_ZMQ_CONFIG, RPC_MYSQL_CONFIG, DOWNLOAD_JOBS_ENABLED, DOWNLOAD_JOB_CHUNK_SIZE, DOWNLOAD_JOB_MAX_WALL_SECONDS, DOWNLOAD_JOB_TTL_SECONDS, EXEC_EVENTS_ENABLED, EXEC_EVENTS_DEBUG_RAW_FIELDS
     redis_config = dict(redis_config or {})
     REDIS_HOST = redis_config.get("host", REDIS_HOST)
     REDIS_PORT = int(redis_config.get("port", REDIS_PORT))
@@ -277,6 +286,9 @@ def configure_runtime_redis(redis_config):
     )
     DOWNLOAD_JOB_TTL_SECONDS = int(redis_config.get("download_job_ttl_seconds", DOWNLOAD_JOB_TTL_SECONDS))
     EXEC_EVENTS_ENABLED = bool(redis_config.get("exec_events_enabled", EXEC_EVENTS_ENABLED))
+    EXEC_EVENTS_DEBUG_RAW_FIELDS = bool(
+        redis_config.get("exec_events_debug_raw_fields", EXEC_EVENTS_DEBUG_RAW_FIELDS)
+    )
     _apply_config(ACCOUNT_ID)
 
 

--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -649,6 +649,18 @@ def _publish_exec_event(kind, obj):
     """Push a normalized order/trade event to Redis for real-time client callbacks."""
     config = _build_config()
     event_config = dict(config.get("exec_events") or {})
+    # Raw-field diagnostics run BEFORE every other check (and before the
+    # enabled/account_id early returns), because the point is to observe the
+    # object exactly as QMT handed it over — even when publishing is off.
+    raw_fields = None
+    if _config_bool(event_config.get("debug_raw_fields"), False):
+        try:
+            from bigqmt_signal_trader import exec_events
+
+            print(exec_events.format_raw_snapshot(kind, obj))
+            raw_fields = exec_events.raw_field_snapshot(obj)
+        except Exception as exc:
+            print("[bigqmt_exec_raw] snapshot %s failed: %s" % (kind, exc))
     if not _config_bool(event_config.get("enabled"), True):
         return
     account_id = str(event_config.get("account_id") or config.get("account_id") or _account_id or "")
@@ -666,13 +678,15 @@ def _publish_exec_event(kind, obj):
         from bigqmt_signal_trader import exec_events
 
         if kind == "trade":
-            exec_events.publish_trade_event(
-                redis_client, account_id, exec_events.normalize_trade_event(obj, account_id)
-            )
+            event = exec_events.normalize_trade_event(obj, account_id)
+            if raw_fields:
+                event["raw_fields"] = raw_fields
+            exec_events.publish_trade_event(redis_client, account_id, event)
         else:
-            exec_events.publish_order_event(
-                redis_client, account_id, exec_events.normalize_order_event(obj, account_id)
-            )
+            event = exec_events.normalize_order_event(obj, account_id)
+            if raw_fields:
+                event["raw_fields"] = raw_fields
+            exec_events.publish_order_event(redis_client, account_id, event)
     except Exception as exc:
         print("[bigqmt_exec_events] publish %s failed: %s" % (kind, exc))
 

--- a/tests/bigqmt_signal_trader/test_exec_events.py
+++ b/tests/bigqmt_signal_trader/test_exec_events.py
@@ -8,11 +8,13 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(ROOT, "src"))
 
 from bigqmt_signal_trader.exec_events import (
+    format_raw_snapshot,
     normalize_order_event,
     normalize_trade_event,
     order_channel,
     publish_order_event,
     publish_trade_event,
+    raw_field_snapshot,
     trade_channel,
 )
 from bigqmt_signal_trader.xtquant_compat import BigQmtXtTrader, XtQuantTraderCallback
@@ -163,6 +165,68 @@ class ExecEventsServerTest(unittest.TestCase):
 
         self.assertEqual(ev["action"], "")   # pledge is neither buy nor sell
         self.assertEqual(ev["direction"], 81)  # raw direction preserved
+
+
+class RawFieldSnapshotTest(unittest.TestCase):
+    """The snapshot exists to settle what live callbacks actually carry, so it
+    must capture m_* and MiniQMT fields alike and never raise."""
+
+    def test_captures_thinktrader_and_miniqmt_fields(self):
+        snap = raw_field_snapshot(FakeOrder())
+
+        self.assertIn("m_nDirection", snap)
+        self.assertIn("49", snap["m_nDirection"])
+        self.assertIn("int", snap["m_nDirection"])
+        self.assertIn("m_strInstrumentID", snap)
+
+    def test_captures_miniqmt_style_object(self):
+        class XtOrderLike:
+            stock_code = "601398.SH"
+            order_type = 24
+            order_volume = 100
+
+        snap = raw_field_snapshot(XtOrderLike())
+
+        self.assertIn("24", snap["order_type"])
+        self.assertIn("601398.SH", snap["stock_code"])
+
+    def test_captures_dict_payload(self):
+        snap = raw_field_snapshot({"m_nOffsetFlag": 48, "order_type": 24})
+
+        self.assertIn("48", snap["m_nOffsetFlag"])
+        self.assertIn("24", snap["order_type"])
+
+    def test_skips_callables_and_dunders(self):
+        class WithMethod:
+            m_nDirection = 49
+
+            def m_method(self):
+                return 1
+
+        snap = raw_field_snapshot(WithMethod())
+
+        self.assertIn("m_nDirection", snap)
+        self.assertNotIn("m_method", snap)
+
+    def test_unreadable_attribute_does_not_raise(self):
+        class Exploding:
+            m_nDirection = 49
+
+            @property
+            def m_nOffsetFlag(self):
+                raise RuntimeError("boom")
+
+        snap = raw_field_snapshot(Exploding())
+
+        self.assertIn("m_nDirection", snap)
+        self.assertIn("unreadable", snap["m_nOffsetFlag"])
+
+    def test_format_is_a_single_ascii_safe_line(self):
+        line = format_raw_snapshot("order", FakeOrder())
+
+        self.assertNotIn("\n", line)
+        self.assertTrue(line.startswith("[bigqmt_exec_raw] order"))
+        self.assertIn("m_nDirection", line)
 
 
 class ExecEventsClientDispatchTest(unittest.TestCase):

--- a/tests/bigqmt_signal_trader/test_formula_server.py
+++ b/tests/bigqmt_signal_trader/test_formula_server.py
@@ -1,0 +1,340 @@
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader import formula_server as fs
+
+
+class BsonCodecTest(unittest.TestCase):
+    """The built-in codec is the no-dependency path; it must round-trip every
+    type this wire carries and stay byte-compatible with pymongo's bson."""
+
+    def _round_trip(self, document):
+        return fs._decode_document(fs._encode_document(document.items()), 0)[0]
+
+    def test_round_trips_scalars(self):
+        doc = {"s": "平安银行", "i": 42, "big": 2 ** 40, "f": 10.29, "t": True, "f2": False, "n": None}
+
+        self.assertEqual(self._round_trip(doc), doc)
+
+    def test_round_trips_nested_containers(self):
+        doc = {"func": "getMarketData", "params": {"fields": ["close", "volume"], "count": -1}}
+
+        self.assertEqual(self._round_trip(doc), doc)
+
+    def test_round_trips_the_actual_request_envelope(self):
+        doc = {
+            "func": "getMarketData",
+            "params": {
+                "fields": ["close"],
+                "stockCodes": ["000001.SZ"],
+                "startTime": "",
+                "endTime": "",
+                "period": "1d",
+                "dividendType": "none",
+                "count": 3,
+            },
+        }
+
+        self.assertEqual(self._round_trip(doc), doc)
+
+    def test_array_order_is_preserved(self):
+        doc = {"codes": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"]}
+
+        self.assertEqual(self._round_trip(doc)["codes"], doc["codes"])
+
+    def test_matches_pymongo_bson_when_available(self):
+        try:
+            import bson
+        except ImportError:
+            self.skipTest("pymongo bson not installed")
+        doc = {"func": "getLastVolume", "params": {"stockCode": "000001.SZ", "n": 1.5}}
+
+        self.assertEqual(fs._encode_document(doc.items()), bson.BSON.encode(doc))
+        self.assertEqual(fs._decode_document(bson.BSON.encode(doc), 0)[0], doc)
+
+    def test_unsupported_type_is_rejected(self):
+        with self.assertRaises(TypeError):
+            fs._encode_document({"bad": object()}.items())
+
+
+class AddressResolutionTest(unittest.TestCase):
+    def test_reads_port_from_formulaserver_ini(self):
+        import tempfile
+
+        root = tempfile.mkdtemp()
+        ini_dir = os.path.join(root, "config", "formulaserver")
+        os.makedirs(ini_dir)
+        with open(os.path.join(ini_dir, "formulaserver.ini"), "w") as handle:
+            handle.write("[server_formula]\naddress = 0.0.0.0:58600\n")
+
+        self.assertEqual(fs.read_formulaserver_port(root), 58600)
+        self.assertEqual(fs.resolve_address({"qmt_root": root}), ("127.0.0.1", 58600))
+
+    def test_missing_ini_falls_back_to_default_port(self):
+        self.assertIsNone(fs.read_formulaserver_port(os.path.join(ROOT, "no-such-dir")))
+        host, port = fs.resolve_address({"qmt_root": os.path.join(ROOT, "no-such-dir")})
+
+        self.assertEqual((host, port), ("127.0.0.1", fs.DEFAULT_PORT))
+
+    def test_explicit_config_wins(self):
+        self.assertEqual(
+            fs.resolve_address({"host": "10.0.0.5", "port": 59999}), ("10.0.0.5", 59999)
+        )
+
+
+class FakeClient(object):
+    host = "127.0.0.1"
+    port = 58600
+
+    def __init__(self, responses=None, error=None):
+        self.responses = responses or {}
+        self.error = error
+        self.calls = []
+
+    def request(self, func, params=None):
+        self.calls.append((func, dict(params or {})))
+        if self.error is not None:
+            raise self.error
+        return self.responses.get(func, {"result": None})
+
+    def close(self):
+        pass
+
+
+class ParamTranslationTest(unittest.TestCase):
+    def _router(self, responses=None, error=None):
+        client = FakeClient(responses=responses, error=error)
+        return fs.FormulaServerRouter(client=client), client
+
+    def test_instrument_aliases_the_misspelled_volume_fields(self):
+        """FormulaServer ships FloatVolumn/TotalVolumn; the xtdata SDK spells
+        them FloatVolume/TotalVolume. Downstream reads the SDK spelling."""
+        router, _ = self._router(
+            {"getInstrumentDetail": {"result": {"FloatVolumn": 1.0, "TotalVolumn": 2.0}}}
+        )
+
+        out = router.call("get_instrument", {"code": "000001.SZ"})
+
+        self.assertEqual(out["FloatVolume"], 1.0)
+        self.assertEqual(out["TotalVolume"], 2.0)
+        self.assertEqual(out["FloatVolumn"], 1.0)  # raw key still present
+
+    def test_sector_normalizes_the_minus_one_sentinel(self):
+        router, client = self._router({"getStockListInSector": {"result": ["600000.SH"]}})
+
+        router.call("get_stock_list_in_sector", {"sector_name": "沪深300", "real_timetag": -1})
+
+        self.assertEqual(client.calls[0][1], {"sectorName": "沪深300", "realtime": 0})
+
+    def test_market_data_refuses_adjusted_bars(self):
+        """dividendType is not honoured by the server; serving an adjusted
+        request from here would hand back unadjusted prices silently."""
+        router, client = self._router({"getMarketData": {"result": []}})
+
+        for dividend_type in ("front", "back", "front_ratio"):
+            with self.assertRaises(fs.Unroutable):
+                router.call(
+                    "get_market_data_ex",
+                    {
+                        "field_list": ["close"],
+                        "stock_list": ["000001.SZ"],
+                        "dividend_type": dividend_type,
+                    },
+                )
+        self.assertEqual(client.calls, [])
+
+    def test_market_data_allows_unadjusted(self):
+        router, client = self._router({"getMarketData": {"result": []}})
+
+        router.call(
+            "get_market_data_ex",
+            {"field_list": ["close"], "stock_list": ["000001.SZ"], "dividend_type": "none"},
+        )
+
+        self.assertEqual(client.calls[0][1]["dividendType"], "none")
+
+    def test_market_data_translates_flat_wire_shape(self):
+        router, _ = self._router(
+            {
+                "getMarketData": {
+                    "result": [
+                        "000001.SZ",
+                        ["20260703", ["close", 10.29, "volume", 863327.0]],
+                        "600000.SH",
+                        ["20260703", ["close", 8.69, "volume", 695133.0]],
+                    ]
+                }
+            }
+        )
+
+        out = router.call(
+            "get_market_data_ex",
+            {"field_list": ["close", "volume"], "stock_list": ["000001.SZ", "600000.SH"]},
+        )
+
+        self.assertEqual(out["000001.SZ"]["columns"], ["stime", "close", "volume"])
+        self.assertEqual(
+            out["000001.SZ"]["records"],
+            [{"stime": "20260703", "close": 10.29, "volume": 863327.0}],
+        )
+        self.assertEqual(out["600000.SH"]["records"][0]["close"], 8.69)
+
+    def test_market_data_keeps_requested_codes_with_no_bars(self):
+        router, _ = self._router({"getMarketData": {"result": []}})
+
+        out = router.call(
+            "get_market_data_ex",
+            {"field_list": ["close"], "stock_list": ["000001.SZ", "600000.SH"]},
+        )
+
+        self.assertEqual(sorted(out), ["000001.SZ", "600000.SH"])
+        self.assertEqual(out["000001.SZ"]["records"], [])
+
+    def test_missing_required_params_is_unroutable_not_a_crash(self):
+        router, client = self._router()
+
+        with self.assertRaises(fs.Unroutable):
+            router.call("get_instrument", {})
+        self.assertEqual(client.calls, [])
+
+
+class FallbackBehaviourTest(unittest.TestCase):
+    def test_unmapped_method_is_not_supported(self):
+        router = fs.FormulaServerRouter(client=FakeClient())
+
+        self.assertFalse(router.supports("get_asset"))
+        self.assertFalse(router.supports("submit_order"))
+        self.assertFalse(router.supports("get_full_tick"))
+
+    def test_trading_dates_and_dividends_stay_on_rpc(self):
+        """Their FormulaServer params mean something different from ours."""
+        router = fs.FormulaServerRouter(client=FakeClient())
+
+        self.assertFalse(router.supports("get_trading_dates"))
+        self.assertFalse(router.supports("get_divid_factors"))
+        self.assertFalse(router.supports("get_risk_free_rate"))
+
+    def test_transport_failure_trips_the_cooldown(self):
+        router = fs.FormulaServerRouter(
+            client=FakeClient(error=fs.FormulaServerUnavailable("down")),
+            failure_cooldown_seconds=60,
+        )
+
+        with self.assertRaises(fs.Unroutable):
+            router.call("get_last_volume", {"stock": "000001.SZ"})
+        # Breaker is open: no further attempts until the cooldown expires.
+        self.assertFalse(router.supports("get_last_volume"))
+
+    def test_method_not_found_disables_only_that_method(self):
+        router = fs.FormulaServerRouter(
+            client=FakeClient(
+                error=fs.FormulaServerError("nope", error_id=fs.ERROR_METHOD_NOT_FOUND)
+            )
+        )
+
+        with self.assertRaises(fs.Unroutable):
+            router.call("get_main_contract", {"code_market": "IF00.IF"})
+
+        self.assertFalse(router.supports("get_main_contract"))
+        self.assertTrue(router.supports("get_last_volume"))  # breaker not tripped
+
+    def test_disabled_router_supports_nothing(self):
+        router = fs.build_router({"enabled": False})
+
+        for method in fs.SUPPORTED_METHODS:
+            self.assertFalse(router.supports(method))
+
+    def test_enabled_accepts_string_flags(self):
+        self.assertFalse(fs.build_router({"enabled": "false"}).enabled)
+        self.assertFalse(fs.build_router({"enabled": "0"}).enabled)
+        self.assertTrue(fs.build_router({"enabled": "true", "port": 1}).enabled)
+
+
+class ClientCallIntegrationTest(unittest.TestCase):
+    """BigQmtRpcClient.call must prefer the router and fall back cleanly."""
+
+    def _client(self, router):
+        from bigqmt_signal_trader.xtquant_compat import BigQmtRpcClient
+
+        client = BigQmtRpcClient(account_id="acct")
+        client._formula_router_instance = router
+        return client
+
+    def test_routed_method_never_touches_rpc(self):
+        router = fs.FormulaServerRouter(
+            client=FakeClient({"getLastVolume": {"result": 123.0}})
+        )
+        client = self._client(router)
+
+        def explode(*args, **kwargs):
+            raise AssertionError("RPC must not be used for a routed method")
+
+        client._transport = explode
+
+        self.assertEqual(client.call("get_last_volume", {"stock": "000001.SZ"}), 123.0)
+
+    def test_unroutable_falls_back_to_rpc(self):
+        router = fs.FormulaServerRouter(
+            client=FakeClient(error=fs.FormulaServerUnavailable("down"))
+        )
+        client = self._client(router)
+        calls = []
+
+        class FakeTransport:
+            def send_request(self, request, timeout):
+                calls.append(request["method"])
+                return {"ok": True, "data": "from-rpc"}
+
+        client._transport = lambda: FakeTransport()
+
+        self.assertEqual(client.call("get_last_volume", {"stock": "000001.SZ"}), "from-rpc")
+        self.assertEqual(calls, ["get_last_volume"])
+
+    def test_unmapped_method_goes_straight_to_rpc(self):
+        router = fs.FormulaServerRouter(client=FakeClient())
+        client = self._client(router)
+        calls = []
+
+        class FakeTransport:
+            def send_request(self, request, timeout):
+                calls.append(request["method"])
+                return {"ok": True, "data": {"cash": 1.0}}
+
+        client._transport = lambda: FakeTransport()
+
+        self.assertEqual(client.call("get_asset", {}), {"cash": 1.0})
+        self.assertEqual(calls, ["get_asset"])
+
+    def test_routed_dataframe_payload_is_restored_like_rpc(self):
+        router = fs.FormulaServerRouter(
+            client=FakeClient(
+                {
+                    "getMarketData": {
+                        "result": ["000001.SZ", ["20260703", ["close", 10.29]]]
+                    }
+                }
+            )
+        )
+        client = self._client(router)
+
+        out = client.call(
+            "get_market_data_ex", {"field_list": ["close"], "stock_list": ["000001.SZ"]}
+        )
+
+        frame = out["000001.SZ"]
+        # _restore_jsonable rebuilds a DataFrame when pandas is present, and
+        # degrades to the record list otherwise — same as the RPC path.
+        if hasattr(frame, "columns"):
+            self.assertEqual(list(frame.columns), ["stime", "close"])
+            self.assertEqual(frame.iloc[0]["close"], 10.29)
+        else:
+            self.assertEqual(frame, [{"stime": "20260703", "close": 10.29}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The buy/sell direction mapping in exec_events rests on an assumption about
what m_nDirection and m_nOffsetFlag carry in live callbacks, and nothing in
this repo has ever observed the real object. 89efc14 changed the priority
chain on that basis, and its own tests now contradict each other:

  test_action_comes_from_direction_not_offset_flag
      m_nOffsetFlag = 48  # 开仓 (open) — must NOT be read as buy
  test_direction_falls_back_to_offset_when_direction_none
      m_nOffsetFlag = 48  # 开仓 = buy for stocks

Both pass only because the first case has a valid m_nDirection and never
reaches the offset branch. When direction really is 0/None — the exact
condition 89efc14 set out to fix — a sell with offset_flag=48 still maps to
BUY, reproducing the reported symptom.

Rather than guess a new priority chain, capture the evidence. raw_field_snapshot
dumps every m_* and MiniQMT-style field of the callback object;
format_raw_snapshot renders one line for the QMT output panel. The snapshot runs
before the enabled/account_id early returns, since a diagnosis window with
publishing off must still see the object. It never raises: a callback that dies
while being diagnosed is worse than no diagnosis.

Off by default (prints on every callback). Enable with
exec_events_debug_raw_fields=True in the local config, place one live sell, and
the contradiction resolves.

Note the reported root cause does not hold: XtOrder/XtTrade (xttype.py:62) have
no direction or offset_flag at all, so a MiniQMT-style object falls through to
order_type, and order_type=24 already maps to SELL correctly.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>