### PR TITLE
Carry frozen_cash and market_value through the asset chain

### DIFF
--- a/src/bigqmt_signal_trader/adapters/position_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/position_bigqmt.py
@@ -13,6 +13,45 @@ def _attr(obj, names, default=None):
     return default
 
 
+# Candidate ThinkTrader field names on the ACCOUNT row of get_trade_detail_data.
+# The MiniQMT SDK only documents the normalized name (XtAsset.frozen_cash); the
+# big QMT ACCOUNT struct is a different surface and brokers vary, so probe the
+# plausible spellings the way cash/total_asset already do.
+_FROZEN_CASH_FIELDS = (
+    "m_dFrozenCash",
+    "m_dFrozen",
+    "m_dFrozenBalance",
+    "m_dFrozenMargin",
+    "frozen_cash",
+    "frozen",
+)
+_MARKET_VALUE_FIELDS = (
+    "m_dInstrumentValue",
+    "m_dStockValue",
+    "m_dMarketValue",
+    "market_value",
+)
+
+# Printed once per process when the frozen field is not found, listing what the
+# row actually carries. Guessing a field name and shipping it unverified is how
+# the order-direction bug happened; this makes the real name self-reporting.
+_missing_field_reported = set()
+
+
+def _report_missing_field(label, row, candidates):
+    if label in _missing_field_reported:
+        return
+    _missing_field_reported.add(label)
+    try:
+        available = sorted(name for name in dir(row) if name.startswith("m_"))
+    except Exception:
+        available = []
+    print(
+        "[bigqmt_asset] %s not found (tried %s); ACCOUNT row exposes: %s"
+        % (label, ", ".join(candidates), ", ".join(available) or "<none>")
+    )
+
+
 def _full_code(instrument_id, exchange_id):
     code = str(instrument_id or "").strip().upper()
     market = str(exchange_id or "").strip().upper()
@@ -72,8 +111,20 @@ class BigQmtPositionProvider:
         row = rows[0]
         cash = _attr(row, ("m_dAvailable", "m_dAvailableCash", "available_cash", "cash"))
         total_asset = _attr(row, ("m_dBalance", "m_dAsset", "total_asset", "asset"))
+        frozen_cash = _attr(row, _FROZEN_CASH_FIELDS)
+        market_value = _attr(row, _MARKET_VALUE_FIELDS)
+        if frozen_cash is None:
+            _report_missing_field("frozen_cash", row, _FROZEN_CASH_FIELDS)
+        if market_value is None and cash is not None and total_asset is not None:
+            # Derive only as a last resort. Without frozen_cash this overstates
+            # market value by the frozen amount, so subtract it when known.
+            market_value = float(total_asset) - float(cash)
+            if frozen_cash is not None:
+                market_value -= float(frozen_cash)
         return AssetSnapshot(
             account_id=account_id,
             cash=float(cash) if cash is not None else None,
             total_asset=float(total_asset) if total_asset is not None else None,
+            frozen_cash=float(frozen_cash) if frozen_cash is not None else None,
+            market_value=float(market_value) if market_value is not None else None,
         )

--- a/src/bigqmt_signal_trader/adapters/position_sync_redis.py
+++ b/src/bigqmt_signal_trader/adapters/position_sync_redis.py
@@ -33,6 +33,10 @@ class RedisPositionSyncSink:
             "asset": {
                 "cash": snapshot.asset.cash,
                 "total_asset": snapshot.asset.total_asset,
+                # Carried so the client's cached-asset fallback exposes the same
+                # fields as a live query_stock_asset.
+                "frozen_cash": getattr(snapshot.asset, "frozen_cash", None),
+                "market_value": getattr(snapshot.asset, "market_value", None),
             },
             "positions": {
                 code: {

--- a/src/bigqmt_signal_trader/models.py
+++ b/src/bigqmt_signal_trader/models.py
@@ -171,10 +171,24 @@ class PositionSnapshot:
 
 
 class AssetSnapshot:
-    def __init__(self, account_id, cash=None, total_asset=None):
+    """Account funds, mirroring MiniQMT's ``XtAsset``.
+
+    Field names follow ``xtquant.xttype.XtAsset(account_id, cash, frozen_cash,
+    market_value, total_asset)`` so ``query_stock_asset`` can hand callers the
+    same attributes they get from MiniQMT.
+
+    ``cash`` is 可用 (available), NOT the full 资金余额:
+    ``total_asset == cash + frozen_cash + market_value``. New fields are
+    appended with None defaults so existing positional callers keep working,
+    and None means "the terminal did not report it" — distinct from 0.0.
+    """
+
+    def __init__(self, account_id, cash=None, total_asset=None, frozen_cash=None, market_value=None):
         self.account_id = account_id
         self.cash = cash
         self.total_asset = total_asset
+        self.frozen_cash = frozen_cash
+        self.market_value = market_value
 
 
 class AccountSnapshot:

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -1358,13 +1358,23 @@ class BigQmtXtTrader:
             data = self._cached_asset(account_id) or data
         cash = data.get("cash")
         total_asset = data.get("total_asset")
+        frozen_cash = data.get("frozen_cash")
         market_value = data.get("market_value")
         if market_value is None and cash is not None and total_asset is not None:
+            # total_asset = cash(available) + frozen_cash + market_value. Older
+            # servers send neither frozen_cash nor market_value; deriving without
+            # frozen_cash overstates market value by the frozen amount, so
+            # subtract it whenever the server did report it.
             market_value = _safe_float(total_asset) - _safe_float(cash)
+            if frozen_cash is not None:
+                market_value -= _safe_float(frozen_cash)
         return CompatObject(
             account_id=account_id,
             cash=_safe_float(cash, 0.0) if cash is not None else None,
             available_cash=_safe_float(cash, 0.0) if cash is not None else None,
+            # MiniQMT's XtAsset always exposes frozen_cash, so default to 0.0
+            # rather than None: callers do arithmetic on it.
+            frozen_cash=_safe_float(frozen_cash, 0.0) if frozen_cash is not None else 0.0,
             total_asset=_safe_float(total_asset, 0.0) if total_asset is not None else None,
             market_value=_safe_float(market_value, 0.0) if market_value is not None else 0.0,
         )

--- a/tests/bigqmt_signal_trader/test_asset_frozen_cash.py
+++ b/tests/bigqmt_signal_trader/test_asset_frozen_cash.py
@@ -1,0 +1,226 @@
+"""frozen_cash must survive the whole chain: QMT row -> AssetSnapshot -> RPC
+serialization -> client CompatObject, plus the Redis cached-asset fallback.
+
+Field names follow MiniQMT's XtAsset(account_id, cash, frozen_cash,
+market_value, total_asset), where total_asset = cash + frozen_cash + market_value.
+"""
+
+import datetime as _dt
+import json
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.adapters import position_bigqmt
+from bigqmt_signal_trader.adapters.position_bigqmt import BigQmtPositionProvider
+from bigqmt_signal_trader.adapters.position_sync_redis import RedisPositionSyncSink
+from bigqmt_signal_trader.models import AccountSnapshot, AssetSnapshot, PositionSnapshot
+from bigqmt_signal_trader.redis_rpc import to_jsonable
+from bigqmt_signal_trader.xtquant_compat import BigQmtXtTrader, StockAccount
+
+
+class Row:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _provider(row):
+    def query(account_id, account_type, detail_type):
+        return [row] if detail_type in ("ACCOUNT", "ASSET") else []
+
+    return BigQmtPositionProvider(query)
+
+
+class AssetSnapshotModelTest(unittest.TestCase):
+    def test_defaults_keep_existing_positional_callers_working(self):
+        snapshot = AssetSnapshot("acct", 100.0, 1000.0)
+
+        self.assertEqual(snapshot.cash, 100.0)
+        self.assertEqual(snapshot.total_asset, 1000.0)
+        self.assertIsNone(snapshot.frozen_cash)
+        self.assertIsNone(snapshot.market_value)
+
+    def test_carries_the_full_xtasset_field_set(self):
+        snapshot = AssetSnapshot("acct", 100.0, 1000.0, frozen_cash=50.0, market_value=850.0)
+
+        self.assertEqual(snapshot.frozen_cash, 50.0)
+        self.assertEqual(snapshot.market_value, 850.0)
+
+
+class QmtCollectionTest(unittest.TestCase):
+    def setUp(self):
+        position_bigqmt._missing_field_reported.clear()
+
+    def test_reads_frozen_cash_from_the_account_row(self):
+        provider = _provider(
+            Row(m_dAvailable=100.0, m_dBalance=1000.0, m_dFrozenCash=50.0, m_dInstrumentValue=850.0)
+        )
+
+        asset = provider.get_asset("acct")
+
+        self.assertEqual(asset.cash, 100.0)
+        self.assertEqual(asset.frozen_cash, 50.0)
+        self.assertEqual(asset.market_value, 850.0)
+        self.assertEqual(asset.total_asset, 1000.0)
+
+    def test_accepts_alternate_broker_spellings(self):
+        for field in ("m_dFrozenCash", "m_dFrozen", "m_dFrozenBalance", "frozen_cash"):
+            provider = _provider(Row(m_dAvailable=100.0, m_dBalance=1000.0, **{field: 50.0}))
+
+            self.assertEqual(provider.get_asset("acct").frozen_cash, 50.0, field)
+
+    def test_derived_market_value_excludes_frozen_cash(self):
+        """Without this, market value is overstated by the frozen amount."""
+        provider = _provider(Row(m_dAvailable=100.0, m_dBalance=1000.0, m_dFrozenCash=50.0))
+
+        self.assertEqual(provider.get_asset("acct").market_value, 850.0)
+
+    def test_derivation_falls_back_when_frozen_is_absent(self):
+        provider = _provider(Row(m_dAvailable=100.0, m_dBalance=1000.0))
+        asset = provider.get_asset("acct")
+
+        self.assertIsNone(asset.frozen_cash)
+        self.assertEqual(asset.market_value, 900.0)  # legacy behaviour preserved
+
+    def test_missing_frozen_field_reports_what_the_row_actually_has(self):
+        """The ThinkTrader spelling is unverified offline; make it self-reporting
+        instead of silently returning None forever."""
+        import io
+        import contextlib
+
+        provider = _provider(Row(m_dAvailable=100.0, m_dBalance=1000.0, m_dWhateverElse=1.0))
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            provider.get_asset("acct")
+        output = buffer.getvalue()
+
+        self.assertIn("frozen_cash not found", output)
+        self.assertIn("m_dWhateverElse", output)  # names the real fields
+
+    def test_missing_field_is_reported_once_not_per_call(self):
+        import io
+        import contextlib
+
+        provider = _provider(Row(m_dAvailable=100.0, m_dBalance=1000.0))
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            for _ in range(5):
+                provider.get_asset("acct")
+
+        self.assertEqual(buffer.getvalue().count("frozen_cash not found"), 1)
+
+    def test_empty_rows_still_degrade_to_all_none(self):
+        provider = BigQmtPositionProvider(lambda *args: [])
+
+        asset = provider.get_asset("acct")
+
+        self.assertIsNone(asset.cash)
+        self.assertIsNone(asset.frozen_cash)
+
+
+class RpcSerializationTest(unittest.TestCase):
+    def test_to_jsonable_carries_frozen_cash_over_the_wire(self):
+        snapshot = AssetSnapshot("acct", 100.0, 1000.0, frozen_cash=50.0, market_value=850.0)
+
+        payload = to_jsonable(snapshot)
+
+        self.assertEqual(payload["frozen_cash"], 50.0)
+        self.assertEqual(payload["market_value"], 850.0)
+
+
+class FakeRedis:
+    def __init__(self):
+        self.kv = {}
+        self.streams = {}
+
+    def set(self, key, value):
+        self.kv[key] = value
+
+    def setex(self, key, ttl_seconds, value):
+        self.kv[key] = value
+
+    def xadd(self, key, fields, maxlen=None, approximate=None):
+        self.streams.setdefault(key, []).append(fields)
+        return b"1-0"
+
+    def publish(self, key, value):
+        return 1
+
+
+class PositionSyncTest(unittest.TestCase):
+    def test_cached_snapshot_includes_frozen_cash(self):
+        redis_client = FakeRedis()
+        RedisPositionSyncSink(redis_client).publish(
+            AccountSnapshot(
+                account_id="acct",
+                asset=AssetSnapshot("acct", 100.0, 1000.0, frozen_cash=50.0, market_value=850.0),
+                positions={"600000.SH": PositionSnapshot("600000.SH", 100, 100, 10.0, "PF")},
+                reason="test",
+                updated_at=_dt.datetime(2026, 7, 1, 9, 31),
+            )
+        )
+
+        payload = json.loads(redis_client.kv["bigqmt:positions:acct"])
+
+        self.assertEqual(payload["asset"]["frozen_cash"], 50.0)
+        self.assertEqual(payload["asset"]["market_value"], 850.0)
+
+
+class ClientSurfaceTest(unittest.TestCase):
+    """The reported AttributeError: asset.frozen_cash must simply exist."""
+
+    def _trader(self, response):
+        trader = BigQmtXtTrader(account_id="acct")
+        trader.client.call = lambda method, params=None, account_id=None, **kw: response
+        return trader
+
+    def test_frozen_cash_is_exposed(self):
+        asset = self._trader(
+            {"cash": 100.0, "total_asset": 1000.0, "frozen_cash": 50.0, "market_value": 850.0}
+        ).query_stock_asset(StockAccount("acct"))
+
+        self.assertEqual(asset.frozen_cash, 50.0)
+        self.assertEqual(asset.cash, 100.0)
+        self.assertEqual(asset.market_value, 850.0)
+        self.assertEqual(asset.total_asset, 1000.0)
+
+    def test_frozen_cash_defaults_to_zero_not_missing(self):
+        """A server that predates this field must not resurrect the
+        AttributeError, and callers do arithmetic on it."""
+        asset = self._trader({"cash": 100.0, "total_asset": 1000.0}).query_stock_asset(
+            StockAccount("acct")
+        )
+
+        self.assertEqual(asset.frozen_cash, 0.0)
+        self.assertEqual(asset.cash + asset.frozen_cash, 100.0)
+
+    def test_derived_market_value_excludes_frozen_cash(self):
+        asset = self._trader(
+            {"cash": 100.0, "total_asset": 1000.0, "frozen_cash": 50.0}
+        ).query_stock_asset(StockAccount("acct"))
+
+        self.assertEqual(asset.market_value, 850.0)
+
+    def test_server_market_value_wins_over_derivation(self):
+        asset = self._trader(
+            {"cash": 100.0, "total_asset": 1000.0, "frozen_cash": 50.0, "market_value": 111.0}
+        ).query_stock_asset(StockAccount("acct"))
+
+        self.assertEqual(asset.market_value, 111.0)
+
+    def test_components_reconstruct_total_asset(self):
+        asset = self._trader(
+            {"cash": 100.0, "total_asset": 1000.0, "frozen_cash": 50.0, "market_value": 850.0}
+        ).query_stock_asset(StockAccount("acct"))
+
+        self.assertAlmostEqual(
+            asset.cash + asset.frozen_cash + asset.market_value, asset.total_asset
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
asset.frozen_cash raised AttributeError because the field was absent at every layer: AssetSnapshot never defined it, the QMT adapter never read it off the ACCOUNT row, and query_stock_asset never put it on the returned object.

Field names follow MiniQMT's XtAsset(account_id, cash, frozen_cash, market_value, total_asset) — xttype.py:46 — so callers get the same attributes they get from MiniQMT. New model fields are appended with None defaults, so existing positional constructions keep working, and None stays distinct from 0.0: it means the terminal did not report the value.

market_value is included because it is the same gap and the two interact. query_stock_asset already read data["market_value"], but no server ever sent it, so it always fell through to total_asset - cash. That derivation silently includes frozen cash. Now the ACCOUNT row's own market value is used when present, and the fallback subtracts frozen_cash when known — restoring total_asset == cash + frozen_cash + market_value.

The exact ThinkTrader spelling on the big QMT ACCOUNT row could not be verified offline (the local SDK documents only the normalized XtAsset name), so the adapter probes the plausible candidates the way cash/total_asset already do, and prints the row's actual m_* fields once if none match. That keeps the unknown self-reporting rather than silently returning None forever.

RedisPositionSyncSink carries both fields too, so the client's cached-asset fallback exposes the same surface as a live query.