### PR TITLE
fix: support QMT paste-run mode by falling back to sys.path for local module lookup

### DIFF
--- a/src/BIGQMT_REDIS_DRYRUN.py
+++ b/src/BIGQMT_REDIS_DRYRUN.py
@@ -29,13 +29,10 @@ _ORIGINAL_RELOAD = _importlib.reload
 
 
 def _known_qmt_python_dir():
-    # chr()-encoded so GBK save does not mangle the CJK path.
-    # decodes to: D:\国金证券QMT交易端_lemo\python
-    root = "".join(chr(value) for value in (
-        0x56fd, 0x91d1, 0x8bc1, 0x5238, 0x51, 0x4d, 0x54,
-    ))
-    suffix = "".join(chr(value) for value in (0x4ea4, 0x6613, 0x7aef))
-    return r"D:\\" + root + suffix + "_lemo\\python"
+    for p in sys.path:
+        if p and r"\python" in p and os.path.isdir(p):
+            return p
+    return ""
 
 
 try:
@@ -65,12 +62,19 @@ def _resolve_name(name, module_globals, level):
 
 def _find_local_source(name):
     relative = name.replace(".", os.sep)
-    package_init = os.path.join(_SOURCE_ROOT, relative, "__init__.py")
-    if os.path.isfile(package_init):
-        return package_init, True
-    module_file = os.path.join(_SOURCE_ROOT, relative + ".py")
-    if os.path.isfile(module_file):
-        return module_file, False
+    dirs = []
+    if _SOURCE_ROOT:
+        dirs.append(_SOURCE_ROOT)
+    for p in sys.path:
+        if p and os.path.isdir(p) and p not in dirs:
+            dirs.append(p)
+    for d in dirs:
+        package_init = os.path.join(d, relative, "__init__.py")
+        if os.path.isfile(package_init):
+            return package_init, True
+        module_file = os.path.join(d, relative + ".py")
+        if os.path.isfile(module_file):
+            return module_file, False
     raise ModuleNotFoundError("local source not found: %s" % name, name=name)
 
 

--- a/src/BIGQMT_ZMQ_BACKTEST.py
+++ b/src/BIGQMT_ZMQ_BACKTEST.py
@@ -31,10 +31,10 @@ _ORIGINAL_IMPORT = _builtins.__import__
 
 
 def _known_qmt_python_dir():
-    install = "".join(chr(value) for value in (
-        0x541b, 0x5f18, 0x541b, 0x667a, 0x4ea4, 0x6613, 0x7cfb, 0x7edf,
-    ))
-    return "D:\\" + install + "\\python"
+    for p in sys.path:
+        if p and r"\python" in p and os.path.isdir(p):
+            return p
+    return ""
 
 
 try:
@@ -62,12 +62,19 @@ def _resolve_name(name, module_globals, level):
 
 def _find_source(name):
     relative = name.replace(".", os.sep)
-    package_init = os.path.join(_SOURCE_ROOT, relative, "__init__.py")
-    if os.path.isfile(package_init):
-        return package_init, True
-    module_file = os.path.join(_SOURCE_ROOT, relative + ".py")
-    if os.path.isfile(module_file):
-        return module_file, False
+    dirs = []
+    if _SOURCE_ROOT:
+        dirs.append(_SOURCE_ROOT)
+    for p in sys.path:
+        if p and os.path.isdir(p) and p not in dirs:
+            dirs.append(p)
+    for d in dirs:
+        package_init = os.path.join(d, relative, "__init__.py")
+        if os.path.isfile(package_init):
+            return package_init, True
+        module_file = os.path.join(d, relative + ".py")
+        if os.path.isfile(module_file):
+            return module_file, False
     raise ModuleNotFoundError("local source not found: %s" % name, name=name)
 
 


### PR DESCRIPTION
## Problem
ModuleNotFoundError: local source not found on QMT terminals that
execute strategies via code paste (e.g. 国金证券, 申万宏源).

Root cause: custom import system (`_find_local_source`/`_find_source`)
only searches `_SOURCE_ROOT` (derived from `__file__`). In paste-run
mode `__file__` points to a temp directory, not the user's module
directory in QMT python path.

## Changes
1. `_known_qmt_python_dir()`: hardcoded paths → dynamic `sys.path` detection
2. `_find_local_source()` / `_find_source()`: fall back to `sys.path`
   directories after `_SOURCE_ROOT`

## Compatibility
- Backward compatible: file-selection mode (国泰君安) still works
- Fixes paste-run mode (国金证券, 申万宏源, etc.)
