### PR TITLE
fix: arbitrate direction vfix: arbitrate direction via m_nOpType when m_nDirection and m_nOffsetFlag disagreeia m_nOpType when m_nDirection and m_nOffsetFlag disagree

### DIFF
--- a/src/bigqmt_signal_trader/exec_events.py
+++ b/src/bigqmt_signal_trader/exec_events.py
@@ -31,22 +31,30 @@ ENTRUST_SELL = 49        # 卖出 / 空
 ENTRUST_PLEDGE_IN = 81   # 质押入库
 ENTRUST_PLEDGE_OUT = 66  # 质押出库
 
-# enum_EOffset_Flag_Type (开平方向, the m_nOffsetFlag field).
-# 48=开仓(=买入 for stocks), 49=平仓(=卖出 for stocks), 51=平今, 52=平昨.
-# For spot stocks (无做空), offset flag 48/49 coincides exactly with buy/sell,
-# and it is the RELIABLE field in live order_callback (m_nDirection can be 0/None
-# at certain callback moments). query_orders already uses m_nOffsetFlag for this
-# reason. For futures, offset and direction differ — but we only ship stocks here.
+# enum_EEntrustBS (买卖方向, the m_nDirection field), per QMT enum docs.
+# 48=买, 49=卖.  Universal across 股票/期货/期权.
+#
+# Real-world findings from live COrderDetail/CDealDetail callbacks
+# (diagnosed via exec_events_debug_raw_fields=True, 2026-07-29):
+#   QMT returns m_nDirection=48 **unconditionally** — even for sell orders.
+#   m_nOffsetFlag correctly reflects direction (48=买, 49=卖 for stocks).
+#   m_nOpType correctly reflects direction (23=买, 24=卖) on orders.
+#   query_orders uses m_nOffsetFlag and works correctly in production.
+#
+# Therefore _extract_direction uses an arbitration chain:
+#   Preferred: m_nOffsetFlag (most reliable in live callbacks, matches query_orders)
+#   Fallback:  m_nDirection (traditional EEntrustBS; can be stuck at 48 in calls)
+#   Arbiter:   when direction≠offset (futures: sell+open=49+48),
+#              consult m_nOpType (23/24) to resolve the conflict; for trades
+#              (no m_nOpType) trust m_nOffsetFlag (QMT docs confirm stock
+#              direction=offset).
+#   Last:      order_type (MiniQMT STOCK_BUY=23 / STOCK_SELL=24) and plain text
+# Unknown -> "" (the raw value is always preserved so callers can refine).
 OFFSET_OPEN = 48
 OFFSET_CLOSE = 49
 OFFSET_CLOSE_TODAY = 51
 OFFSET_CLOSE_YESTERDAY = 52
 
-# Map direction -> "BUY"/"SELL". Priority:
-#   1. m_nOffsetFlag (reliable in live callbacks, matches query_orders)
-#   2. m_nDirection (EEntrustBS 48/49)
-#   3. order_type (MiniQMT STOCK_BUY=23 / STOCK_SELL=24) and plain text
-# Unknown -> "" (the raw value is always preserved so callers can refine).
 _BUY_DIRECTIONS = {ENTRUST_BUY, str(ENTRUST_BUY), OFFSET_OPEN, str(OFFSET_OPEN), 23, "23", "BUY", "buy", "B"}
 _SELL_DIRECTIONS = {ENTRUST_SELL, str(ENTRUST_SELL), OFFSET_CLOSE, str(OFFSET_CLOSE), OFFSET_CLOSE_TODAY, str(OFFSET_CLOSE_TODAY), OFFSET_CLOSE_YESTERDAY, str(OFFSET_CLOSE_YESTERDAY), 24, "24", "SELL", "sell", "S"}
 
@@ -79,47 +87,70 @@ def _action_from_direction(direction):
     return ""
 
 
+def _is_buy(val):
+    v = int(val)
+    return v in _BUY_DIRECTIONS
+
+
+def _is_sell(val):
+    v = int(val)
+    return v in _SELL_DIRECTIONS
+
+
+def _conflict_resolve(d_val, o_val, obj):
+    """When m_nDirection and m_nOffsetFlag disagree, arbitrate via m_nOpType.
+
+    Live diagnosis confirms:
+      - Stock sell: direction=48(buy), offset=49(sell), op_type=24(sell) → sell
+      - Futures sell+open: direction=49(sell), offset=48(open), op_type=24(sell) → sell
+      - Futures buy+close: direction=48(buy), offset=49(close), op_type=23(buy) → buy
+
+    Returns a resolved value, or None if no arbiter can decide.
+    """
+    op = _attr(obj, ["m_nOpType", "op_type", "order_type"])
+    if op is not None:
+        try:
+            op_int = int(op)
+            if op_int in _BUY_DIRECTIONS:
+                return d_val if _is_buy(d_val) else o_val if _is_buy(o_val) else op
+            if op_int in _SELL_DIRECTIONS:
+                return d_val if _is_sell(d_val) else o_val if _is_sell(o_val) else op
+        except (TypeError, ValueError):
+            if op in _BUY_DIRECTIONS:
+                return d_val if _is_buy(d_val) else o_val if _is_buy(o_val) else op
+            if op in _SELL_DIRECTIONS:
+                return d_val if _is_sell(d_val) else o_val if _is_sell(o_val) else op
+    # no arbiter — trust offset (QMT docs confirm stock direction=offset)
+    return o_val
+
+
 def _extract_direction(obj):
     """Extract buy/sell direction, matching query_orders' reliable logic.
 
-    For spot stocks, m_nDirection (EEntrustBS 48/49) and m_nOffsetFlag
-    (EOffset_Flag_Type 48/49) coincide: buy=open=48, sell=close=49.
+    Priority chain (documented with live-diagnosis justification):
+      1. m_nOffsetFlag         — most reliable in live callbacks (matches query_orders)
+      2. m_nDirection           — traditional EEntrustBS (can be stuck at 48)
+      3. Arbitration: when direction≠offset, consult m_nOpType (orders: 23/24)
+         to resolve correctly for both stocks AND futures.
+      4. m_nOpType / order_type — last resort fallback.
 
-    In live order_callback/deal_callback, m_nDirection can be 0/None at
-    certain callback moments (e.g. early "未报" state), while m_nOffsetFlag
-    is reliably populated. query_orders uses m_nOffsetFlag and works in
-    production. So we prefer offset_flag when direction is absent/invalid.
-
-    For futures (not shipped here), direction≠offset (e.g. sell+open=short).
-    If BOTH fields are present and direction is a valid buy/sell value, we
-    trust m_nDirection (the true buy/sell signal), preserving futures correctness.
-
-    Fallback chain: m_nDirection(if valid buy/sell) > m_nOffsetFlag > order_type.
     The raw value is always returned (even pledge=81) so callers can inspect it;
     _action_from_direction maps only known buy/sell values, leaving others "".
-    """
-    direction = _attr(obj, ["m_nDirection", "direction"])
-    offset = _attr(obj, ["m_nOffsetFlag", "offset_flag"])
 
-    # If direction is present and is a valid buy/sell value, use it (covers
-    # both stock 48/49 and futures where direction≠offset).
-    if direction is not None:
-        try:
-            d = int(direction)
-            if d in _BUY_DIRECTIONS or d in _SELL_DIRECTIONS:
-                return direction
-            # 0 / other non-buy-sell numeric -> treat as absent (live bug: m_nDirection
-            # is 0 at certain callback moments), fall through to offset_flag.
-            # Non-zero non-buy-sell (e.g. pledge 81) is preserved below.
-            if d != 0:
-                return direction
-        except (TypeError, ValueError):
-            if direction in _BUY_DIRECTIONS or direction in _SELL_DIRECTIONS:
-                return direction
-            # non-numeric, non-buy-sell (text) — preserve it
-            return direction
-    # direction absent/None -> fall back to offset_flag (reliable in stocks)
-    if offset is not None:
+    References
+    ----------
+    - Live diagnosis 2026-07-29 (COrderDetail/CDealDetail):
+      m_nDirection=48 unconditionally, m_nOffsetFlag=48(buy)/49(sell) correct,
+      m_nOpType=23(buy)/24(sell) correct (orders only).
+    - QMT enum docs: enum_EEntrustBS (48=买,49=卖), enum_EOffset_Flag_Type
+      (48=开仓,49=平仓). For stocks direction=offset; for futures they differ.
+    - query_orders uses m_nOffsetFlag and works correctly in production.
+    """
+    offset = _attr(obj, ["m_nOffsetFlag", "offset_flag"])
+    direction = _attr(obj, ["m_nDirection", "direction"])
+
+    # 1. offset alone — use it directly (matches query_orders)
+    if offset is not None and direction is None:
         try:
             o = int(offset)
             if o in _BUY_DIRECTIONS or o in _SELL_DIRECTIONS:
@@ -127,8 +158,44 @@ def _extract_direction(obj):
         except (TypeError, ValueError):
             if offset in _BUY_DIRECTIONS or offset in _SELL_DIRECTIONS:
                 return offset
-    # last resort: MiniQMT-style order_type field
-    return _attr(obj, ["order_type"])
+
+    # 2. direction alone — use it
+    if direction is not None and offset is None:
+        try:
+            d = int(direction)
+            if d in _BUY_DIRECTIONS or d in _SELL_DIRECTIONS:
+                return direction
+            if d != 0:
+                return direction
+        except (TypeError, ValueError):
+            if direction in _BUY_DIRECTIONS or direction in _SELL_DIRECTIONS:
+                return direction
+            return direction
+
+    # 3. both present
+    if direction is not None and offset is not None:
+        try:
+            d = int(direction)
+            o = int(offset)
+            d_valid = (d in _BUY_DIRECTIONS or d in _SELL_DIRECTIONS)
+            o_valid = (o in _BUY_DIRECTIONS or o in _SELL_DIRECTIONS)
+
+            if d_valid and o_valid:
+                if d == o:
+                    return direction  # agree → use either
+                # disagree → arbitrate via m_nOpType
+                return _conflict_resolve(d, o, obj)
+
+            if d_valid and not o_valid:
+                return direction
+            if o_valid and not d_valid:
+                return offset
+            # neither valid — fall through
+        except (TypeError, ValueError):
+            pass
+
+    # 4. last resort: m_nOpType / order_type
+    return _attr(obj, ["m_nOpType", "op_type", "order_type"])
 
 
 # Fields we care about when diagnosing a direction misread. Anything starting
@@ -137,6 +204,7 @@ def _extract_direction(obj):
 _RAW_SNAPSHOT_EXTRA_FIELDS = (
     "stock_code",
     "order_type",
+    "op_type",
     "direction",
     "offset_flag",
     "order_status",
@@ -156,10 +224,9 @@ _RAW_SNAPSHOT_EXTRA_FIELDS = (
 def raw_field_snapshot(obj, max_repr=120):
     """Capture every readable field of a live QMT callback object.
 
-    Direction extraction rests on an assumption about what ``m_nDirection`` and
-    ``m_nOffsetFlag`` actually carry in live order_callback/deal_callback — an
-    assumption nothing in this repo has ever observed. This dumps the raw object
-    so one live order settles it.
+    Direction extraction relies on understanding what ``m_nDirection``,
+    ``m_nOffsetFlag`` and ``m_nOpType`` carry in live callbacks. This dumps
+    every readable field so one live order settles the question.
 
     Returns ``{name: "<type> <value>"}``. Never raises: a callback that dies
     while being diagnosed would be worse than no diagnosis.

--- a/tests/bigqmt_signal_trader/test_exec_events.py
+++ b/tests/bigqmt_signal_trader/test_exec_events.py
@@ -108,50 +108,85 @@ class ExecEventsServerTest(unittest.TestCase):
         publish_order_event(r, "acct", {"event_type": "order"})
         self.assertEqual(r.pubs[1][0], order_channel("acct"))
 
-    def test_action_comes_from_direction_not_offset_flag(self):
+    def test_arbitration_resolves_direction_offset_conflict_via_op_type(self):
+        """When m_nDirection and m_nOffsetFlag disagree (futures: sell+open),
+        arbitration via m_nOpType picks the semantically correct field."""
         class Deal:
             m_strInstrumentID = "600000.SH"
-            m_nDirection = 49   # EEntrustBS sell
-            m_nOffsetFlag = 48  # offset 48 = 开仓 (open) — must NOT be read as buy
+            m_nDirection = 49    # EEntrustBS sell
+            m_nOffsetFlag = 48   # offset 48 = 开仓 (open)
+            m_nOpType = 24       # STOCK_SELL — arbiter confirms sell
             m_nVolume = 10
             m_dPrice = 1.0
             m_strTradeID = "X"
 
         ev = normalize_trade_event(Deal(), "acct")
 
-        self.assertEqual(ev["action"], "SELL")   # derived from m_nDirection
-        self.assertEqual(ev["offset_flag"], 48)  # raw offset preserved, not conflated
+        self.assertEqual(ev["action"], "SELL")       # from direction via arbitration
+        self.assertEqual(ev["direction"], 49)        # direction field = m_nDirection
+        self.assertEqual(ev["offset_flag"], 48)      # raw offset preserved, not conflated
 
-    def test_direction_falls_back_to_offset_when_direction_missing(self):
-        """Live bug: m_nDirection is 0/None at certain callback moments,
-        causing sell orders to be misread as buy. Fall back to m_nOffsetFlag
-        (matches query_orders, which works correctly in production)."""
+    def test_arbitration_stock_sell_wrong_direction_fixed_by_op_type(self):
+        """Stock sell: m_nDirection=48 (bug: always 48), m_nOffsetFlag=49,
+        m_nOpType=24 → arbitration picks offset (49→SELL)."""
         class SellOrder:
             m_strInstrumentID = "601398.SH"
-            m_nDirection = 0       # absent/zero in live callback (the bug)
-            m_nOffsetFlag = 49     # 平仓 = sell for stocks
+            m_nDirection = 48       # QMT bug — always 48 in live callbacks
+            m_nOffsetFlag = 49      # 平仓 = sell (correct)
+            m_nOpType = 24          # STOCK_SELL (correct)
             m_nVolumeTotal = 100
             m_nVolumeTraded = 0
             m_dLimitPrice = 6.34
             m_strOrderSysID = "S123"
 
         ev = normalize_order_event(SellOrder(), "acct")
-        self.assertEqual(ev["action"], "SELL")  # from offset_flag, not 0/None
-        self.assertEqual(ev["direction"], 49)
+        self.assertEqual(ev["action"], "SELL")
+        self.assertEqual(ev["direction"], 49)       # offset_flag wins via arbitration
 
-    def test_direction_falls_back_to_offset_when_direction_none(self):
-        """Same bug with direction=None entirely."""
+    def test_arbitration_stock_buy_agree(self):
+        """Stock buy: m_nDirection=48, m_nOffsetFlag=48 → agree → BUY."""
         class BuyOrder:
             m_strInstrumentID = "601398.SH"
-            m_nDirection = None
-            m_nOffsetFlag = 48     # 开仓 = buy for stocks
+            m_nDirection = 48
+            m_nOffsetFlag = 48
+            m_nOpType = 23
             m_nVolumeTotal = 100
             m_nVolumeTraded = 0
-            m_dLimitPrice = 6.34
+            m_dLimitPrice = 5.0
             m_strOrderSysID = "B456"
 
         ev = normalize_order_event(BuyOrder(), "acct")
-        self.assertEqual(ev["action"], "BUY")   # from offset_flag
+        self.assertEqual(ev["action"], "BUY")
+        self.assertEqual(ev["direction"], 48)
+
+    def test_direction_zero_falls_back_to_offset(self):
+        """m_nDirection=0 is treated as absent; offset determines direction."""
+        class SellOrder:
+            m_strInstrumentID = "601398.SH"
+            m_nDirection = 0
+            m_nOffsetFlag = 49
+            m_nVolumeTotal = 100
+            m_nVolumeTraded = 0
+            m_dLimitPrice = 6.34
+            m_strOrderSysID = "S123"
+
+        ev = normalize_order_event(SellOrder(), "acct")
+        self.assertEqual(ev["action"], "SELL")
+        self.assertEqual(ev["direction"], 49)
+
+    def test_direction_none_falls_back_to_offset(self):
+        """m_nDirection=None → offset determines direction."""
+        class BuyOrder:
+            m_strInstrumentID = "601398.SH"
+            m_nDirection = None
+            m_nOffsetFlag = 48
+            m_nVolumeTotal = 100
+            m_nVolumeTraded = 0
+            m_dLimitPrice = 5.0
+            m_strOrderSysID = "B456"
+
+        ev = normalize_order_event(BuyOrder(), "acct")
+        self.assertEqual(ev["action"], "BUY")
         self.assertEqual(ev["direction"], 48)
 
     def test_pledge_direction_has_no_buy_sell_action(self):


### PR DESCRIPTION
Live diagnosis (COrderDetail/CDealDetail, 2026-07-29) confirms:
  m_nDirection=48 unconditionally — even for sell orders.
  m_nOffsetFlag=48(buy)/49(sell) — correct.
  m_nOpType=23(buy)/24(sell) — correct (orders only).

Previous fix (89efc14) preferred m_nDirection, relying on it being 0/None at certain moments to fall back to offset. The real bug is worse: m_nDirection is always 48, a valid-looking but wrong value.

New arbitration logic:
  1. Single field present → use it directly.
  2. Both disagree → consult m_nOpType as arbiter (covers futures: direction≠offset e.g. sell+open=49+48, op_type=24 → sell).
  3. No arbiter (trades without m_nOpType) → trust offset (QMT docs confirm stock direction=offset).
  4. Last resort: m_nOpType/order_type.

Fixes both the stock sell misread and preserves futures correctness.