### PR TITLE
feat: subscribe_whole_quote 真推送 — 对齐 MiniQMT 全推行情订阅

### DIFF
--- a/docs/RPC_API_REFERENCE.md
+++ b/docs/RPC_API_REFERENCE.md
@@ -64,6 +64,27 @@
 
 ---
 
+## 2.5 全推行情订阅（server 推送，对齐 miniqmt `subscribe_whole_quote`）
+
+这三个方法只管理**订阅生命周期与心跳**；行情数据本身走独立的 server→client 推送通道（zmq PUB/SUB 或 redis pub/sub，msgpack 编码、json 兜底），**不经过 RPC 响应**。多 client 订阅同一组合（`frozenset` 规范化）共享同一个大 QMT `ContextInfo.subscribe_whole_quote`，引用计数归零（全部退订或全部心跳超时）才真正退订大 QMT。详见 `docs/SUBSCRIBE_WHOLE_QUOTE_PUSH.md`。
+
+### `subscribe_whole_quote`
+- **参数**：`client_id`（str，必填，client 进程级稳定 id）、`sub_id`（str，必填，client 侧订阅号）、`codes`（list[str]，必填）：市场代码（`["SH","SZ"]`）或品种代码列表。
+- **返回**：`{"combo_key": str, "topic": str, "push_endpoint": str}`。`topic` 即推送通道的过滤主题；`push_endpoint` 为 zmq PUB 地址（redis 推送时为空，client 本地推导 channel 名）。
+- **语义**：首个 client 订阅该组合时建立大 QMT 订阅；同组合后续 client 共享。幂等（重复 subscribe 不重复建订阅，用于 server 重启后 client 重放恢复）。
+
+### `unsubscribe_whole_quote`
+- **参数**：`client_id`、`sub_id`（均 str，必填）。
+- **返回**：`{}`。
+- **语义**：移除该 `(client_id, sub_id)` 的引用；该组合最后一个 client 离开时退订大 QMT。未知 sub_id 为 no-op。
+
+### `quote_keepalive`
+- **参数**：`client_id`、`sub_id`（均 str，必填）。
+- **返回**：`{}`。
+- **语义**：刷新该订阅的 `last_seen`。client 每 `heartbeat_interval`（默认 3s）发送一次；server 端某 client 超过 `heartbeat_timeout_seconds`（默认 30s = 10 个心跳周期）无心跳则被 reaper 移除，组合清空后退订大 QMT。
+
+---
+
 ## 3. 行情 / K线 / 板块 / 日历 / 下载 / 财务 / 期权 / 龙虎榜 / 资金流 / 因子
 
 下列 84 个方法统一通过 `_handle_market_data_method` **按方法名转发给 `BigQmtMarketDataProvider` 的同名方法**，参数字典直接 `**kwargs` 展开。调用方按下方签名传参即可。客户端兼容层对常用方法有显式封装，其余用 `xtdata.call_method(name, **params)`。

--- a/docs/SUBSCRIBE_WHOLE_QUOTE_LIVE_VERIFICATION.md
+++ b/docs/SUBSCRIBE_WHOLE_QUOTE_LIVE_VERIFICATION.md
@@ -1,0 +1,174 @@
+# subscribe_whole_quote 全推行情 — 真机联调验证报告
+
+> 日期:2026-08-10(周一,交易日)
+> 环境:本地客户端 + Windows QMT 服务端(内网联调)
+> 版本:`feat/impl_subscribe_whole_quote` 分支(commit 7e0d67d 及之后修复)
+> 文档:`docs/SUBSCRIBE_WHOLE_QUOTE_PUSH.md`(设计),本文档为真实环境验证结果
+
+---
+
+## 1. 环境与部署
+
+### 1.1 拓扑
+
+```
+本地客户端 (venv, Python 3.10)
+  └─ bigqmt_signal_trader (editable 安装, 指向仓库 src/)
+      ├─ BigQmtRpcClient ── redis (内网, db5) ──► 服务端 RPC
+      └─ RedisQuotePushChannel (pub/sub bigqmt:quote_push:{acct}:{topic})
+                                ▲
+                                │ redis pub/sub
+Windows 服务端 (QMT 交易端, Python 3.6)
+  └─ <QMT python 目录>/  (策略 BIGQMT_REDIS_DRYRUN)
+      ├─ bigqmt_signal_trader_strategy.py ── 启动 QuoteSubscriptionManager
+      ├─ quote_subscription_manager.py     ── 引用计数订阅管理
+      └─ quote_push_channel.py             ── 推送通道(服务端, json 兜底编码)
+```
+
+### 1.2 部署动作
+
+| 步骤 | 内容 | 结果 |
+|---|---|---|
+| 1 | 修复本地开发 venv(uv 重建 Python 3.10) | ✅ |
+| 2 | `uv pip install -e /path/xtquant_big_convert[redis,msgpack]` 部署到 venv | ✅ |
+| 3 | 全量替换服务端 40 个 bigqmt 文件为本地当前版本(逐文件 MD5 校验一致,保留 `local_config.py` 生产配置) | ✅ |
+| 4 | 服务端 `full_tick_cache_enabled: True`(既有配置,无需改动) | ✅ |
+
+> 关键教训:初期误判"服务端文件已是最新"(大小写哈希比对看串),实际除 3 个新文件外其余 19 个均为旧版,导致订阅 RPC 报 `method is not allowed`。全量替换 + 程序化 MD5 校验后解决。
+
+---
+
+## 2. 验证过程与结果
+
+### 2.1 阶段一:基础链路(09:00-09:06)
+
+| # | 验证项 | 结果 | 证据 |
+|---|---|---|---|
+| 1 | RPC 链路存活 | ✅ | `get_full_tick` 2.1s 返回盘前快照 |
+| 2 | `subscribe_whole_quote` RPC 允许 | ✅ | 282ms 返回 seq(修复前报 `method is not allowed`,因服务端旧版 `redis_rpc.py` 缺 `READ_METHODS |= QUOTE_SUBSCRIPTION_METHODS`) |
+| 3 | 初始快照 prime | ✅ | 订阅后立即回调完整快照(lastPrice 11.19 昨收) |
+| 4 | redis 推送通道 | ✅ | 模拟发布 → 客户端实时收到 |
+| 5 | 竞价真实推送(09:15:27) | ✅ | stockStatus=12 集合竞价,盘口 397/23 |
+
+**发现 Bug #1:msgpack/json 编码不对称**
+- 现象:客户端推送线程 `msgpack.exceptions.ExtraData: unpack(b) received extra data` 崩溃
+- 根因:服务端 QMT 内置 Python **无 msgpack**(json 兜底编码),客户端**有 msgpack**(按 msgpack 解码 json 文本 → 首字节 `{` 被当整数 + 尾随字节)
+- 修复:`decode_push_payload` msgpack 失败时回退 json(测试驱动:红→绿)
+
+### 2.2 阶段二:数据正确性(09:45-09:48,连续竞价)
+
+**单标的 000001.SZ(60s)**:21 笔推送,间隔 min=2.21s / max=3.11s / avg=2.96s,>4s 的 0 个;time/volume/amount 单调性零违规。
+
+**20 只活跃股(沪深300 成交额 top20, 120s)**:
+
+| 指标 | 结果 |
+|---|---|
+| 每只推送次数 | 41~42 次(120s / 3s ≈ 40,高度一致) |
+| 最大间隔 | 3.1~3.3s(全部 < 4s) |
+| 平均间隔 | 2.93~2.99s |
+| gap>4s | 0(全部 20 只) |
+| 数据单调性(vol/amt/time) | 0 违规(全部 20 只) |
+
+结论:**每 3 秒一份推送、零丢失、零乱序、零数据回退**,覆盖主板/创业板/科创板。
+
+### 2.3 阶段三:多标的规模(09:36-09:40)
+
+| 标的数 | 订阅耗时 | 初始快照 | 60s 增量推送 | 覆盖 | 错误 |
+|---|---|---|---|---|---|
+| 20 只 | 1.1s | 4 次/20 只 | 61 次 | 20/20 | 0 |
+| 50 只 | 0.8s | 7 次/50 只 | 140 次 | 50/50 | 0 |
+| 100 只 | 2.1s | 19 次/100 只 | 336 次 | 100/100 | 0 |
+
+结论:推送量随标的数线性增长,覆盖完整,订阅耗时稳定,零错误。
+
+### 2.4 阶段四:心跳与超时回收(A 组,09:53-09:56)
+
+| # | 验证项 | 结果 | 证据 |
+|---|---|---|---|
+| A1 | 正常心跳保活 | ✅ | 90s 31 次推送,间隔 2.90s |
+| A2 | 心跳超时回收(kill 不发退订) | ✅ | 之后同 client_id 重连安全 |
+| A4 | 同 client_id 重连恢复 | ✅ | 45s 16 次推送,推送恢复 |
+| A5 | 正常退订 + 再订阅 | ✅ | 退订后 10s 0 次,再订阅 11 次恢复 |
+
+### 2.5 阶段五:多 client 并发(B 组,09:57-10:00)
+
+| # | 验证项 | 结果 | 证据 |
+|---|---|---|---|
+| B1 | 两 client 同组合 | ✅ | A=7 B=7 各自收推 |
+| B2 | 组合去重共享订阅 | ✅ | 推送节奏一致(7=7),服务端只建 1 个订阅 |
+| B3 | 一方退订对方持续 | ✅ | A 退订后 A=0 B=5 |
+| B4 | 全退订拆订阅 | ✅ | 无推送 |
+| B5 | 不同组合互不干扰 | ✅ | 000001 只有 A 收,000002 只有 B 收 |
+| B6 | 同 client 多 sub_id | ✅(修复后) | 见 Bug #2 |
+| B7 | 混合组合隔离 | ✅ | 000001 双方收,000002 只有 E 收 |
+
+**发现 Bug #2:客户端订阅线程泄漏**
+- 现象:B6 首测失败(退订 sub1 后 sub2 偶发收不到),深挖发现订阅/退订时 `_sync_subscriber_locked` 无脑新起线程、旧线程不停止(3 个 `bigqmt-quote-push-sub` 线程并存),多线程消费同一 pubsub 有竞态
+- 修复:topic 集合 diff——不变则复用,变化则先 stop 旧线程再起新线程,变空则停(测试驱动)
+
+### 2.6 阶段六:异常与边界(C 组,10:05-10:18)
+
+| # | 验证项 | 结果 | 证据 |
+|---|---|---|---|
+| C1 | 重复订阅幂等 | ✅ | 15s 11 次推送 |
+| C2 | 空代码列表 | ✅ | `ValueError: code_list is required` |
+| C3 | 非法代码容错 | ✅ | 未崩,无推送 |
+| C4 | 同 topic 多 sub_id 退订隔离 | ✅(修复后) | 见 Bug #3 |
+| C5 | 拔线重连 | ✅ | A2/A4 覆盖 |
+
+**发现 Bug #3:服务端引用计数粒度错误**
+- 现象:C4 首测失败——同 client 两个 sub_id 订阅同一组合,退订一个后,另一个的推送停止(组合被整体拆掉)
+- 根因:`_Combo.clients` 按 `client_id` 粒度,但订阅单元是 `(client_id, sub_id)`;退订一个 sub 时 `_remove_client_locked` 把整个 client 移出,组合错误拆解
+- 修复:改为 `(client_id, sub_id)` 粒度(含 subscribe/unsubscribe/keepalive/reaper 四处)(测试驱动,新增单测覆盖)
+
+### 2.7 阶段七:服务端重启恢复(C6,10:27-10:31)
+
+| 验证轮次 | 客户端行为 | 结果 |
+|---|---|---|
+| C6v1(修复前) | 无自动重放 | ❌ 重启后推送永久中断(140s 静默) |
+| C6v2(keepalive 失败重放) | 只靠 keepalive 失败检测 | ❌ 未触发——重启窗口内 keepalive 被 redis 队列兜住"成功",检测不到 |
+| C6v3(静默检测重放) | 推送静默超阈值自动重放 | ✅ 中断 42s 后自动恢复,后续 27 次推送正常 |
+
+**发现 Bug #4:服务端重启后订阅丢失,客户端无自动恢复**
+- 根因:文档承诺的"client 检测断连→自动重放"**从未实现**(`replay_subscriptions` 无生产调用点);且仅靠 keepalive 失败检测不可靠(redis 请求队列在重启窗口内缓冲,keepalive 不抛异常)
+- 修复:心跳循环增加**推送静默检测**——订阅期间超过 N 个心跳周期(默认 10,≈30s)无推送到达,自动重放订阅(测试驱动,新增 2 个单测)
+
+### 2.8 阶段八:配置验证(D 组,10:32)
+
+| # | 验证项 | 结果 |
+|---|---|---|
+| D1 | `BIGQMT_QUOTE_HEARTBEAT_SECONDS` env 生效 | ✅ 1s 心跳,30s 10 次推送 |
+| D2 | `heartbeat_timeout_seconds` 配置生效 | 单测覆盖(修改需重启策略,跳过) |
+
+---
+
+## 3. 发现并修复的 Bug 汇总(4 个)
+
+| # | Bug | 位置 | 根因 | 修复 |
+|---|---|---|---|---|
+| 1 | 推送解码崩溃 `ExtraData` | `quote_push_channel.py` | 服务端无 msgpack(json 兜底)与客户端 msgpack 解码不对称 | msgpack 失败回退 json |
+| 2 | 订阅线程泄漏/竞态 | `whole_quote_session.py` | `_sync_subscriber_locked` 每次新起线程不停止旧的 | topic 集合 diff,复用/停止 |
+| 3 | 同 client 多 sub 退订误拆组合 | `quote_subscription_manager.py` | 引用计数按 client 粒度而非 (client, sub) 粒度 | 改 (client_id, sub_id) 粒度 |
+| 4 | 服务端重启后订阅丢失 | `whole_quote_session.py` | 自动重放从未接线;keepalive 被 redis 队列兜住检测不到重启 | 推送静默检测自动重放 |
+
+全部按 TDD 修复(红→绿),同步部署到服务端。
+
+---
+
+## 4. 测试基线
+
+- 全量:`266 passed, 3 skipped, 1 failed`
+- 唯一失败:`test_transports.py::MysqlTransportTest::test_round_trip`(`No module named 'dbutils'`,本地 venv 未装 mysql extra)——**预先存在,与本次改动无关**
+- 新增测试:
+  - `test_quote_push_channel.py`:json 解码回退 2 个
+  - `test_whole_quote_client.py`:线程复用/重启 4 个 + 自动重放 2 个
+  - `test_quote_subscription_manager.py`:(client, sub) 粒度退订 1 个
+
+---
+
+## 5. 结论
+
+1. **全链路功能正确**:订阅 RPC、初始快照 prime、redis 推送通道、增量推送(3s 节奏)、多标的(20/50/100)、多 client 共享订阅、退订隔离、心跳保活/超时回收、服务端重启自动恢复,全部通过。
+2. **数据正确性**:单标的 21/60s、20 只活跃股 41-42/120s,间隔 2.93-3.0s 稳定,零丢失、零乱序、零回退。
+3. **发现并修复 4 个真实 bug**,均经 TDD 验证,全量测试无回归。
+4. **遗留**:D2(超时配置生效)仅单测覆盖;mysql 测试环境缺 DBUtils(预先存在);`docs/SUBSCRIBE_WHOLE_QUOTE_PUSH.md` 中"自动重放"设计描述现已实现,可保持同步。

--- a/docs/SUBSCRIBE_WHOLE_QUOTE_PUSH.md
+++ b/docs/SUBSCRIBE_WHOLE_QUOTE_PUSH.md
@@ -1,0 +1,317 @@
+# subscribe_whole_quote 真推送方案（对齐 miniqmt）
+
+> 状态：**待评审**（方案已成型，未动实现。实现严格按 TDD：先红→绿→回归）
+> 分支：`feat/impl_subscribe_whole_quote`
+
+## 1. 背景与现状诊断
+
+### 1.1 miniqmt 语义（目标行为）
+
+`xtdata.subscribe_whole_quote(code_list, callback)` 在 miniqmt 里是**真订阅**：
+
+- 注册后，行情服务**持续推送**，每个行情周期触发一次 `callback(data)`，`data` 是 `{code: tick_dict}` 的全推快照。
+- 返回一个 `seq`（订阅句柄）；`unsubscribe_quote(seq)` 后推送停止。
+- 全市场用板块代码：`["SH"]`、`["SZ"]`、`["SH","SZ"]`（也支持 `"BJ"`、`"HK"`）。
+
+### 1.2 当前实现（client 端假订阅，server 端空转）
+
+- **client**（`xtquant_compat.py:781`）：`subscribe_whole_quote` 只是 `publish_event("subscribe_whole_quote", ...)` 到 redis stream（`bigqmt:quote_events:{account_id}`），然后**同步调一次 `get_full_tick` 触发一次 callback** 就返回 `seq`。之后**再无任何推送**。`callback` 不被持有，纯一次性。
+- **server**：**全仓库没有任何代码消费 `quote_events` stream**，也没有任何代码调用大 QMT 的 `ContextInfo.subscribe_whole_quote` / `xtdata.subscribe_whole_quote`。事件发出去石沉大海。
+- `unsubscribe_quote(seq)` 同样只发事件 + 删 redis 订阅记录，无实际效果。
+
+**结论：miniqmt 的「注册 → 持续推送 → 回调」语义当前完全没有实现。**
+
+### 1.3 transport 现状
+
+- `RpcTransport`（`transports/base.py`）是**纯请求/响应**模型：client `send_request`、server `start_receiving`/`send_response`。**没有 server→client 的主动推送通道**。
+- zmq transport 用 ROUTER/DEALER，请求响应式；redis transport 的 pubsub 只用于 RPC 请求/响应通道，不用于行情推送。
+
+### 1.4 可复用的资产
+
+- `full_tick_cache`：server 周期 `ContextInfo.get_full_tick` 拉快照写 redis，client 读缓存。**是轮询拉取，不是推送**，但有现成的 demand/TTL 机制（本方案不采用它做数据面，仅作对比参考）。
+- `BigQmtRpcHandlers`（`redis_rpc.py:333`）：server 端白名单 dispatch，`market_data` 适配器持有 `ContextInfo` —— server 端订阅管理器复用此路径访问大 QMT 行情接口。
+- 参考实现：`quant-qmt-proxy` 的 `SubscriptionManager` 已验证 `xtdata.subscribe_whole_quote(["SH","SZ"], callback)` 推送模式 + 心跳超时（默认 60s）在本环境可行。
+
+---
+
+## 2. 已确认的决策（来自讨论）
+
+| # | 决策点 | 结论 |
+|---|--------|------|
+| Q1 | 数据通路 | **方案 A：真推送**。server 端大 QMT 订阅回调 → 推送通道 → client callback。新增 server→client 推送通道。 |
+| Q2 | 去重粒度 | **按组合去重**：`frozenset(code_list)` 规范化后作为订阅单元 key。不同 client 传相同集合 → 共享同一个大 QMT 订阅。 |
+| Q3 | 引用计数 & keepalive | client 分配 `client_id`，周期发 keepalive（带 `client_id`+组合）；server 维护 `{组合: {client_id: last_seen}}`，**超时阈值 = 10 个心跳周期**未收到才认为该 client 消亡；组合所有 client 消亡后才真正退订大 QMT。 |
+| Q4 | server 重启恢复 | **client 重放**：client 记忆自己的订阅集合，检测到断连/server 重启后自动重放订阅；server 无状态、靠 client 重放/keepalive 重建订阅。**server 订阅表落盘不做**（实现阶段决定：client 重放已覆盖恢复路径，落盘引入 QMT 环境文件 IO 复杂度，无额外收益）。 |
+| Q5 | 大 QMT 行情源 | **ContextInfo 优先**：server 用策略进程内 `ContextInfo.subscribe_whole_quote`。"建/退订阅"收敛为可替换适配层，按真实环境实测微调（见 §7 风险 1）。 |
+| Q6 | 推送通道落地 | **zmq + redis 同阶段交付**：同一 `QuotePushChannel` 抽象下两个实现，按部署 transport 选择。 |
+| Q7 | 推送编码 | **高效编码：msgpack 优先，json 兜底**。msgpack 作为可选依赖（`optional-dependencies`），全市场推送建议安装；未装时退化为 json。 |
+
+---
+
+## 3. 总体架构
+
+```
+┌─────────────┐   subscribe_whole_quote   ┌──────────────────────────────────┐
+│   client A  │ ────────────────────────► │            server (大 QMT 进程)    │
+│  (xtdata)   │   RPC: subscribe_whole     │  QuoteSubscriptionManager         │
+└─────────────┘   _quote {client_id,       │   ├─ 组合去重 frozenset            │
+                  │      codes, sub_id}     │   ├─ refcount {combo: {cid: ts}} │
+┌─────────────┐                             │   └─ ContextInfo/xtdata.          │
+│   client B  │ ────────────────────────►  │      subscribe_whole_quote(      │
+└─────────────┘   同组合 → 共享同一订阅      │         codes, on_push)          │
+                  │                          └──────────┬───────────────────────┘
+   keepalive RPC  │  周期心跳 {client_id, sub_id}        │ 大 QMT 行情回调 on_push(data)
+        ──────────┼──────────────────────────►          │
+                  │                                     ▼
+                  │                          ┌──────────────────────────┐
+   行情推送        │ ◄──────────────────────  │  QuotePusher (PUB socket)│
+   (PUB/SUB)      │   topic=combo, {data}    │  按组合 topic 广播         │
+                  │                          └──────────────────────────┘
+```
+
+**三条逻辑通道**（对应三个职责）：
+
+1. **控制面 RPC（已有 transport 复用）**：`subscribe_whole_quote` / `unsubscribe_whole_quote` / `quote_keepalive` 三个新 RPC 方法，走现有请求/响应 transport（redis 或 zmq）。
+2. **数据面推送（新增）**：server→client 单向 PUB/SUB 通道，承载行情推送。
+3. **大 QMT 行情源**：server 端 `ContextInfo.subscribe_whole_quote`（或 `xtdata.subscribe_whole_quote`）回调。
+
+---
+
+## 4. 详细设计
+
+### 4.1 订阅单元 key（Q2：组合去重）
+
+```python
+def combo_key(code_list):
+    """规范化组合 → 唯一 key。顺序无关、大小写统一、去空白。"""
+    return ",".join(sorted({str(c).strip().upper() for c in (code_list or []) if str(c).strip()}))
+```
+
+- `["SH","SZ"]` 与 `["sz","SH"]` → 同一 key `"SH,SZ"`，共享同一个大 QMT 订阅。
+- 全市场 `["SH"]`、标的组合 `["000001.SZ","600000.SH"]` 都是合法 key。
+
+### 4.2 client 端（`BigQmtXtData.subscribe_whole_quote` 重写）
+
+- 入参 `code_list, callback` 不变（对齐 miniqmt 签名）。
+- 生成 `client_id`（进程级唯一，复用 zmq DEALER identity 或 `uuid4`，**进程生命周期内稳定**，持久化到本地文件以便重启后识别同一 client）。
+- 为本次订阅分配 `sub_id`（沿用现有 `_next_seq()`）。
+- 记录到 client 侧订阅表 `{sub_id: {codes, callback, combo_key}}`（**用于重放恢复**）。
+- 发 RPC `subscribe_whole_quote {client_id, sub_id, codes}` → server 返回 `{combo_key, push_endpoint, push_topic}`。
+- 启动/复用一个 **SUB 接收线程**，订阅 `push_topic`，每收到一帧 → 解析 → 调用所有匹配该 topic 的本地 callback。
+- 启动/复用一个 **keepalive 线程**，每 `heartbeat_interval` 秒对所有活跃 `sub_id` 发 `quote_keepalive {client_id, sub_id}`。
+- **初始全量打底**：大 QMT 全推回调是**增量**的（见 §4.3 调研结论），不保证订阅后立即给全量。client 在订阅成功后**先主动调一次 `get_full_tick(code_list)` 触发 callback 打底**，随后由增量推送驱动 callback。这既保留现有"订阅即给一帧"的行为，又对齐大 QMT 的增量语义。
+- 返回 `sub_id`。
+
+`unsubscribe_quote(sub_id)`：发 RPC `unsubscribe_whole_quote {client_id, sub_id}`，从本地表删除；该 sub_id 停止 keepalive。返回 0（对齐 miniqmt）。
+
+### 4.3 server 端 `QuoteSubscriptionManager`（新模块）
+
+挂在 server 进程内，持有 **ContextInfo**（Q5：优先用策略进程内 `ContextInfo.subscribe_whole_quote`；复用 `market_data` 适配器的 ContextInfo 引用）与 `QuotePusher`。
+
+**大 QMT 订阅适配层**（Q5：ContextInfo 优先）。已调研确认大 QMT 真实签名（见下方"调研结论"），适配层对外只暴露两个方法：
+
+```python
+class QuoteSourceAdapter:           # ContextInfo 优先实现
+    def subscribe(self, codes, on_push) -> handle: ...
+    def unsubscribe(self, handle) -> None: ...
+```
+
+**调研结论（真实大 QMT 环境，官方文档 + 隔壁 quant-qmt-proxy 实测交叉验证）**：
+
+| 项 | 结论 |
+|---|---|
+| 订阅签名 | `ContextInfo.subscribe_whole_quote(code_list, callback=None)` |
+| `code_list` | 市场代码 `['SH','SZ']` 或品种代码 `['600000.SH','000001.SZ']` |
+| 返回值 | `int` 订阅号 `subId`；**`< 0` 表示失败**（quant-qmt-proxy 实测） |
+| 退订 | `ContextInfo.unsubscribe_quote(subId)`（与 `subscribe_quote` 共用同一退订方法） |
+| **回调数据** | **增量推送**：每次回调只含**有变化**品种的最新 tick；`get_full_tick` 才是全量快照 |
+| 回调线程 | 独立于 `handlebar` 的推送线程（官方建议回调内不阻塞、扔队列处理） |
+
+`QuoteSubscriptionManager` 只跟 `QuoteSourceAdapter` 打交道，不直接碰 ContextInfo——`subscribe` 内部调 `ContextInfo.subscribe_whole_quote(codes, on_push)`、`unsubscribe` 内部调 `ContextInfo.unsubscribe_quote(handle)`；若实测仍有出入，只改这一层。
+
+**核心状态（内存，权威）**：
+
+```python
+{
+  combo_key: {
+    "codes": [...],              # 原始 code_list
+    "qmt_sub_handle": <大QMT订阅句柄>,   # subscribe_whole_quote 返回值
+    "clients": {client_id: last_seen_ts},  # 引用计数 + 心跳
+    "topic": push_topic,
+  }
+}
+```
+
+另维护 `sub_id → (client_id, combo_key)` 反向索引，用于按 sub_id 退订。
+
+**三个 RPC handler**（加入 `BigQmtRpcHandlers.allowed_methods`，走现有 dispatch）：
+
+- `subscribe_whole_quote {client_id, sub_id, codes}`：
+  - `key = combo_key(codes)`。
+  - 若该 combo 不存在：调 `ContextInfo.subscribe_whole_quote(codes, on_push)` 建订阅，记录 handle，`on_push` 闭包绑定 `key`；建 `topic`。
+  - `clients[client_id] = now`；登记 `sub_id → (client_id, key)`。
+  - 返回 `{combo_key, topic, push_endpoint}`。
+- `unsubscribe_whole_quote {client_id, sub_id}`：
+  - 由 `sub_id` 找到 `(client_id, key)`，`clients.pop(client_id)`，删除 `sub_id` 索引。
+  - 若该 combo 的 `clients` 为空 → `ContextInfo.unsubscribe_whole_quote(handle)`（或对应退订 API），销毁 combo。
+  - 返回 `{}`。
+- `quote_keepalive {client_id, sub_id}`：
+  - 由 `sub_id` 找 combo，`clients[client_id] = now`。返回 `{}`。
+
+**reaper（后台周期任务，挂在 server 的 adjust/调度循环上）**：
+
+- 每 `reap_interval` 秒扫描：对每 combo，删除 `now - last_seen > 10 * heartbeat_interval` 的 client。
+- combo 的 `clients` 清空后 → 退订大 QMT、销毁 combo。
+
+**on_push 回调**（大 QMT 行情线程触发）：
+
+- 收到 `data`（`{code: tick}`）→ 调 `QuotePusher.publish(topic, data)`。
+- **注意线程安全**：大 QMT 回调在行情线程，zmq PUB socket 的 send 需串行化（入队给专属发送线程，或加锁）。参照 zmq transport 已有的"socket 只能由创建它的线程关闭/使用"约束，推送也走队列 + 专属线程。
+
+### 4.4 推送通道（新增 `QuotePushChannel`，zmq + redis 同阶段交付）
+
+同一抽象下**两个实现同阶段交付**（Q6），按 client 当前 transport 选择：
+
+```python
+class QuotePushChannel:            # 抽象
+    def publish(self, topic, data) -> None: ...        # server 端
+    def subscribe(self, topic, on_msg) -> None: ...    # client 端
+```
+
+**zmq PUB/SUB 实现**（无 redis 部署的原生通道）：
+
+- server 端绑定一个 `PUB` socket（独立于现有 ROUTER，单独端口，地址随 RPC discovery 下发或在 subscribe 响应里返回 `push_endpoint`）。
+- client 端 `SUB` socket connect，`setsockopt(SUBSCRIBE, topic)` 按组合过滤。
+- 帧格式：`[topic_bytes][payload_bytes]`。
+- topic = `combo_key`（即 `"SH,SZ"`），SUB 端精确匹配前缀即可。
+
+**redis pub/sub 实现**（redis 部署）：
+
+- 复用现有 redis 连接，channel 名 `bigqmt:quote_push:{account_id}:{combo_key}`。
+- server `publish`、client `subscribe` 同一 channel。
+
+**编码（Q7：msgpack 优先，json 兜底）**：
+
+- 推送 payload 用 **msgpack** 序列化（对 `{code: {field: number}}` 这类结构，比 json 快数倍、体积更小，是全市场推送的标准选择）。
+- msgpack 列为**可选依赖**（`pyproject.toml` 的 `optional-dependencies`，与 redis/mysql 同组织方式），避免给最小安装（仅 pyzmq）增加硬依赖。
+- 未安装 msgpack 时**退化为 json**（stdlib），保证功能可用、仅吞吐降级。编码选择封装在 `QuotePushChannel` 内部，对上层透明。
+
+> 取舍说明：zmq PUB/SUB 是 **fire-and-forget**，client 掉线期间推送被丢弃（符合行情推送语义——增量丢了就等下一帧，无需逐条补发）。**但增量推送不自带全量**，client 重连/重放后必须由 §4.2 的"初始全量打底"（`get_full_tick`）重建本地状态，再接收增量。这与 miniqmt 行为一致。
+
+### 4.5 keepalive 与超时（Q3）
+
+- `heartbeat_interval`（client 发心跳周期），**默认 3s**。
+- 超时阈值 = `10 * heartbeat_interval = 30s`（Q3 已确认 10 个周期）。server 端某 client 超过 30s 无心跳 → 判定消亡，从所有 combo 的 `clients` 移除。
+- 心跳与数据面解耦：即便行情静默（盘后用快照），心跳照发，保证引用计数准确。
+
+### 4.6 server 重启恢复（Q4）
+
+- **client 重放**：client 的 SUB 接收线程检测到推送通道断开/server ping 失败 → 触发重连；重连成功后，对本地订阅表里**所有活跃 sub_id 重新发 `subscribe_whole_quote`**（幂等：server 按 `(client_id, combo)` 去重，重放不会重复建大 QMT 订阅）。
+- **server 落盘（不做）**：实现阶段决定 server 订阅表**不落盘**。client 重放已覆盖恢复路径（重启后 client 重放即可重建全部订阅），落盘只增加 QMT 环境文件 IO 与状态一致性复杂度，无额外收益。
+- **幂等性**：`subscribe_whole_quote` handler 对相同 `(client_id, sub_id, combo)` 重复调用安全（重建 last_seen，不重复建大 QMT 订阅）。
+
+---
+
+## 5. 配置项
+
+server 端（`config["quote_push"]`，见 `bigqmt_signal_trader_strategy.py`）：
+
+| 配置键 | 默认 | 说明 |
+|------|------|------|
+| `enabled` | `true` | 是否启用全推推送服务 |
+| `heartbeat_timeout_seconds` | `30.0` | client 无心跳超时阈值（= 10 个心跳周期 × 3s） |
+| `zmq_bind_address` | RPC zmq 端口 + 1 | zmq PUB 绑定地址（仅 transport=zmq 时用） |
+
+> 推送通道跟随 RPC transport（zmq/redis），reaper 挂在 RPC drain 上（随 drain 周期执行，无独立 interval）。server 订阅表不落盘（见 §4.6）。
+
+client 端（`bigqmt_signal_trader_client_config.py` / 环境变量）：
+
+| 配置 | 默认 | 说明 |
+|------|------|------|
+| `BIGQMT_QUOTE_CLIENT_ID` | 自动生成并持久化到 `~/.cache/bigqmt/quote_client_id` | client 唯一 id（重启稳定，用于重放识别） |
+| `BIGQMT_QUOTE_HEARTBEAT_SECONDS` | `3.0` | 心跳周期（环境变量），须 < server 超时 |
+
+---
+
+## 6. TDD 实施计划（先红→绿→回归）
+
+按依赖顺序分 6 个增量，每个增量都是「先写失败测试 → 实现 → 回归全套」。
+
+**阶段 1 — 组合 key + 引用计数核心（纯逻辑，无 IO）**
+- 红：`tests/bigqmt_signal_trader/test_quote_subscription_manager.py`
+  - `combo_key` 顺序无关/大小写统一。
+  - 两个 client 订阅同组合 → 只建一次大 QMT 订阅（mock ContextInfo），refcount=2。
+  - 一个 client 退 → 不退大 QMT；全部退 → 退一次大 QMT。
+  - 心跳超时：构造 `last_seen` 过期 → reaper 移除 client；combo 空 → 退订。
+- 绿：`src/bigqmt_signal_trader/quote_subscription_manager.py`（`combo_key` + `QuoteSubscriptionManager`，ContextInfo 用注入的 mock）。
+- 回归：全套测试。
+
+**阶段 2 — server RPC handler 接线**
+- 红：`subscribe_whole_quote` / `unsubscribe_whole_quote` / `quote_keepalive` 三个方法经 `BigQmtRpcHandlers.handle` 可达、白名单放行、参数校验、幂等重放。
+- 绿：在 `redis_rpc.py` 加 handler 方法 + `allowed_methods`，注入 `QuoteSubscriptionManager`。
+- 回归。
+
+**阶段 3 — 推送通道抽象 + zmq/redis 双实现 + 编码**
+- 红：`tests/bigqmt_signal_trader/test_quote_push_channel.py`
+  - `QuotePushChannel` 接口（`publish(topic, data)` / `subscribe(topic, on_msg)`）。
+  - zmq PUB/SUB 回环：bind PUB → SUB connect → publish → SUB 收到且 topic 过滤正确。
+  - redis pub/sub 回环：fake redis 下 publish → subscribe 收到。
+  - 编码：msgpack 可用时 payload 用 msgpack（解出结构与原始一致），未装时退化 json。
+- 绿：`src/bigqmt_signal_trader/quote_push_channel.py`（抽象 + zmq 实现 + redis 实现 + msgpack/json 编码选择）。
+- 回归。
+
+**阶段 4 — server on_push → 推送通道接线**
+- 红：mock ContextInfo 触发 `on_push(data)` → `QuotePushChannel.publish` 被以正确 topic+data 调用；线程安全（并发回调不竞态）。
+- 绿：`QuoteSubscriptionManager` 接 `QuotePushChannel`。
+- 回归。
+
+**阶段 5 — client 端重写（订阅 + SUB 接收 + keepalive 线程）**
+- 红：`tests/bigqmt_signal_trader/test_whole_quote_client.py`
+  - `subscribe_whole_quote` 发正确 RPC、注册本地 callback、启动 keepalive。
+  - 收到推送帧 → 触发对应 callback。
+  - `unsubscribe_quote` 发 RPC、停心跳。
+  - 重放：模拟断连后 → 对所有活跃 sub_id 重发 subscribe。
+- 绿：重写 `BigQmtXtData.subscribe_whole_quote` / `unsubscribe_quote`，新增 client 侧 SUB 接收与 keepalive 线程、`client_id` 管理。
+- 回归。
+
+**阶段 6 — 端到端 + 多 client 共享 + server 重启恢复**
+- 红：端到端测试（in-proc fake server + 两 client）
+  - 两 client 订同组合 → 各自 callback 都收到推送；server 只对大 QMT 建一次订阅。
+  - 一 client 退 → 另一个仍收；全退 → server 退订大 QMT。
+  - server "重启"（重建 manager + 推送通道）→ client 重放 → 恢复推送。
+  - client 静默超 30s → server 清引用 → 退订。
+- 绿：补齐集成胶水（server 启动时装配 manager+push channel，client 重连逻辑）。
+- 回归：全套 + 现有 `test_all_apis.py` 端到端不破坏。
+
+---
+
+## 7. 风险与开放问题
+
+1. **大 QMT 订阅/退订 API（已调研确认，风险解除）**：签名、返回值（`int` 订阅号，`<0` 失败）、退订方法 `unsubscribe_quote(subId)` 均已确认（见 §4.3 调研结论）。`QuoteSourceAdapter` 仍保留，作为唯一接触 ContextInfo 的层，便于真实环境联调时微调。
+2. **行情回调线程模型**：大 QMT `on_push` 在独立的推送线程触发（非 `handlebar` 线程），zmq send 必须跨线程安全（队列 + 专属发送线程）；官方亦建议回调内不阻塞、扔队列。阶段 4 专门覆盖。
+3. **增量推送语义**：大 QMT 全推回调是**增量**（只推变化品种），不是全量快照。client 端必须用 `get_full_tick` 打底 + 增量更新（§4.2），不能假设订阅后即得全量。这点与早期假设不同，已在 §4.2/§4.4 修正。
+4. **全市场推送量级**：`["SH","SZ"]` 全推增量仍可能每帧数千条。已按 Q7 采用 **msgpack** 编码（可选依赖，未装退化 json）压低开销；PUB 广播吞吐仍需在真实环境实测，若仍不足再评估压缩/分片（不过早优化）。
+5. **msgpack 依赖**：新增可选依赖 `msgpack`（`optional-dependencies`，对齐 redis/mysql 的组织方式），最小安装（仅 pyzmq）不受影响；未装时推送通道退化 json 编码。
+6. **与 full_tick_cache 关系**：二者独立。full_tick_cache 服务 `get_full_tick` 按需拉取；本方案服务 `subscribe_whole_quote` 推送。不冲突，不合并。
+
+---
+
+## 8. 交付物清单（已全部交付）
+
+- 新增：`src/bigqmt_signal_trader/quote_subscription_manager.py`（`combo_key`、`QuoteSubscriptionManager`、`QuoteSourceAdapter`/`ContextInfoQuoteSource`、`build_quote_subscription_service`）
+- 新增：`src/bigqmt_signal_trader/quote_push_channel.py`（抽象 + zmq/redis 实现 + msgpack/json 编码）
+- 新增：`src/bigqmt_signal_trader/whole_quote_session.py`（client 端订阅会话：订阅表 + 推送路由 + 心跳线程 + 重放）
+- 修改：`src/bigqmt_signal_trader/redis_rpc.py`（`QUOTE_SUBSCRIPTION_METHODS` + 3 个 handler + 白名单 + `quote_subscription_manager` 注入）
+- 修改：`src/bigqmt_signal_trader/xtquant_compat.py`（`subscribe_whole_quote`/`unsubscribe_quote` 重写 + session 懒建 + client_id 持久化 + push channel 选择 + `get_full_tick` 打底）
+- 修改：`src/bigqmt_signal_trader_strategy.py`（server 启动装配 `_build_quote_subscription_service` + publisher 启动 + reaper 挂 RPC drain）
+- 修改：`pyproject.toml`（`optional-dependencies` 增加 `msgpack`）
+- 新增测试：`test_quote_subscription_manager.py` / `test_quote_push_channel.py` / `test_quote_on_push_wiring.py` / `test_whole_quote_client.py` / `test_xtdata_whole_quote.py` / `test_quote_subscription_service.py` / `test_whole_quote_e2e.py`
+- 文档：本文档 + `RPC_API_REFERENCE.md` §2.5 增补 3 个新方法 + `bigqmt_signal_trader_client_config.example.py` 增补 client 配置
+
+**实现期间 TDD 抓到的两个真实 bug**：
+1. **`_sub_index` 键冲突**：两 client 各自 `sub_id` 从 1 开始，server 以单 `sub_id` 为键互相覆盖 → 引用计数错乱、"全退才退订"失效。e2e 测试暴露后改为 `(client_id, sub_id)` 复合键。这是多 client 场景的核心正确性问题，单 client 测试无法覆盖。
+2. **`load_client_config` 漏 `quote_client_id` 键**：导致 client_id 配置读不到、静默退回持久化文件路径。
+
+**未实现**：server 订阅表落盘兜底（§4.6，经决策不做，靠 client 重放恢复）。
+
+**待真实环境联调**（不阻塞交付，均已在 §7 标注）：`ContextInfo.subscribe_whole_quote` 实际句柄/退订微调、`["SH","SZ"]` 全推吞吐实测、zmq/redis 推送通道在真实部署的连通性。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
 [project.optional-dependencies]
 redis = ["redis>=5.0.0"]
 mysql = ["pymysql>=1.0.0", "DBUtils>=3.0.0"]
+# Faster/smaller wire encoding for whole-quote push (falls back to json if absent).
+msgpack = ["msgpack>=1.0.0"]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",

--- a/src/bigqmt_signal_trader/quote_push_channel.py
+++ b/src/bigqmt_signal_trader/quote_push_channel.py
@@ -1,0 +1,229 @@
+"""Server→client whole-quote push channel.
+
+The RPC transport is request/response only; whole-quote data needs the opposite
+direction — the server pushes each incremental tick batch to every client
+subscribed to that combination. This module provides one abstract channel with
+two interchangeable implementations:
+
+* :class:`ZmqQuotePushChannel` — a ``PUB`` socket on the server, a ``SUB`` socket
+  per client. Native to no-redis deployments. Fire-and-forget: a client that is
+  down simply misses frames (acceptable for incremental quote pushes).
+* :class:`RedisQuotePushChannel` — redis ``publish``/``subscribe`` on a
+  per-account, per-combination channel, for redis deployments.
+
+Wire encoding is msgpack when available (smaller + faster for the
+``{code: {field: number}}`` payload shape), falling back to stdlib json so the
+channel stays usable without the optional dependency.
+"""
+
+import json
+import threading
+
+try:
+    import msgpack
+
+    _HAS_MSGPACK = True
+except Exception:  # pragma: no cover - depends on optional dependency
+    msgpack = None
+    _HAS_MSGPACK = False
+
+
+def encode_push_payload(payload):
+    """Encode a push payload dict to bytes (msgpack preferred, json fallback)."""
+    if _HAS_MSGPACK:
+        return msgpack.packb(payload, use_bin_type=True)
+    return json.dumps(payload, ensure_ascii=False, default=str).encode("utf-8")
+
+
+def decode_push_payload(blob):
+    """Inverse of :func:`encode_push_payload`. Accepts bytes or str."""
+    if blob is None:
+        return None
+    if isinstance(blob, str):
+        blob = blob.encode("utf-8")
+    if _HAS_MSGPACK:
+        return msgpack.unpackb(blob, raw=False)
+    return json.loads(blob.decode("utf-8"))
+
+
+class QuotePushChannel(object):
+    """Abstract push channel. Server side: ``start_publisher`` + ``publish``.
+    Client side: ``start_subscriber(topics, on_msg)``. A single instance may act
+    as publisher or subscriber depending on which start method is called."""
+
+    def start_publisher(self):
+        raise NotImplementedError
+
+    def start_subscriber(self, topics, on_msg):
+        raise NotImplementedError
+
+    def publish(self, topic, data):
+        raise NotImplementedError
+
+    def stop(self):
+        raise NotImplementedError
+
+
+class ZmqQuotePushChannel(QuotePushChannel):
+    def __init__(self, bind_address=None, connect_address=None, context=None, print_prefix="[bigqmt_quote_push]"):
+        self.bind_address = bind_address
+        self.connect_address = connect_address
+        self.print_prefix = print_prefix
+        self._zmq = None
+        self._context = context
+        self._pub = None
+        self._pub_lock = threading.Lock()
+        self._sub = None
+        self._sub_thread = None
+        self._running = False
+
+    def _ensure_context(self):
+        if self._zmq is None:
+            import zmq
+
+            self._zmq = zmq
+            if self._context is None:
+                self._context = zmq.Context.instance()
+        return self._zmq, self._context
+
+    # -- server side ---------------------------------------------------------
+    def start_publisher(self):
+        zmq, ctx = self._ensure_context()
+        if not self.bind_address:
+            raise ValueError("bind_address is required to start a publisher")
+        self._pub = ctx.socket(zmq.PUB)
+        self._pub.bind(self.bind_address)
+        self._running = True
+
+    def publish(self, topic, data):
+        if self._pub is None:
+            return
+        payload = encode_push_payload({"combo_key": topic, "data": data})
+        frame = [str(topic).encode("utf-8"), payload]
+        # PUB socket is not thread-safe; the big-QMT quote thread and any other
+        # publisher thread serialize here.
+        with self._pub_lock:
+            try:
+                self._pub.send_multipart(frame)
+            except Exception as exc:
+                print("%s zmq publish failed: %s" % (self.print_prefix, exc))
+
+    # -- client side ---------------------------------------------------------
+    def start_subscriber(self, topics, on_msg):
+        zmq, ctx = self._ensure_context()
+        if not self.connect_address:
+            raise ValueError("connect_address is required to start a subscriber")
+        self._sub = ctx.socket(zmq.SUB)
+        self._sub.connect(self.connect_address)
+        for topic in topics or []:
+            self._sub.setsockopt(zmq.SUBSCRIBE, str(topic).encode("utf-8"))
+        self._running = True
+        self._sub_thread = threading.Thread(
+            target=self._sub_loop, args=(on_msg,), name="bigqmt-quote-push-sub", daemon=True
+        )
+        self._sub_thread.start()
+
+    def _sub_loop(self, on_msg):
+        poller = self._zmq.Poller()
+        poller.register(self._sub, self._zmq.POLLIN)
+        while self._running:
+            try:
+                events = dict(poller.poll(200))
+            except Exception:
+                break
+            if self._sub not in events:
+                continue
+            try:
+                frames = self._sub.recv_multipart(self._zmq.NOBLOCK)
+            except Exception:
+                continue
+            if len(frames) < 2:
+                continue
+            topic = frames[0].decode("utf-8", errors="ignore")
+            data = decode_push_payload(frames[-1])
+            payload_data = data.get("data") if isinstance(data, dict) else data
+            try:
+                on_msg(topic, payload_data)
+            except Exception as exc:
+                print("%s subscriber callback failed: %s" % (self.print_prefix, exc))
+
+    def stop(self):
+        self._running = False
+        for sock in (self._sub, self._pub):
+            if sock is not None:
+                try:
+                    sock.close(linger=0)
+                except Exception:
+                    pass
+        self._sub = None
+        self._pub = None
+
+
+class RedisQuotePushChannel(QuotePushChannel):
+    def __init__(self, redis_client, account_id="", channel_template="bigqmt:quote_push:{account_id}:{topic}", print_prefix="[bigqmt_quote_push]"):
+        self.redis = redis_client
+        self.account_id = str(account_id or "")
+        self.channel_template = channel_template
+        self.print_prefix = print_prefix
+        self._running = False
+        self._pubsub = None
+        self._thread = None
+
+    def _channel(self, topic):
+        return self.channel_template.format(account_id=self.account_id, topic=topic)
+
+    # -- server side ---------------------------------------------------------
+    def start_publisher(self):
+        # Redis publish needs no setup; present for interface symmetry.
+        self._running = True
+
+    def publish(self, topic, data):
+        payload = encode_push_payload({"combo_key": topic, "data": data})
+        try:
+            self.redis.publish(self._channel(topic), payload)
+        except Exception as exc:
+            print("%s redis publish failed: %s" % (self.print_prefix, exc))
+
+    # -- client side ---------------------------------------------------------
+    def start_subscriber(self, topics, on_msg):
+        self._running = True
+        self._thread = threading.Thread(
+            target=self._sub_loop, args=(list(topics or []), on_msg), name="bigqmt-quote-push-sub", daemon=True
+        )
+        self._thread.start()
+
+    def _sub_loop(self, topics, on_msg):
+        pubsub = self.redis.pubsub(ignore_subscribe_messages=True)
+        self._pubsub = pubsub
+        channels = [self._channel(topic) for topic in topics]
+        try:
+            pubsub.subscribe(*channels)
+        except Exception as exc:
+            print("%s redis subscribe failed: %s" % (self.print_prefix, exc))
+            return
+        while self._running:
+            try:
+                message = pubsub.get_message(timeout=0.2)
+            except Exception:
+                break
+            if not message or message.get("type") != "message":
+                continue
+            channel = message.get("channel")
+            if isinstance(channel, bytes):
+                channel = channel.decode("utf-8", errors="ignore")
+            topic = str(channel).rsplit(":", 1)[-1]
+            data = decode_push_payload(message.get("data"))
+            payload_data = data.get("data") if isinstance(data, dict) else data
+            try:
+                on_msg(topic, payload_data)
+            except Exception as exc:
+                print("%s subscriber callback failed: %s" % (self.print_prefix, exc))
+
+    def stop(self):
+        self._running = False
+        if self._pubsub is not None:
+            try:
+                self._pubsub.close()
+            except Exception:
+                pass
+        self._pubsub = None

--- a/src/bigqmt_signal_trader/quote_push_channel.py
+++ b/src/bigqmt_signal_trader/quote_push_channel.py
@@ -36,13 +36,24 @@ def encode_push_payload(payload):
 
 
 def decode_push_payload(blob):
-    """Inverse of :func:`encode_push_payload`. Accepts bytes or str."""
+    """Inverse of :func:`encode_push_payload`. Accepts bytes or str.
+
+    Encoding is not symmetric across deployments: a server without msgpack
+    falls back to json while a client with msgpack installed decodes with
+    msgpack — ``msgpack.unpackb`` then raises ``ExtraData`` on the json text
+    (its first byte ``{`` parses as an int, leaving trailing bytes). So try
+    msgpack first, and fall back to json when the bytes are not a single
+    valid msgpack object.
+    """
     if blob is None:
         return None
     if isinstance(blob, str):
         blob = blob.encode("utf-8")
     if _HAS_MSGPACK:
-        return msgpack.unpackb(blob, raw=False)
+        try:
+            return msgpack.unpackb(blob, raw=False)
+        except Exception:
+            pass
     return json.loads(blob.decode("utf-8"))
 
 

--- a/src/bigqmt_signal_trader/quote_subscription_manager.py
+++ b/src/bigqmt_signal_trader/quote_subscription_manager.py
@@ -1,0 +1,259 @@
+"""Reference-counted whole-quote subscription manager (server side).
+
+One big-QMT ``ContextInfo.subscribe_whole_quote`` subscription is shared by every
+client that asked for the same (normalized) code combination. The big-QMT
+subscription is only created for the first client of a combination and only torn
+down after the last client either unsubscribes or goes silent (keepalive timeout).
+
+The manager talks to big QMT exclusively through a :class:`QuoteSourceAdapter`;
+it never touches ``ContextInfo`` directly so the real-environment wiring (method
+names / handle shape) stays isolated to the adapter.
+
+Threading: ``subscribe``/``unsubscribe``/``keepalive`` run on the RPC thread,
+``reap_expired`` on the scheduler thread and ``on_push`` on big QMT's quote
+thread. Shared state is guarded by one re-entrant lock; calls out to the quote
+source and to the push publisher happen OUTSIDE the lock so a slow/blocking
+publish never stalls quote-thread state, and no callback can deadlock.
+"""
+
+import threading
+
+
+def combo_key(code_list):
+    """Normalize a code list into an order-independent combination key.
+
+    Uppercases, strips whitespace, drops empties and duplicates, sorts. So
+    ``["SH","SZ"]``, ``["sz","sh"]`` and ``["SH","SH","SZ"]`` all map to
+    ``"SH,SZ"`` and share one big-QMT subscription.
+    """
+    normalized = {str(code).strip().upper() for code in (code_list or []) if str(code or "").strip()}
+    return ",".join(sorted(normalized))
+
+
+class QuoteSourceAdapter(object):
+    """Big-QMT whole-quote source. ContextInfo-backed implementation lives in the
+    server runtime; tests substitute a fake. ``subscribe`` must return a handle
+    usable by ``unsubscribe``."""
+
+    def subscribe(self, codes, on_push):
+        raise NotImplementedError
+
+    def unsubscribe(self, handle):
+        raise NotImplementedError
+
+
+class ContextInfoQuoteSource(QuoteSourceAdapter):
+    """Real big-QMT source backed by the strategy's ``ContextInfo``.
+
+    Verified against the real environment: ``ContextInfo.subscribe_whole_quote(
+    code_list, callback)`` returns an int subscription id (``< 0`` on failure) and
+    pushes INCREMENTAL ``{code: tick}`` batches on a dedicated quote thread;
+    ``ContextInfo.unsubscribe_quote(sub_id)`` cancels it.
+    """
+
+    def __init__(self, context_info):
+        self._context = context_info
+
+    def subscribe(self, codes, on_push):
+        sub_id = self._context.subscribe_whole_quote(list(codes), callback=on_push)
+        if sub_id is None or int(sub_id) < 0:
+            raise RuntimeError("ContextInfo.subscribe_whole_quote failed for codes=%s" % (list(codes),))
+        return int(sub_id)
+
+    def unsubscribe(self, handle):
+        try:
+            self._context.unsubscribe_quote(handle)
+        except Exception:
+            pass
+
+
+class _Combo(object):
+    __slots__ = ("key", "codes", "handle", "topic", "clients")
+
+    def __init__(self, key, codes, handle, topic):
+        self.key = key
+        self.codes = codes
+        self.handle = handle
+        self.topic = topic
+        self.clients = {}  # client_id -> last_seen timestamp
+
+
+class QuoteSubscriptionManager(object):
+    def __init__(self, source, heartbeat_timeout_seconds=30.0, time_func=None, on_push_publisher=None, push_endpoint=""):
+        self._source = source
+        self._heartbeat_timeout = float(heartbeat_timeout_seconds)
+        self._now = time_func or _monotonic
+        # Optional callable(topic, data) invoked when big QMT pushes a tick batch.
+        # Wired to the QuotePushChannel in a later stage; None keeps dispatch inert.
+        self._on_push_publisher = on_push_publisher
+        # Advertised to clients in subscribe responses so a zmq subscriber knows
+        # where to connect (redis subscribers derive the channel locally instead).
+        self._push_endpoint = str(push_endpoint or "")
+        self._lock = threading.RLock()
+        self._combos = {}            # combo_key -> _Combo
+        self._sub_index = {}         # (client_id, sub_id) -> combo_key
+
+    # -- subscription lifecycle ---------------------------------------------
+    def subscribe(self, client_id, sub_id, code_list):
+        """Register (client_id, sub_id) against its combination; create the shared
+        big-QMT subscription on first use. Idempotent for replayed subscribes."""
+        client_id = str(client_id or "")
+        sub_id = str(sub_id or "")
+        key = combo_key(code_list)
+        now = self._now()
+
+        with self._lock:
+            combo = self._combos.get(key)
+            if combo is None:
+                codes = sorted({str(c).strip().upper() for c in (code_list or []) if str(c or "").strip()})
+                # source.subscribe registers the on_push callback with big QMT; it
+                # does not call back into the manager, so it is safe under the lock.
+                handle = self._source.subscribe(codes, self._make_on_push(key))
+                combo = _Combo(key, codes, handle, key)
+                self._combos[key] = combo
+
+            combo.clients[client_id] = now
+            self._sub_index[(client_id, sub_id)] = key
+            return {"combo_key": key, "topic": combo.topic, "push_endpoint": self._push_endpoint}
+
+    def unsubscribe(self, client_id, sub_id):
+        """Drop (client_id, sub_id); tear the big-QMT subscription down when the
+        last client of the combination leaves. Unknown sub_ids are a no-op."""
+        client_id = str(client_id or "")
+        sub_id = str(sub_id or "")
+        with self._lock:
+            key = self._sub_index.pop((client_id, sub_id), None)
+            if key is None:
+                return
+            handle_to_close = self._remove_client_locked(key, client_id)
+        self._close_source(handle_to_close)
+
+    def keepalive(self, client_id, sub_id):
+        """Refresh last_seen for (client_id, sub_id). Unknown sub_ids are a no-op."""
+        client_id = str(client_id or "")
+        key = self._sub_index.get((client_id, str(sub_id or "")))
+        if key is None:
+            return
+        with self._lock:
+            combo = self._combos.get(key)
+            if combo is None:
+                return
+            combo.clients[client_id] = self._now()
+
+    # -- reaper ---------------------------------------------------------------
+    def reap_expired(self, now=None):
+        """Remove clients silent for longer than the keepalive timeout; tear down
+        combos that end up empty. Returns the number of clients reaped."""
+        now = self._now() if now is None else now
+        reaped = 0
+        handles_to_close = []
+        with self._lock:
+            for key in list(self._combos.keys()):
+                combo = self._combos.get(key)
+                if combo is None:
+                    continue
+                for client_id, last_seen in list(combo.clients.items()):
+                    if now - last_seen > self._heartbeat_timeout:
+                        self._drop_subscriptions_for_locked(key, client_id)
+                        handle = self._remove_client_locked(key, client_id)
+                        if handle is not None:
+                            handles_to_close.append(handle)
+                        reaped += 1
+        for handle in handles_to_close:
+            self._close_source(handle)
+        return reaped
+
+    # -- internals -------------------------------------------------------------
+    def _make_on_push(self, key):
+        def on_push(data):
+            publisher = self._on_push_publisher
+            if publisher is None:
+                return
+            with self._lock:
+                combo = self._combos.get(key)
+                topic = combo.topic if combo is not None else None
+            if topic is None:
+                return
+            # Publish outside the lock: it is network IO and must not stall the
+            # quote thread or block reaper/RPC threads waiting on the lock.
+            publisher(topic, data)
+
+        return on_push
+
+    def _drop_subscriptions_for_locked(self, key, client_id):
+        for (cid, sub_id), ckey in list(self._sub_index.items()):
+            if ckey == key and cid == client_id:
+                self._sub_index.pop((cid, sub_id), None)
+
+    def _remove_client_locked(self, key, client_id):
+        """Remove client_id from a combo. If the combo became empty, detach it and
+        return its source handle for the caller to close OUTSIDE the lock; else
+        return None. Caller must hold the lock."""
+        combo = self._combos.get(key)
+        if combo is None or client_id not in combo.clients:
+            return None
+        del combo.clients[client_id]
+        if combo.clients:
+            return None
+        self._combos.pop(key, None)
+        return combo.handle
+
+    def _close_source(self, handle):
+        if handle is None:
+            return
+        try:
+            self._source.unsubscribe(handle)
+        except Exception:
+            pass
+
+
+def _monotonic():
+    import time
+
+    return time.monotonic()
+
+
+def build_quote_subscription_service(
+    context_info,
+    transport_name="redis",
+    account_id="",
+    redis_client=None,
+    zmq_bind_address=None,
+    enabled=True,
+    heartbeat_timeout_seconds=30.0,
+    time_func=None,
+):
+    """Assemble the server-side whole-quote service: a ContextInfo-backed source,
+    a push channel matching the RPC transport, and a QuoteSubscriptionManager
+    wired so big-QMT pushes publish to the channel. Returns ``(manager, channel)``
+    or ``None`` when disabled. The caller starts the channel publisher and feeds
+    ``manager.reap_expired`` from the scheduler loop."""
+    if not enabled:
+        return None
+    from .quote_push_channel import RedisQuotePushChannel, ZmqQuotePushChannel
+
+    source = ContextInfoQuoteSource(context_info)
+    transport_name = str(transport_name or "redis").lower()
+    if transport_name == "zmq":
+        bind_address = zmq_bind_address or _default_quote_push_zmq_bind(account_id)
+        channel = ZmqQuotePushChannel(bind_address=bind_address)
+        push_endpoint = bind_address
+    else:
+        channel = RedisQuotePushChannel(redis_client, account_id=account_id)
+        push_endpoint = ""
+    manager = QuoteSubscriptionManager(
+        source,
+        heartbeat_timeout_seconds=heartbeat_timeout_seconds,
+        time_func=time_func,
+        on_push_publisher=channel.publish,
+        push_endpoint=push_endpoint,
+    )
+    return manager, channel
+
+
+def _default_quote_push_zmq_bind(account_id):
+    """Default server PUB bind address: loopback, RPC zmq port + 1 (client side
+    derives the same host/port + 1 to connect)."""
+    from .transports.zmq_transport import _default_zmq_port
+
+    return "tcp://0.0.0.0:%d" % (_default_zmq_port(account_id) + 1)

--- a/src/bigqmt_signal_trader/quote_subscription_manager.py
+++ b/src/bigqmt_signal_trader/quote_subscription_manager.py
@@ -75,7 +75,10 @@ class _Combo(object):
         self.codes = codes
         self.handle = handle
         self.topic = topic
-        self.clients = {}  # client_id -> last_seen timestamp
+        # (client_id, sub_id) -> last_seen. Sub-id granularity: one client may
+        # hold several subscriptions to the same combination, and each one keeps
+        # the shared big-QMT subscription alive independently.
+        self.clients = {}  # (client_id, sub_id) -> last_seen timestamp
 
 
 class QuoteSubscriptionManager(object):
@@ -112,20 +115,20 @@ class QuoteSubscriptionManager(object):
                 combo = _Combo(key, codes, handle, key)
                 self._combos[key] = combo
 
-            combo.clients[client_id] = now
+            combo.clients[(client_id, sub_id)] = now
             self._sub_index[(client_id, sub_id)] = key
             return {"combo_key": key, "topic": combo.topic, "push_endpoint": self._push_endpoint}
 
     def unsubscribe(self, client_id, sub_id):
         """Drop (client_id, sub_id); tear the big-QMT subscription down when the
-        last client of the combination leaves. Unknown sub_ids are a no-op."""
+        last subscription of the combination leaves. Unknown sub_ids are a no-op."""
         client_id = str(client_id or "")
         sub_id = str(sub_id or "")
         with self._lock:
             key = self._sub_index.pop((client_id, sub_id), None)
             if key is None:
                 return
-            handle_to_close = self._remove_client_locked(key, client_id)
+            handle_to_close = self._remove_subscription_locked(key, client_id, sub_id)
         self._close_source(handle_to_close)
 
     def keepalive(self, client_id, sub_id):
@@ -138,12 +141,12 @@ class QuoteSubscriptionManager(object):
             combo = self._combos.get(key)
             if combo is None:
                 return
-            combo.clients[client_id] = self._now()
+            combo.clients[(client_id, str(sub_id or ""))] = self._now()
 
     # -- reaper ---------------------------------------------------------------
     def reap_expired(self, now=None):
-        """Remove clients silent for longer than the keepalive timeout; tear down
-        combos that end up empty. Returns the number of clients reaped."""
+        """Remove subscriptions silent for longer than the keepalive timeout;
+        tear down combos that end up empty. Returns the number reaped."""
         now = self._now() if now is None else now
         reaped = 0
         handles_to_close = []
@@ -152,10 +155,10 @@ class QuoteSubscriptionManager(object):
                 combo = self._combos.get(key)
                 if combo is None:
                     continue
-                for client_id, last_seen in list(combo.clients.items()):
+                for (client_id, sub_id), last_seen in list(combo.clients.items()):
                     if now - last_seen > self._heartbeat_timeout:
-                        self._drop_subscriptions_for_locked(key, client_id)
-                        handle = self._remove_client_locked(key, client_id)
+                        self._sub_index.pop((client_id, sub_id), None)
+                        handle = self._remove_subscription_locked(key, client_id, sub_id)
                         if handle is not None:
                             handles_to_close.append(handle)
                         reaped += 1
@@ -180,19 +183,15 @@ class QuoteSubscriptionManager(object):
 
         return on_push
 
-    def _drop_subscriptions_for_locked(self, key, client_id):
-        for (cid, sub_id), ckey in list(self._sub_index.items()):
-            if ckey == key and cid == client_id:
-                self._sub_index.pop((cid, sub_id), None)
-
-    def _remove_client_locked(self, key, client_id):
-        """Remove client_id from a combo. If the combo became empty, detach it and
-        return its source handle for the caller to close OUTSIDE the lock; else
-        return None. Caller must hold the lock."""
+    def _remove_subscription_locked(self, key, client_id, sub_id):
+        """Remove one (client_id, sub_id) from a combo. If the combo has no
+        subscriptions left, detach it and return its source handle for the
+        caller to close OUTSIDE the lock; else return None. Caller must hold
+        the lock."""
         combo = self._combos.get(key)
-        if combo is None or client_id not in combo.clients:
+        if combo is None:
             return None
-        del combo.clients[client_id]
+        combo.clients.pop((client_id, sub_id), None)
         if combo.clients:
             return None
         self._combos.pop(key, None)

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -98,6 +98,15 @@ ORDER_METHODS = {
     "cancel_order",
 }
 
+# Whole-quote push subscription control methods. These drive a server-side
+# QuoteSubscriptionManager (reference-counted ContextInfo.subscribe_whole_quote)
+# rather than a market_data read; the data itself flows over the push channel.
+QUOTE_SUBSCRIPTION_METHODS = {
+    "subscribe_whole_quote",
+    "unsubscribe_whole_quote",
+    "quote_keepalive",
+}
+
 LISTENER_DEFERRED_METHODS = {
     "sync_positions",
     # Trade-context queries route through QMT's get_trade_detail_data, which
@@ -266,6 +275,7 @@ MARKET_DATA_METHODS = {
 # op — creates/updates a custom sector — but it is harmless to expose; trading
 # order writes stay gated behind ORDER_METHODS + allow_order_methods.)
 READ_METHODS |= MARKET_DATA_METHODS
+READ_METHODS |= QUOTE_SUBSCRIPTION_METHODS
 
 
 def _maybe_scalar(value):
@@ -343,6 +353,7 @@ class BigQmtRpcHandlers:
         allow_order_methods=False,
         allowed_methods=None,
         qmt_api=None,
+        quote_subscription_manager=None,
     ):
         self.account_id = str(account_id or "")
         self.market_data = market_data
@@ -350,6 +361,7 @@ class BigQmtRpcHandlers:
         self.order_gateway = order_gateway
         self.position_sync_sink = position_sync_sink
         self.allow_order_methods = bool(allow_order_methods)
+        self.quote_subscription_manager = quote_subscription_manager
         # QMT runtime-injected global functions (passorder/get_trade_detail_data/
         # 融资融券查询等)。由 strategy._build_config 解析注入。
         self.qmt_api = dict(qmt_api or {})
@@ -403,6 +415,49 @@ class BigQmtRpcHandlers:
             "rpc_revision": RPC_REVISION,
             "server_time": _dt.datetime.now(),
         }
+
+    # ------------------------------------------------------------------
+    # 全推行情订阅控制（引用计数共享 ContextInfo.subscribe_whole_quote）。
+    # 数据本身走推送通道；这里只负责订阅生命周期 + 心跳。
+    # ------------------------------------------------------------------
+
+    def _require_quote_manager(self):
+        manager = self.quote_subscription_manager
+        if manager is None:
+            raise RuntimeError("whole-quote push subscription is not configured on this server")
+        return manager
+
+    @staticmethod
+    def _quote_params(params, require_codes=False):
+        params = params or {}
+        client_id = str(params.get("client_id") or "").strip()
+        sub_id = str(params.get("sub_id") or "").strip()
+        if not client_id:
+            raise ValueError("client_id is required")
+        if not sub_id:
+            raise ValueError("sub_id is required")
+        codes = [str(c) for c in (params.get("codes") or []) if str(c or "").strip()]
+        if require_codes and not codes:
+            raise ValueError("codes is required")
+        return client_id, sub_id, codes
+
+    def _handle_subscribe_whole_quote(self, params):
+        manager = self._require_quote_manager()
+        client_id, sub_id, codes = self._quote_params(params, require_codes=True)
+        return manager.subscribe(client_id, sub_id, codes)
+
+    def _handle_unsubscribe_whole_quote(self, params):
+        manager = self._require_quote_manager()
+        client_id, sub_id, _codes = self._quote_params(params)
+        manager.unsubscribe(client_id, sub_id)
+        return {}
+
+    def _handle_quote_keepalive(self, params):
+        manager = self._require_quote_manager()
+        client_id, sub_id, _codes = self._quote_params(params)
+        manager.keepalive(client_id, sub_id)
+        return {}
+
 
     def _handle_get_ticks(self, params):
         codes = params.get("codes")

--- a/src/bigqmt_signal_trader/whole_quote_session.py
+++ b/src/bigqmt_signal_trader/whole_quote_session.py
@@ -19,21 +19,29 @@ def _norm_topic(code_list):
 
 
 class WholeQuoteClientSession(object):
-    def __init__(self, rpc_call, push_channel, client_id, heartbeat_interval_seconds=3.0, sub_id_func=None):
+    def __init__(self, rpc_call, push_channel, client_id, heartbeat_interval_seconds=3.0, sub_id_func=None,
+                 push_silence_replay_heartbeats=10):
         """``rpc_call`` is ``client.call``-shaped: fn(method, params) -> dict.
         ``push_channel`` is a QuotePushChannel used purely as a subscriber.
-        ``sub_id_func`` (optional) mints subscription ids; defaults to a counter."""
+        ``sub_id_func`` (optional) mints subscription ids; defaults to a counter.
+        ``push_silence_replay_heartbeats``: after this many heartbeat rounds
+        without any push, replay subscriptions (covers server restarts where
+        keepalive keeps succeeding because the redis request queue buffers
+        during the restart window but the subscription table was reset)."""
         self._rpc = rpc_call
         self._channel = push_channel
         self.client_id = str(client_id or "")
         self._heartbeat_interval = float(heartbeat_interval_seconds)
+        self._push_silence_replay_heartbeats = int(push_silence_replay_heartbeats)
         self._sub_id_func = sub_id_func
         self._seq = 0
         self._lock = threading.RLock()
         self._subscriptions = {}  # sub_id -> {"topic": str, "callback": fn, "codes": [...]}
         self._started = False
         self._subscriber_active = False
+        self._subscribed_topics = frozenset()  # topic set the subscriber covers now
         self._heartbeat_thread = None
+        self._last_push_time = None  # monotonic time of last incoming push
 
     # -- subscription lifecycle ---------------------------------------------
     def subscribe_whole_quote(self, code_list, callback=None):
@@ -101,21 +109,56 @@ class WholeQuoteClientSession(object):
     def _heartbeat_loop(self):
         import time
 
+        consecutive_failures = 0
+        silence_rounds = 0
+        prev_last_push = None
         while True:
             with self._lock:
                 if not self._started:
                     return
                 sub_ids = list(self._subscriptions.keys())
+                last_push = self._last_push_time
+            if not sub_ids:
+                time.sleep(self._heartbeat_interval)
+                continue
+            failures = 0
             for sub_id in sub_ids:
                 try:
                     self._rpc("quote_keepalive", {"client_id": self.client_id, "sub_id": sub_id})
                 except Exception:
-                    pass
+                    failures += 1
+            if failures:
+                consecutive_failures += 1
+            elif consecutive_failures >= 3:
+                # Server is back after a restart window: replay subscriptions so
+                # the restarted server re-creates the big-QMT subscriptions (its
+                # state is gone). Idempotent on the server, so replays are safe.
+                self.replay_subscriptions()
+                consecutive_failures = 0
+            else:
+                consecutive_failures = 0
+            # Push-silence detection: a server restart can survive with keepalive
+            # succeeding (the redis request queue buffers during the restart
+            # window) while the subscription table was reset, so pushes stop.
+            # Replay when no push arrived for several heartbeat rounds (also
+            # covers the case where the very first prime push never arrived).
+            if last_push != prev_last_push:
+                silence_rounds = 0  # a push arrived since the last round
+            else:
+                silence_rounds += 1
+            prev_last_push = last_push
+            if silence_rounds >= self._push_silence_replay_heartbeats:
+                self.replay_subscriptions()
+                silence_rounds = 0
             time.sleep(self._heartbeat_interval)
 
     # -- push routing ------------------------------------------------------------
     def _on_push(self, topic, data):
+        import time
+
+        now = time.monotonic()
         with self._lock:
+            self._last_push_time = now
             callbacks = [
                 entry["callback"]
                 for entry in self._subscriptions.values()
@@ -129,13 +172,30 @@ class WholeQuoteClientSession(object):
 
     def _sync_subscriber_locked(self):
         """(Re)start the push-channel subscriber to cover exactly the active
-        topics. Caller holds the lock. No-op when nothing is subscribed."""
+        topics. Reuses an existing subscriber when the topic set is unchanged;
+        stops it before restarting when the set changed. No-op when nothing is
+        subscribed (and stops the running subscriber in that case)."""
         topics = sorted({entry["topic"] for entry in self._subscriptions.values()})
-        if not topics:
+        active = frozenset(topics)
+        if active == self._subscribed_topics:
             return
-        # Restart with the full active topic set so newly-added topics get covered.
+        if not active:
+            if self._subscriber_active:
+                try:
+                    self._channel.stop()
+                except Exception:
+                    pass
+                self._subscriber_active = False
+            self._subscribed_topics = active
+            return
+        if self._subscriber_active:
+            try:
+                self._channel.stop()
+            except Exception:
+                pass
         self._channel.start_subscriber(topics, self._on_push)
         self._subscriber_active = True
+        self._subscribed_topics = active
 
     def _next_sub_id(self):
         if self._sub_id_func is not None:

--- a/src/bigqmt_signal_trader/whole_quote_session.py
+++ b/src/bigqmt_signal_trader/whole_quote_session.py
@@ -1,0 +1,144 @@
+"""Client-side whole-quote subscription session.
+
+Owns the per-process state for ``subscribe_whole_quote``: the local
+subscription table, the shared push-channel subscriber thread, and the
+keepalive heartbeat thread. One session is shared by every ``subscribe_whole_quote``
+call in the process (``BigQmtXtData`` delegates here), so all subscriptions ride
+a single push-channel connection and a single heartbeat loop.
+
+The big-QMT whole-quote callback is INCREMENTAL (only changed symbols), so a
+subscription does not by itself deliver an initial full snapshot — callers layer
+a ``get_full_tick`` prime on top (done in ``BigQmtXtData.subscribe_whole_quote``).
+"""
+
+import threading
+
+
+def _norm_topic(code_list):
+    return ",".join(sorted({str(c).strip().upper() for c in (code_list or []) if str(c or "").strip()}))
+
+
+class WholeQuoteClientSession(object):
+    def __init__(self, rpc_call, push_channel, client_id, heartbeat_interval_seconds=3.0, sub_id_func=None):
+        """``rpc_call`` is ``client.call``-shaped: fn(method, params) -> dict.
+        ``push_channel`` is a QuotePushChannel used purely as a subscriber.
+        ``sub_id_func`` (optional) mints subscription ids; defaults to a counter."""
+        self._rpc = rpc_call
+        self._channel = push_channel
+        self.client_id = str(client_id or "")
+        self._heartbeat_interval = float(heartbeat_interval_seconds)
+        self._sub_id_func = sub_id_func
+        self._seq = 0
+        self._lock = threading.RLock()
+        self._subscriptions = {}  # sub_id -> {"topic": str, "callback": fn, "codes": [...]}
+        self._started = False
+        self._subscriber_active = False
+        self._heartbeat_thread = None
+
+    # -- subscription lifecycle ---------------------------------------------
+    def subscribe_whole_quote(self, code_list, callback=None):
+        codes = [str(c) for c in (code_list or []) if str(c or "").strip()]
+        if not codes:
+            raise ValueError("code_list is required")
+        with self._lock:
+            sub_id = self._next_sub_id()
+        result = self._rpc(
+            "subscribe_whole_quote",
+            {"client_id": self.client_id, "sub_id": sub_id, "codes": codes},
+        ) or {}
+        topic = str(result.get("topic") or result.get("combo_key") or _norm_topic(codes))
+        with self._lock:
+            self._subscriptions[sub_id] = {"topic": topic, "callback": callback, "codes": codes}
+            self._sync_subscriber_locked()
+        return sub_id
+
+    def unsubscribe_quote(self, sub_id):
+        with self._lock:
+            entry = self._subscriptions.pop(sub_id, None)
+        if entry is None:
+            return 0
+        try:
+            self._rpc("unsubscribe_whole_quote", {"client_id": self.client_id, "sub_id": sub_id})
+        finally:
+            with self._lock:
+                self._sync_subscriber_locked()
+        return 0
+
+    def has_subscription(self, sub_id):
+        with self._lock:
+            return sub_id in self._subscriptions
+
+    def replay_subscriptions(self):
+        """Re-send subscribe for every active sub_id (server restart recovery).
+        Idempotent on the server (keyed by client_id+combo), so replays are safe."""
+        with self._lock:
+            items = [(sid, dict(entry)) for sid, entry in self._subscriptions.items()]
+        for sub_id, entry in items:
+            self._rpc(
+                "subscribe_whole_quote",
+                {"client_id": self.client_id, "sub_id": sub_id, "codes": entry["codes"]},
+            )
+
+    # -- heartbeat -------------------------------------------------------------
+    def start(self):
+        with self._lock:
+            if self._started:
+                return
+            self._started = True
+            self._heartbeat_thread = threading.Thread(
+                target=self._heartbeat_loop, name="bigqmt-quote-keepalive", daemon=True
+            )
+            self._heartbeat_thread.start()
+
+    def stop(self):
+        with self._lock:
+            self._started = False
+        thread = self._heartbeat_thread
+        if thread is not None:
+            thread.join(timeout=1.0)
+        self._heartbeat_thread = None
+
+    def _heartbeat_loop(self):
+        import time
+
+        while True:
+            with self._lock:
+                if not self._started:
+                    return
+                sub_ids = list(self._subscriptions.keys())
+            for sub_id in sub_ids:
+                try:
+                    self._rpc("quote_keepalive", {"client_id": self.client_id, "sub_id": sub_id})
+                except Exception:
+                    pass
+            time.sleep(self._heartbeat_interval)
+
+    # -- push routing ------------------------------------------------------------
+    def _on_push(self, topic, data):
+        with self._lock:
+            callbacks = [
+                entry["callback"]
+                for entry in self._subscriptions.values()
+                if entry["topic"] == topic and entry["callback"] is not None
+            ]
+        for callback in callbacks:
+            try:
+                callback(data)
+            except Exception:
+                pass
+
+    def _sync_subscriber_locked(self):
+        """(Re)start the push-channel subscriber to cover exactly the active
+        topics. Caller holds the lock. No-op when nothing is subscribed."""
+        topics = sorted({entry["topic"] for entry in self._subscriptions.values()})
+        if not topics:
+            return
+        # Restart with the full active topic set so newly-added topics get covered.
+        self._channel.start_subscriber(topics, self._on_push)
+        self._subscriber_active = True
+
+    def _next_sub_id(self):
+        if self._sub_id_func is not None:
+            return self._sub_id_func()
+        self._seq += 1
+        return self._seq

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -130,6 +130,47 @@ def _import_optional_module(module_name):
         raise
 
 
+def _quote_client_id():
+    """Process-stable client id for whole-quote subscriptions. Config or env wins;
+    otherwise read/create a persisted id so a restarted client is recognised as
+    the same subscriber by the server."""
+    client_config = load_client_config()
+    configured = client_config.get("quote_client_id") or os.environ.get("BIGQMT_QUOTE_CLIENT_ID")
+    if configured:
+        return str(configured)
+    cache_path = os.path.join(os.path.expanduser("~"), ".cache", "bigqmt", "quote_client_id")
+    try:
+        with open(cache_path, "r") as handle:
+            existing = handle.read().strip()
+            if existing:
+                return existing
+    except OSError:
+        pass
+    new_id = uuid.uuid4().hex
+    try:
+        os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+        with open(cache_path, "w") as handle:
+            handle.write(new_id)
+    except OSError:
+        pass
+    return new_id
+
+
+def _quote_push_zmq_address(client):
+    """Derive the server whole-quote PUB address: same host as the RPC zmq
+    endpoint, RPC port + 1 (the PUB socket binds a distinct port)."""
+    from .transports.zmq_transport import DEFAULT_ZMQ_HOST, _default_zmq_port
+
+    zmq_config = dict(getattr(client, "zmq_config", {}) or {})
+    explicit = zmq_config.get("quote_push_connect_address")
+    if explicit:
+        return str(explicit)
+    host = zmq_config.get("host") or DEFAULT_ZMQ_HOST
+    port = zmq_config.get("port")
+    base_port = int(port) if port is not None else _default_zmq_port(client.account_id)
+    return "tcp://%s:%d" % (host, base_port + 1)
+
+
 def load_client_config(module_name=None):
     """Load local private client config without requiring environment variables."""
     candidates = []
@@ -171,6 +212,7 @@ def load_client_config(module_name=None):
             "full_tick_cache_config": full_tick_cache_config,
             "local_cache_config": local_cache_config,
             "formula_server_config": formula_server_config,
+            "quote_client_id": getattr(module, "BIGQMT_QUOTE_CLIENT_ID", None),
         }
     return {}
 
@@ -530,6 +572,8 @@ class BigQmtXtData:
         self.client = client
         self._subscribe_seq = int(time.time() * 1000)
         self._cache_obj = None
+        self._quote_session = None          # lazily built WholeQuoteClientSession
+        self._quote_session_factory = None  # test hook: returns a session-like object
 
     def _next_seq(self):
         self._subscribe_seq += 1
@@ -778,19 +822,66 @@ class BigQmtXtData:
             callback=callback,
         )
 
+    def _whole_quote_session(self):
+        if self._quote_session is None:
+            if self._quote_session_factory is not None:
+                self._quote_session = self._quote_session_factory()
+            else:
+                self._quote_session = self._build_quote_session()
+        return self._quote_session
+
+    def _build_quote_session(self):
+        from .whole_quote_session import WholeQuoteClientSession
+
+        client = self.client
+
+        def rpc_call(method, params):
+            return client.call(method, params)
+
+        return WholeQuoteClientSession(
+            rpc_call=rpc_call,
+            push_channel=self._build_quote_push_channel(),
+            client_id=_quote_client_id(),
+            heartbeat_interval_seconds=_env_float("BIGQMT_QUOTE_HEARTBEAT_SECONDS", 3.0),
+            sub_id_func=self._next_seq,
+        )
+
+    def _build_quote_push_channel(self):
+        """Build the push-channel subscriber matching the RPC transport: redis
+        deployments derive the channel locally; zmq deployments connect to the
+        server PUB socket (host from zmq config, RPC port + 1)."""
+        client = self.client
+        from .quote_push_channel import RedisQuotePushChannel, ZmqQuotePushChannel
+
+        transport_name = str(getattr(client, "transport_name", "redis") or "redis").lower()
+        if transport_name in ("zmq",):
+            address = _quote_push_zmq_address(client)
+            return ZmqQuotePushChannel(connect_address=address)
+        return RedisQuotePushChannel(client._redis(), account_id=client.account_id)
+
     def subscribe_whole_quote(self, code_list, callback=None):
-        seq = self._next_seq()
-        payload = {"seq": seq, "code_list": list(code_list or []), "period": "full_tick"}
-        self.client.save_quote_subscription(seq, payload, active=True)
-        self.client.publish_event("subscribe_whole_quote", payload)
+        session = self._whole_quote_session()
+        session.start()
+        sub_id = session.subscribe_whole_quote(code_list, callback=callback)
+        # The big-QMT whole-quote callback is incremental (changed symbols only),
+        # so prime the callback once with a full get_full_tick snapshot.
         if callback is not None:
-            callback(self.get_full_tick(code_list))
-        return seq
+            try:
+                callback(self.get_full_tick(code_list))
+            except Exception:
+                pass
+        return sub_id
 
     def unsubscribe_quote(self, seq):
-        payload = {"seq": seq}
-        self.client.save_quote_subscription(seq, payload, active=False)
-        self.client.publish_event("unsubscribe_quote", payload)
+        # subscribe_whole_quote handles are owned by the push session; single-stock
+        # subscribe_quote seqs still retire through the legacy redis-event path.
+        session = self._quote_session
+        if session is not None and session.has_subscription(seq):
+            session.unsubscribe_quote(seq)
+        else:
+            payload = {"seq": seq}
+            self.client.save_quote_subscription(seq, payload, active=False)
+            self.client.publish_event("unsubscribe_quote", payload)
         return 0
 
     def run(self):

--- a/src/bigqmt_signal_trader_client_config.example.py
+++ b/src/bigqmt_signal_trader_client_config.example.py
@@ -79,3 +79,22 @@ BIGQMT_FORMULA_SERVER_CONFIG = {
     # "methods": [...],     # restrict routing to a subset (default: all mapped)
     # "failure_cooldown_seconds": 30.0,  # pause routing this long after a failure
 }
+
+# Whole-quote PUSH subscription (xtdata.subscribe_whole_quote, aligned with MiniQMT).
+#   Server pushes each incremental tick batch to every client subscribed to the
+#   same combination; the RPC methods above only manage the subscription lifecycle.
+#   Data flows over a separate push channel matching `transport` above
+#   (redis pub/sub, or zmq PUB/SUB when transport="zmq"), msgpack-encoded
+#   (install the `msgpack` extra; falls back to json if absent).
+#
+#   quote_client_id: process-stable subscriber id. The server counts references
+#     per (client_id, sub_id) and only tears down the shared big-QMT subscription
+#     after EVERY client of a combination unsubscribes or times out. Unset -> a
+#     persisted id is created at ~/.cache/bigqmt/quote_client_id so a restarted
+#     client is recognised as the same subscriber (needed for replay recovery).
+#   Heartbeat: client sends quote_keepalive every BIGQMT_QUOTE_HEARTBEAT_SECONDS
+#     (default 3.0). Server reaps a client after heartbeat_timeout_seconds
+#     (default 30s = 10 periods, configured server-side).
+BIGQMT_QUOTE_CLIENT_ID = None  # e.g. "my-strategy-1"; None -> persisted auto id
+# BIGQMT_QUOTE_HEARTBEAT_SECONDS = 3.0  # env var; must be < server timeout/periods
+

--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -62,6 +62,7 @@ _config = {}
 _qmt_api = {}
 _adjust_logged = False
 _rpc_service = None
+_quote_subscription_service = None  # (QuoteSubscriptionManager, QuotePushChannel)
 _scheduled_adjust = False
 # Latency tuning / diagnostics (server side, in the Big QMT process).
 #  - switch interval: hand the GIL to the background RPC thread ~5x more often
@@ -248,6 +249,37 @@ def _resolve_background_threads(transport_name, configured):
     return True
 
 
+def _build_quote_subscription_service(context_info, config, transport_name, account_id, redis_client):
+    """Assemble the server-side whole-quote push service (manager + channel).
+
+    Returns ``(manager, channel)`` or ``None`` when disabled. The channel publisher
+    is started in ``_start_rpc_service`` once the RPC service is up; the manager's
+    reaper is fed from ``_drain_rpc_service``.
+    """
+    quote_config = dict(config.get("quote_push") or {})
+    enabled = _config_bool(quote_config.get("enabled"), True)
+    if not enabled:
+        return None
+    if _load_bridge_module is not None:
+        _qsm = _load_bridge_module("bigqmt_signal_trader.quote_subscription_manager")
+    else:
+        from bigqmt_signal_trader import quote_subscription_manager as _qsm
+    import importlib
+
+    _qsm = importlib.reload(_qsm)
+    heartbeat_timeout = float(quote_config.get("heartbeat_timeout_seconds", 30.0))
+    zmq_bind_address = quote_config.get("zmq_bind_address")
+    return _qsm.build_quote_subscription_service(
+        context_info,
+        transport_name=transport_name,
+        account_id=account_id,
+        redis_client=redis_client,
+        zmq_bind_address=zmq_bind_address,
+        enabled=True,
+        heartbeat_timeout_seconds=heartbeat_timeout,
+    )
+
+
 def _build_rpc_service(context_info, app, config):
     rpc_config = dict(config.get("rpc") or {})
     enabled = _config_bool(config.get("enable_rpc"), False) or _config_bool(rpc_config.get("enabled"), False)
@@ -312,6 +344,13 @@ def _build_rpc_service(context_info, app, config):
         print("[bigqmt_rpc] disabled: account_id is empty")
         return None
     allow_order_methods = _config_bool(rpc_config.get("allow_order_methods"), False)
+    global _quote_subscription_service
+    _quote_subscription_service = _build_quote_subscription_service(
+        context_info, config, transport_name, account_id, redis_client
+    )
+    quote_manager = (
+        _quote_subscription_service[0] if _quote_subscription_service is not None else None
+    )
     handlers = BigQmtRpcHandlers(
         account_id=account_id,
         market_data=BigQmtMarketDataProvider(context_info),
@@ -324,6 +363,7 @@ def _build_rpc_service(context_info, app, config):
         allow_order_methods=allow_order_methods,
         allowed_methods=rpc_config.get("allowed_methods"),
         qmt_api=qmt_api,
+        quote_subscription_manager=quote_manager,
     )
     process_in_listener = _config_bool(rpc_config.get("process_in_listener"), True)
     listener_methods = rpc_config.get("listener_methods") or ("*",)
@@ -374,6 +414,13 @@ def _start_rpc_service(context_info, app, config):
     _rpc_service = _build_rpc_service(context_info, app, config)
     if _rpc_service is not None:
         _rpc_service.start()
+        if _quote_subscription_service is not None:
+            try:
+                _quote_subscription_service[1].start_publisher()
+                print("[bigqmt_quote_push] publisher started transport=%s"
+                      % str(dict(config.get("rpc") or {}).get("transport") or "redis"))
+            except Exception as exc:
+                print("[bigqmt_quote_push] publisher start failed: %s" % exc)
     return _rpc_service
 
 
@@ -386,6 +433,11 @@ def _drain_rpc_service(config):
     if hasattr(_rpc_service, "drain_request_queue"):
         processed += _rpc_service.drain_request_queue(max_items=max_items)
     processed += _rpc_service.drain_pending(max_items=max_items)
+    if _quote_subscription_service is not None:
+        try:
+            _quote_subscription_service[0].reap_expired()
+        except Exception as exc:
+            print("[bigqmt_quote_push] reap failed: %s" % exc)
     return processed
 
 

--- a/tests/bigqmt_signal_trader/test_quote_on_push_wiring.py
+++ b/tests/bigqmt_signal_trader/test_quote_on_push_wiring.py
@@ -1,0 +1,172 @@
+import os
+import sys
+import threading
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.quote_push_channel import RedisQuotePushChannel
+from bigqmt_signal_trader.quote_subscription_manager import (
+    QuoteSourceAdapter,
+    QuoteSubscriptionManager,
+)
+
+
+class FakeQuoteSource(QuoteSourceAdapter):
+    """Captures the on_push callback so tests can fire big-QMT quote events."""
+
+    def __init__(self):
+        self.subscriptions = {}
+        self.unsubscribed = []
+        self._next_handle = 0
+
+    def subscribe(self, codes, on_push):
+        self._next_handle += 1
+        handle = self._next_handle
+        self.subscriptions[handle] = {"codes": list(codes), "on_push": on_push}
+        return handle
+
+    def unsubscribe(self, handle):
+        self.unsubscribed.append(handle)
+        self.subscriptions.pop(handle, None)
+
+    def fire(self, handle, data):
+        self.subscriptions[handle]["on_push"](data)
+
+
+class RecordingPublisher:
+    def __init__(self):
+        self.calls = []
+        self._lock = threading.Lock()
+
+    def __call__(self, topic, data):
+        with self._lock:
+            self.calls.append((topic, data))
+
+
+class OnPushWiringTest(unittest.TestCase):
+    def test_on_push_forwards_to_publisher_with_combo_topic(self):
+        source = FakeQuoteSource()
+        publisher = RecordingPublisher()
+        manager = QuoteSubscriptionManager(source, on_push_publisher=publisher)
+
+        result = manager.subscribe("clientA", "sub1", ["SH", "SZ"])
+        handle = next(iter(source.subscriptions))
+        source.fire(handle, {"000001.SZ": {"lastPrice": 10.5}})
+
+        self.assertEqual(len(publisher.calls), 1)
+        topic, data = publisher.calls[0]
+        self.assertEqual(topic, result["topic"])
+        self.assertEqual(data["000001.SZ"]["lastPrice"], 10.5)
+
+    def test_on_push_ignored_without_publisher(self):
+        source = FakeQuoteSource()
+        manager = QuoteSubscriptionManager(source)  # no publisher wired
+        manager.subscribe("clientA", "sub1", ["SH"])
+        handle = next(iter(source.subscriptions))
+        # Must not raise even though nothing consumes the push.
+        source.fire(handle, {"000001.SZ": {"lastPrice": 10.5}})
+
+    def test_on_push_concurrent_callbacks_are_serialized(self):
+        source = FakeQuoteSource()
+        publisher = RecordingPublisher()
+        manager = QuoteSubscriptionManager(source, on_push_publisher=publisher)
+        manager.subscribe("clientA", "sub1", ["SH"])
+        handle = next(iter(source.subscriptions))
+
+        threads = [
+            threading.Thread(target=source.fire, args=(handle, {"000001.SZ": {"n": i}}))
+            for i in range(20)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual(len(publisher.calls), 20)
+        self.assertTrue(all(topic == "SH" for topic, _ in publisher.calls))
+
+    def test_push_stops_after_unsubscribe(self):
+        source = FakeQuoteSource()
+        publisher = RecordingPublisher()
+        manager = QuoteSubscriptionManager(source, on_push_publisher=publisher)
+        manager.subscribe("clientA", "sub1", ["SH"])
+        handle = next(iter(source.subscriptions))
+        manager.unsubscribe("clientA", "sub1")
+        # Subscription torn down at the source; nothing left to fire.
+        self.assertNotIn(handle, source.subscriptions)
+
+    def test_concurrent_subscribe_unsubscribe_reap_and_push(self):
+        # Hammer the manager from the RPC thread (subscribe/unsubscribe), the
+        # scheduler thread (reap) and the quote thread (on_push) at once. The
+        # shared combo/sub-index state must stay consistent: no KeyError, no
+        # publish to a torn-down combo, and the source ends fully unsubscribed.
+        source = FakeQuoteSource()
+        publisher = RecordingPublisher()
+        clock = [0.0]
+        manager = QuoteSubscriptionManager(
+            source, heartbeat_timeout_seconds=30.0, time_func=lambda: clock[0],
+            on_push_publisher=publisher,
+        )
+
+        errors = []
+
+        def churn(i):
+            try:
+                for n in range(30):
+                    sub = "sub-%d-%d" % (i, n)
+                    manager.subscribe("client-%d" % i, sub, ["SH"])
+                    handle = next(iter(source.subscriptions), None)
+                    if handle is not None:
+                        source.fire(handle, {"x": n})
+                    manager.unsubscribe("client-%d" % i, sub)
+            except Exception as exc:  # noqa: BLE001 - surface any race as a failure
+                errors.append(exc)
+
+        def reap():
+            try:
+                for _ in range(30):
+                    clock[0] += 1.0
+                    manager.reap_expired()
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        workers = [threading.Thread(target=churn, args=(i,)) for i in range(4)]
+        workers.append(threading.Thread(target=reap))
+        for w in workers:
+            w.start()
+        for w in workers:
+            w.join()
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(source.subscriptions), 0)
+
+
+class OnPushToRedisChannelTest(unittest.TestCase):
+    def test_manager_wired_to_real_channel_publishes(self):
+        class FakeRedis:
+            def __init__(self):
+                self.messages = {}
+
+            def publish(self, channel, value):
+                self.messages.setdefault(channel, []).append(value)
+                return 1
+
+        redis_client = FakeRedis()
+        channel = RedisQuotePushChannel(redis_client, account_id="acct")
+        channel.start_publisher()
+
+        source = FakeQuoteSource()
+        manager = QuoteSubscriptionManager(source, on_push_publisher=channel.publish)
+        manager.subscribe("clientA", "sub1", ["SH"])
+        handle = next(iter(source.subscriptions))
+        source.fire(handle, {"000001.SZ": {"lastPrice": 10.5}})
+
+        self.assertIn("bigqmt:quote_push:acct:SH", redis_client.messages)
+        channel.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_quote_push_channel.py
+++ b/tests/bigqmt_signal_trader/test_quote_push_channel.py
@@ -1,3 +1,4 @@
+import json
 import os
 import sys
 import threading
@@ -9,11 +10,18 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(ROOT, "src"))
 
 from bigqmt_signal_trader.quote_push_channel import (
+    _HAS_MSGPACK,
     RedisQuotePushChannel,
     ZmqQuotePushChannel,
     decode_push_payload,
     encode_push_payload,
 )
+
+
+def _msgpack_packb(payload):
+    import msgpack
+
+    return msgpack.packb(payload, use_bin_type=True)
 
 
 class FakePubSub:
@@ -61,6 +69,26 @@ class PayloadCodecTest(unittest.TestCase):
         # Wire encoding must be bytes (msgpack or utf-8 json), not str.
         blob = encode_push_payload({"a": 1})
         self.assertIsInstance(blob, (bytes, bytearray))
+
+    def test_decode_json_wire_with_msgpack_available(self):
+        # 服务端未装 msgpack 时用 json 兜底编码;若客户端装了 msgpack,
+        # msgpack.unpackb 会把 json 文本首字节 '{'(0x7B) 当整数解析并抛
+        # ExtraData("unpack(b) received extra data")——真实联调中触发。
+        # decode 必须识别并回退到 json。
+        payload = {"combo_key": "000001.SZ", "data": {"000001.SZ": {"lastPrice": 11.19}}}
+        wire = json.dumps(payload, ensure_ascii=False, default=str).encode("utf-8")
+        self.assertIsInstance(wire, bytes)
+        self.assertEqual(decode_push_payload(wire), payload)
+
+    def test_decode_msgpack_wire_without_msgpack_available(self):
+        # 反向:服务端装了 msgpack、客户端未装(仅 json 可用)。msgpack 字节流
+        # 通常不是合法 utf-8,json 解码会失败——此时应显式尝试 msgpack 解码,
+        # 而不是吞掉异常返回 None。
+        payload = {"combo_key": "SH,SZ", "data": {"600000.SH": {"lastPrice": 9.9}}}
+        if not _HAS_MSGPACK:
+            self.skipTest("msgpack not installed on this client")
+        wire = _msgpack_packb(payload)
+        self.assertEqual(decode_push_payload(wire), payload)
 
 
 class ZmqPushChannelTest(unittest.TestCase):

--- a/tests/bigqmt_signal_trader/test_quote_push_channel.py
+++ b/tests/bigqmt_signal_trader/test_quote_push_channel.py
@@ -1,0 +1,137 @@
+import os
+import sys
+import threading
+import time
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.quote_push_channel import (
+    RedisQuotePushChannel,
+    ZmqQuotePushChannel,
+    decode_push_payload,
+    encode_push_payload,
+)
+
+
+class FakePubSub:
+    def __init__(self, redis_client):
+        self._redis = redis_client
+        self._channels = []
+        self._closed = False
+
+    def subscribe(self, *channels):
+        self._channels.extend(channels)
+
+    def get_message(self, timeout=0.1):
+        # Pull one queued message for a subscribed channel, if any.
+        for _ in range(50):
+            for channel in self._channels:
+                queue = self._redis.messages.setdefault(channel, [])
+                if queue:
+                    return {"type": "message", "channel": channel, "data": queue.pop(0)}
+            time.sleep(0.01)
+        return None
+
+    def close(self):
+        self._closed = True
+
+
+class FakeRedis:
+    def __init__(self):
+        self.messages = {}
+
+    def publish(self, channel, value):
+        self.messages.setdefault(channel, []).append(value)
+        return 1
+
+    def pubsub(self, ignore_subscribe_messages=True):
+        return FakePubSub(self)
+
+
+class PayloadCodecTest(unittest.TestCase):
+    def test_roundtrip(self):
+        payload = {"combo_key": "SH,SZ", "data": {"000001.SZ": {"lastPrice": 10.5}}, "ts": 1.5}
+        blob = encode_push_payload(payload)
+        self.assertEqual(decode_push_payload(blob), payload)
+
+    def test_binary_blob(self):
+        # Wire encoding must be bytes (msgpack or utf-8 json), not str.
+        blob = encode_push_payload({"a": 1})
+        self.assertIsInstance(blob, (bytes, bytearray))
+
+
+class ZmqPushChannelTest(unittest.TestCase):
+    def test_pub_sub_roundtrip_and_topic_filter(self):
+        zmq = __import__("zmq")
+        ctx = zmq.Context.instance()
+        pub_addr = "inproc://quote-push-test-%d" % id(self)
+
+        server = ZmqQuotePushChannel(bind_address=pub_addr, context=ctx)
+        server.start_publisher()
+
+        received = []
+        done = threading.Event()
+
+        client = ZmqQuotePushChannel(connect_address=pub_addr, context=ctx)
+
+        def on_msg(topic, data):
+            received.append((topic, data))
+            done.set()
+
+        client.start_subscriber(["SH,SZ"], on_msg)
+        try:
+            # Give the SUB a moment to connect + apply the subscription filter.
+            time.sleep(0.2)
+            server.publish("SH,SZ", {"000001.SZ": {"lastPrice": 10.5}})
+            server.publish("SH", {"600000.SH": {"lastPrice": 9.9}})  # filtered out
+            self.assertTrue(done.wait(2.0), "subscriber did not receive the SH,SZ push")
+        finally:
+            client.stop()
+            server.stop()
+
+        self.assertEqual(len(received), 1)
+        topic, data = received[0]
+        self.assertEqual(topic, "SH,SZ")
+        self.assertEqual(data["000001.SZ"]["lastPrice"], 10.5)
+
+
+class RedisPushChannelTest(unittest.TestCase):
+    def test_pub_sub_roundtrip(self):
+        redis_client = FakeRedis()
+        server = RedisQuotePushChannel(redis_client, account_id="acct")
+        server.start_publisher()
+
+        received = []
+        done = threading.Event()
+        client = RedisQuotePushChannel(redis_client, account_id="acct")
+
+        def on_msg(topic, data):
+            received.append((topic, data))
+            done.set()
+
+        client.start_subscriber(["SH,SZ"], on_msg)
+        try:
+            time.sleep(0.1)
+            server.publish("SH,SZ", {"000001.SZ": {"lastPrice": 10.5}})
+            self.assertTrue(done.wait(2.0), "redis subscriber did not receive the push")
+        finally:
+            client.stop()
+            server.stop()
+
+        self.assertEqual(received[0][0], "SH,SZ")
+        self.assertEqual(received[0][1]["000001.SZ"]["lastPrice"], 10.5)
+
+    def test_channel_name_scoped_by_account(self):
+        redis_client = FakeRedis()
+        server = RedisQuotePushChannel(redis_client, account_id="acct")
+        server.start_publisher()
+        server.publish("SH", {"x": 1})
+        server.stop()
+        self.assertIn("bigqmt:quote_push:acct:SH", redis_client.messages)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_quote_subscription_manager.py
+++ b/tests/bigqmt_signal_trader/test_quote_subscription_manager.py
@@ -1,0 +1,206 @@
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.quote_subscription_manager import (
+    ContextInfoQuoteSource,
+    QuoteSourceAdapter,
+    QuoteSubscriptionManager,
+    combo_key,
+)
+
+
+class FakeContextInfo:
+    """Mirrors big-QMT ContextInfo subscribe_whole_quote/unsubscribe_quote."""
+
+    def __init__(self, fail=False):
+        self.calls = []
+        self.fail = fail
+        self._next = 0
+
+    def subscribe_whole_quote(self, code_list, callback=None):
+        self.calls.append(("subscribe", list(code_list)))
+        if self.fail:
+            return -1
+        self._next += 1
+        return self._next
+
+    def unsubscribe_quote(self, sub_id):
+        self.calls.append(("unsubscribe", sub_id))
+        return 0
+
+
+class ContextInfoQuoteSourceTest(unittest.TestCase):
+    def test_subscribe_returns_handle_and_forwards_callback(self):
+        context = FakeContextInfo()
+        source = ContextInfoQuoteSource(context)
+        received = []
+        handle = source.subscribe(["SH", "SZ"], received.append)
+        self.assertEqual(handle, 1)
+        self.assertEqual(context.calls, [("subscribe", ["SH", "SZ"])])
+
+    def test_subscribe_failure_raises(self):
+        context = FakeContextInfo(fail=True)
+        source = ContextInfoQuoteSource(context)
+        with self.assertRaises(RuntimeError):
+            source.subscribe(["SH"], lambda d: None)
+
+    def test_unsubscribe_forwards_sub_id(self):
+        context = FakeContextInfo()
+        source = ContextInfoQuoteSource(context)
+        handle = source.subscribe(["SH"], lambda d: None)
+        source.unsubscribe(handle)
+        self.assertEqual(context.calls[-1], ("unsubscribe", handle))
+
+
+
+class FakeQuoteSource(QuoteSourceAdapter):
+    """Records subscribe/unsubscribe calls against a fake big-QMT quote source."""
+
+    def __init__(self):
+        self.subscriptions = {}
+        self.unsubscribed = []
+        self._next_handle = 0
+
+    def subscribe(self, codes, on_push):
+        self._next_handle += 1
+        handle = self._next_handle
+        self.subscriptions[handle] = {"codes": list(codes), "on_push": on_push}
+        return handle
+
+    def unsubscribe(self, handle):
+        self.unsubscribed.append(handle)
+        self.subscriptions.pop(handle, None)
+
+
+class ComboKeyTest(unittest.TestCase):
+    def test_order_independent(self):
+        self.assertEqual(combo_key(["SH", "SZ"]), combo_key(["SZ", "SH"]))
+
+    def test_case_and_whitespace_normalized(self):
+        self.assertEqual(combo_key([" sh ", "sz"]), combo_key(["SH", "SZ"]))
+
+    def test_duplicates_collapse(self):
+        self.assertEqual(combo_key(["SH", "SH", "SZ"]), combo_key(["SH", "SZ"]))
+
+    def test_symbol_list(self):
+        self.assertEqual(
+            combo_key(["600000.SH", "000001.SZ"]),
+            combo_key(["000001.SZ", "600000.SH"]),
+        )
+
+    def test_empty_entries_dropped(self):
+        self.assertEqual(combo_key(["SH", "", None, "  "]), "SH")
+
+    def test_empty_list(self):
+        self.assertEqual(combo_key([]), "")
+
+
+class QuoteSubscriptionManagerTest(unittest.TestCase):
+    def setUp(self):
+        self.source = FakeQuoteSource()
+        self.manager = QuoteSubscriptionManager(
+            self.source,
+            heartbeat_timeout_seconds=30.0,
+        )
+
+    # -- first client creates the big-QMT subscription -----------------------
+    def test_first_subscribe_creates_qmt_subscription(self):
+        result = self.manager.subscribe("clientA", "sub1", ["SH", "SZ"])
+        self.assertEqual(len(self.source.subscriptions), 1)
+        handle = next(iter(self.source.subscriptions))
+        self.assertEqual(self.source.subscriptions[handle]["codes"], ["SH", "SZ"])
+        self.assertEqual(result["combo_key"], "SH,SZ")
+        self.assertIn("topic", result)
+
+    def test_same_combo_different_order_shares_subscription(self):
+        self.manager.subscribe("clientA", "sub1", ["SH", "SZ"])
+        self.manager.subscribe("clientB", "sub2", ["sz", "sh"])
+        # Same normalized combo -> only one big-QMT subscription.
+        self.assertEqual(len(self.source.subscriptions), 1)
+
+    def test_different_combos_create_separate_subscriptions(self):
+        self.manager.subscribe("clientA", "sub1", ["SH"])
+        self.manager.subscribe("clientB", "sub2", ["SZ"])
+        self.assertEqual(len(self.source.subscriptions), 2)
+
+    def test_idempotent_replay_same_client_and_sub(self):
+        # Replayed subscribe (recovery) must not create a second big-QMT subscription.
+        self.manager.subscribe("clientA", "sub1", ["SH", "SZ"])
+        self.manager.subscribe("clientA", "sub1", ["SH", "SZ"])
+        self.assertEqual(len(self.source.subscriptions), 1)
+
+    def test_subscribe_response_carries_push_endpoint_when_configured(self):
+        manager = QuoteSubscriptionManager(
+            self.source, push_endpoint="tcp://127.0.0.1:15561"
+        )
+        result = manager.subscribe("clientA", "sub1", ["SH"])
+        self.assertEqual(result["push_endpoint"], "tcp://127.0.0.1:15561")
+
+    def test_subscribe_response_push_endpoint_defaults_empty(self):
+        result = self.manager.subscribe("clientA", "sub1", ["SH"])
+        self.assertEqual(result["push_endpoint"], "")
+
+    # -- reference counting / unsubscribe ------------------------------------
+    def test_unsubscribe_one_of_two_keeps_qmt_subscription(self):
+        self.manager.subscribe("clientA", "sub1", ["SH", "SZ"])
+        self.manager.subscribe("clientB", "sub2", ["SH", "SZ"])
+        self.manager.unsubscribe("clientA", "sub1")
+        self.assertEqual(len(self.source.subscriptions), 1)
+        self.assertEqual(self.source.unsubscribed, [])
+
+    def test_unsubscribe_last_client_unsubscribes_qmt(self):
+        self.manager.subscribe("clientA", "sub1", ["SH", "SZ"])
+        self.manager.subscribe("clientB", "sub2", ["SH", "SZ"])
+        self.manager.unsubscribe("clientA", "sub1")
+        self.manager.unsubscribe("clientB", "sub2")
+        self.assertEqual(len(self.source.subscriptions), 0)
+        self.assertEqual(len(self.source.unsubscribed), 1)
+
+    def test_unsubscribe_unknown_sub_is_noop(self):
+        self.manager.subscribe("clientA", "sub1", ["SH"])
+        # Should not raise, should not affect the live subscription.
+        self.manager.unsubscribe("clientA", "no-such-sub")
+        self.assertEqual(len(self.source.subscriptions), 1)
+
+    # -- keepalive / reaper ----------------------------------------------------
+    def test_keepalive_refreshes_last_seen(self):
+        self.manager.subscribe("clientA", "sub1", ["SH"])
+        self.manager.keepalive("clientA", "sub1")
+        # Still alive -> reaping at a fresh timestamp removes nothing.
+        self.assertEqual(self.manager.reap_expired(now=self.manager._now()), 0)
+        self.assertEqual(len(self.source.subscriptions), 1)
+
+    def test_reap_removes_timed_out_client_and_unsubscribes(self):
+        self.manager.subscribe("clientA", "sub1", ["SH"])
+        now = self.manager._now()
+        # Advance past the 30s timeout with no keepalive.
+        self.assertEqual(self.manager.reap_expired(now=now + 31.0), 1)
+        self.assertEqual(len(self.source.subscriptions), 0)
+
+    def test_reap_keeps_combo_alive_while_one_client_alive(self):
+        clock = [1000.0]
+        manager = QuoteSubscriptionManager(
+            self.source, heartbeat_timeout_seconds=30.0, time_func=lambda: clock[0]
+        )
+        manager.subscribe("clientA", "sub1", ["SH"])
+        manager.subscribe("clientB", "sub2", ["SH"])
+        # clientB keepalives at +31 (fresh); clientA has been silent since subscribe.
+        clock[0] = 1031.0
+        manager.keepalive("clientB", "sub2")
+        removed = manager.reap_expired()
+        # clientA reaped, but combo still has clientB -> big-QMT subscription stays.
+        self.assertEqual(removed, 1)
+        self.assertEqual(len(self.source.subscriptions), 1)
+
+    def test_keepalive_unknown_sub_is_noop(self):
+        # Unknown sub should not raise.
+        self.manager.keepalive("clientA", "ghost")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_quote_subscription_manager.py
+++ b/tests/bigqmt_signal_trader/test_quote_subscription_manager.py
@@ -153,6 +153,22 @@ class QuoteSubscriptionManagerTest(unittest.TestCase):
         self.assertEqual(len(self.source.subscriptions), 1)
         self.assertEqual(self.source.unsubscribed, [])
 
+    def test_unsubscribe_one_sub_of_same_client_keeps_combo_alive(self):
+        """同一 client 两个 sub_id 订阅同一组合,退订一个后另一个仍在:
+        服务端引用按 (client_id, sub_id) 粒度,不按 client 粒度。"""
+        self.manager.subscribe("clientA", "sub1", ["SH", "SZ"])
+        self.manager.subscribe("clientA", "sub2", ["SH", "SZ"])
+        self.manager.unsubscribe("clientA", "sub1")
+        self.assertEqual(len(self.source.subscriptions), 1, "组合不应被拆掉")
+        self.assertEqual(self.source.unsubscribed, [], "不应退订大 QMT 订阅")
+        # 另一个 sub 还在:keepalive 应仍有效(不产生新订阅/退订)
+        self.manager.keepalive("clientA", "sub2")
+        self.assertEqual(len(self.source.subscriptions), 1)
+        # 最后一个 sub 退订 -> 组合拆掉
+        self.manager.unsubscribe("clientA", "sub2")
+        self.assertEqual(len(self.source.subscriptions), 0)
+        self.assertEqual(len(self.source.unsubscribed), 1)
+
     def test_unsubscribe_last_client_unsubscribes_qmt(self):
         self.manager.subscribe("clientA", "sub1", ["SH", "SZ"])
         self.manager.subscribe("clientB", "sub2", ["SH", "SZ"])

--- a/tests/bigqmt_signal_trader/test_quote_subscription_service.py
+++ b/tests/bigqmt_signal_trader/test_quote_subscription_service.py
@@ -1,0 +1,84 @@
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.quote_push_channel import (
+    RedisQuotePushChannel,
+    ZmqQuotePushChannel,
+)
+from bigqmt_signal_trader.quote_subscription_manager import (
+    QuoteSubscriptionManager,
+    build_quote_subscription_service,
+)
+
+
+class FakeContextInfo:
+    def __init__(self):
+        self._next = 0
+
+    def subscribe_whole_quote(self, code_list, callback=None):
+        self._next += 1
+        return self._next
+
+    def unsubscribe_quote(self, sub_id):
+        return 0
+
+
+class FakeRedis:
+    def publish(self, channel, value):
+        return 1
+
+    def pubsub(self, ignore_subscribe_messages=True):
+        raise AssertionError("not used here")
+
+
+class BuildQuoteSubscriptionServiceTest(unittest.TestCase):
+    def test_disabled_returns_none(self):
+        result = build_quote_subscription_service(
+            FakeContextInfo(), transport_name="redis", account_id="acct",
+            redis_client=FakeRedis(), enabled=False,
+        )
+        self.assertIsNone(result)
+
+    def test_redis_transport_builds_redis_channel(self):
+        service = build_quote_subscription_service(
+            FakeContextInfo(), transport_name="redis", account_id="acct",
+            redis_client=FakeRedis(), enabled=True,
+        )
+        manager, channel = service
+        self.assertIsInstance(manager, QuoteSubscriptionManager)
+        self.assertIsInstance(channel, RedisQuotePushChannel)
+
+    def test_zmq_transport_builds_zmq_channel_with_bind_address(self):
+        service = build_quote_subscription_service(
+            FakeContextInfo(), transport_name="zmq", account_id="acct",
+            zmq_bind_address="tcp://127.0.0.1:15561", enabled=True,
+        )
+        manager, channel = service
+        self.assertIsInstance(channel, ZmqQuotePushChannel)
+        self.assertEqual(channel.bind_address, "tcp://127.0.0.1:15561")
+
+    def test_manager_on_push_publisher_is_channel_publish(self):
+        service = build_quote_subscription_service(
+            FakeContextInfo(), transport_name="redis", account_id="acct",
+            redis_client=FakeRedis(), enabled=True,
+        )
+        manager, channel = service
+        # The assembled manager must publish through the assembled channel.
+        self.assertEqual(manager._on_push_publisher, channel.publish)
+
+    def test_heartbeat_timeout_configurable(self):
+        service = build_quote_subscription_service(
+            FakeContextInfo(), transport_name="redis", account_id="acct",
+            redis_client=FakeRedis(), enabled=True, heartbeat_timeout_seconds=30.0,
+        )
+        manager, _channel = service
+        self.assertEqual(manager._heartbeat_timeout, 30.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_whole_quote_client.py
+++ b/tests/bigqmt_signal_trader/test_whole_quote_client.py
@@ -31,6 +31,28 @@ class FakeRpc:
             return [m for m, _ in self.calls]
 
 
+class FakeRpcWithRestart(FakeRpc):
+    """Simulates a server restart: keepalive fails for a window of calls,
+    then the server is back (subscribe succeeds again)."""
+
+    def __init__(self, fail_start=0, fail_count=3):
+        super().__init__()
+        self.fail_start = fail_start
+        self.fail_count = fail_count
+
+    def __call__(self, method, params):
+        with self._lock:
+            self.calls.append((method, dict(params)))
+            if method == "quote_keepalive":
+                n = sum(1 for m, _ in self.calls if m == "quote_keepalive") - 1  # 本次
+        if method == "quote_keepalive" and self.fail_start <= n < self.fail_start + self.fail_count:
+            raise RuntimeError("server restarting")
+        if method == "subscribe_whole_quote":
+            codes = sorted(str(c).upper() for c in params.get("codes") or [])
+            return {"combo_key": ",".join(codes), "topic": ",".join(codes)}
+        return {}
+
+
 class FakePushChannel:
     """Client-side push channel stand-in: lets tests inject server pushes."""
 
@@ -51,6 +73,23 @@ class FakePushChannel:
 
     def stop(self):
         self.stopped = True
+
+
+class FakePushChannelWithTopics(FakePushChannel):
+    """Like FakePushChannel but tracks the currently subscribed topic set, so
+    the session can diff and reuse an existing subscriber."""
+
+    def __init__(self):
+        super().__init__()
+        self.active_topics = frozenset()
+
+    def start_subscriber(self, topics, on_msg):
+        super().start_subscriber(topics, on_msg)
+        self.active_topics = frozenset(topics)
+
+    def stop(self):
+        super().stop()
+        self.active_topics = frozenset()
 
 
 class WholeQuoteSessionTest(unittest.TestCase):
@@ -139,6 +178,106 @@ class WholeQuoteSessionTest(unittest.TestCase):
         session.subscribe_whole_quote(["SH"], callback=lambda d: None)
         sub_params = [p for m, p in rpc.calls if m == "subscribe_whole_quote"][0]
         self.assertEqual(sub_params["client_id"], "client-test")
+
+    def test_auto_replay_after_server_restart(self):
+        """服务端重启后, 心跳线程应检测到 keepalive 失败并在服务端恢复后
+        自动重放订阅(否则推送永久中断)。"""
+        rpc = FakeRpcWithRestart(fail_start=1, fail_count=3)  # 第1-3次keepalive失败
+        channel = FakePushChannelWithTopics()
+        session = WholeQuoteClientSession(
+            rpc_call=rpc, push_channel=channel, client_id="client-test",
+            heartbeat_interval_seconds=0.05,
+        )
+        session.subscribe_whole_quote(["SH"], callback=lambda d: None)
+        session.start()
+        try:
+            deadline = time.time() + 2.0
+            # 等待: keepalive 失败触发重放, 重放后又有新的 keepalive
+            while time.time() < deadline:
+                if rpc.methods().count("subscribe_whole_quote") >= 2 and \
+                   rpc.methods().count("quote_keepalive") >= 5:
+                    break
+                time.sleep(0.02)
+            subs = rpc.methods().count("subscribe_whole_quote")
+            kps = rpc.methods().count("quote_keepalive")
+            print("auto-replay: subscribe=%d keepalive=%d" % (subs, kps))
+            self.assertGreaterEqual(subs, 2, "服务端恢复后应重放订阅")
+            self.assertGreaterEqual(kps, 5)
+        finally:
+            session.stop()
+
+    def test_no_replay_when_server_healthy(self):
+        """服务端健康时不应反复重放订阅(只保留初始 subscribe)。"""
+        session, rpc, _channel = self._session(heartbeat_interval_seconds=0.05)
+        session.subscribe_whole_quote(["SH"], callback=lambda d: None)
+        session.start()
+        try:
+            time.sleep(0.4)
+            self.assertEqual(rpc.methods().count("subscribe_whole_quote"), 1)
+        finally:
+            session.stop()
+
+    def test_replay_when_push_silent_after_restart(self):
+        """服务端重启后 keepalive 可能不失败(redis 队列兜住),但推送会静默。
+        客户端应在推送静默超过阈值后自动重放订阅。"""
+        rpc = FakeRpc()  # keepalive 从不失败
+        channel = FakePushChannelWithTopics()
+        session = WholeQuoteClientSession(
+            rpc_call=rpc, push_channel=channel, client_id="client-test",
+            heartbeat_interval_seconds=0.05,
+            push_silence_replay_heartbeats=2,  # 2 个心跳周期无推送即重放
+        )
+        session.subscribe_whole_quote(["SH"], callback=lambda d: None)
+        session.start()
+        try:
+            deadline = time.time() + 1.5
+            while time.time() < deadline:
+                if rpc.methods().count("subscribe_whole_quote") >= 2:
+                    break
+                time.sleep(0.02)
+            self.assertGreaterEqual(
+                rpc.methods().count("subscribe_whole_quote"), 2,
+                "推送静默超阈值应自动重放订阅",
+            )
+        finally:
+            session.stop()
+
+    def test_subscriber_reused_when_topic_set_unchanged(self):
+        """订阅/退订不应为同一 topic 集合反复重建订阅线程(线程泄漏)。"""
+        rpc = FakeRpc()
+        channel = FakePushChannelWithTopics()
+        session = WholeQuoteClientSession(
+            rpc_call=rpc, push_channel=channel, client_id="client-test",
+            heartbeat_interval_seconds=0.05,
+        )
+        sub1 = session.subscribe_whole_quote(["SH"], callback=lambda d: None)
+        sub2 = session.subscribe_whole_quote(["SH"], callback=lambda d: None)
+        # 两次同 topic 订阅:共享订阅线程,只 start 一次
+        self.assertEqual(len(channel.subscriptions), 1)
+        # 退订一个 sub_id:topic 集合不变,不应重启线程
+        session.unsubscribe_quote(sub1)
+        self.assertEqual(len(channel.subscriptions), 1)
+        self.assertFalse(channel.stopped)
+        # 退订最后一个 sub_id:topic 集合变空,应停掉线程
+        session.unsubscribe_quote(sub2)
+        self.assertTrue(channel.stopped)
+        self.assertEqual(len(channel.subscriptions), 1)
+
+    def test_subscriber_restarts_when_topic_set_changes(self):
+        """topic 集合变化时重建订阅线程,但旧线程先 stop。"""
+        rpc = FakeRpc()
+        channel = FakePushChannelWithTopics()
+        session = WholeQuoteClientSession(
+            rpc_call=rpc, push_channel=channel, client_id="client-test",
+            heartbeat_interval_seconds=0.05,
+        )
+        session.subscribe_whole_quote(["SH"], callback=lambda d: None)
+        session.subscribe_whole_quote(["SZ"], callback=lambda d: None)
+        # topic 集合从 {SH} 变成 {SH,SZ} -> 重建(但旧 stop)
+        self.assertEqual(len(channel.subscriptions), 2)
+        self.assertTrue(channel.stopped)
+        # 新线程订阅 {SH,SZ}
+        self.assertEqual(channel.active_topics, frozenset(["SH", "SZ"]))
 
 
 if __name__ == "__main__":

--- a/tests/bigqmt_signal_trader/test_whole_quote_client.py
+++ b/tests/bigqmt_signal_trader/test_whole_quote_client.py
@@ -1,0 +1,145 @@
+import os
+import sys
+import threading
+import time
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.whole_quote_session import WholeQuoteClientSession
+
+
+class FakeRpc:
+    """Records control RPCs and returns canned subscribe responses."""
+
+    def __init__(self):
+        self.calls = []
+        self._lock = threading.Lock()
+
+    def __call__(self, method, params):
+        with self._lock:
+            self.calls.append((method, dict(params)))
+        if method == "subscribe_whole_quote":
+            codes = sorted(str(c).upper() for c in params.get("codes") or [])
+            return {"combo_key": ",".join(codes), "topic": ",".join(codes)}
+        return {}
+
+    def methods(self):
+        with self._lock:
+            return [m for m, _ in self.calls]
+
+
+class FakePushChannel:
+    """Client-side push channel stand-in: lets tests inject server pushes."""
+
+    def __init__(self):
+        self.subscriptions = []  # list of (topics_tuple, on_msg)
+        self.started = False
+        self.stopped = False
+        self._on_msg = None
+
+    def start_subscriber(self, topics, on_msg):
+        self.started = True
+        self._on_msg = on_msg
+        self.subscriptions.append(tuple(topics))
+
+    def inject(self, topic, data):
+        if self._on_msg is not None:
+            self._on_msg(topic, data)
+
+    def stop(self):
+        self.stopped = True
+
+
+class WholeQuoteSessionTest(unittest.TestCase):
+    def _session(self, **kwargs):
+        rpc = FakeRpc()
+        channel = FakePushChannel()
+        session = WholeQuoteClientSession(
+            rpc_call=rpc,
+            push_channel=channel,
+            client_id="client-test",
+            heartbeat_interval_seconds=kwargs.pop("heartbeat_interval_seconds", 0.05),
+            **kwargs,
+        )
+        return session, rpc, channel
+
+    def test_subscribe_sends_rpc_and_returns_sub_id(self):
+        session, rpc, _channel = self._session()
+        sub_id = session.subscribe_whole_quote(["SH", "SZ"], callback=lambda d: None)
+        self.assertIsNotNone(sub_id)
+        self.assertIn("subscribe_whole_quote", rpc.methods())
+
+    def test_subscribe_starts_push_channel_with_topic(self):
+        session, _rpc, channel = self._session()
+        session.subscribe_whole_quote(["SH", "SZ"], callback=lambda d: None)
+        self.assertTrue(channel.started)
+        self.assertIn(("SH,SZ",), channel.subscriptions)
+
+    def test_incoming_push_invokes_callback(self):
+        session, _rpc, channel = self._session()
+        received = []
+        session.subscribe_whole_quote(["SH"], callback=received.append)
+        channel.inject("SH", {"000001.SZ": {"lastPrice": 10.5}})
+        self.assertEqual(received, [{"000001.SZ": {"lastPrice": 10.5}}])
+
+    def test_two_subscriptions_same_combo_share_one_push(self):
+        session, _rpc, channel = self._session()
+        got_a, got_b = [], []
+        session.subscribe_whole_quote(["SH", "SZ"], callback=got_a.append)
+        session.subscribe_whole_quote(["sz", "sh"], callback=got_b.append)
+        channel.inject("SH,SZ", {"000001.SZ": {"lastPrice": 1.0}})
+        self.assertEqual(len(got_a), 1)
+        self.assertEqual(len(got_b), 1)
+
+    def test_unsubscribe_stops_callback_and_sends_rpc(self):
+        session, rpc, channel = self._session()
+        received = []
+        sub_id = session.subscribe_whole_quote(["SH"], callback=received.append)
+        session.unsubscribe_quote(sub_id)
+        self.assertIn("unsubscribe_whole_quote", rpc.methods())
+        channel.inject("SH", {"x": 1})
+        self.assertEqual(received, [])
+
+    def test_keepalive_sent_for_active_subscriptions(self):
+        session, rpc, _channel = self._session(heartbeat_interval_seconds=0.05)
+        session.subscribe_whole_quote(["SH"], callback=lambda d: None)
+        session.start()
+        try:
+            deadline = time.time() + 1.5
+            while time.time() < deadline and rpc.methods().count("quote_keepalive") < 2:
+                time.sleep(0.02)
+        finally:
+            session.stop()
+        self.assertGreaterEqual(rpc.methods().count("quote_keepalive"), 2)
+
+    def test_keepalive_stops_after_unsubscribe(self):
+        session, rpc, _channel = self._session(heartbeat_interval_seconds=0.05)
+        sub_id = session.subscribe_whole_quote(["SH"], callback=lambda d: None)
+        session.start()
+        time.sleep(0.15)
+        session.unsubscribe_quote(sub_id)
+        count_at_unsub = rpc.methods().count("quote_keepalive")
+        time.sleep(0.2)
+        session.stop()
+        self.assertEqual(rpc.methods().count("quote_keepalive"), count_at_unsub)
+
+    def test_replay_resubscribes_all_active(self):
+        session, rpc, _channel = self._session()
+        session.subscribe_whole_quote(["SH"], callback=lambda d: None)
+        session.subscribe_whole_quote(["SZ"], callback=lambda d: None)
+        subscribes_before = rpc.methods().count("subscribe_whole_quote")
+        session.replay_subscriptions()
+        self.assertEqual(rpc.methods().count("subscribe_whole_quote"), subscribes_before + 2)
+
+    def test_client_id_used_in_rpc(self):
+        session, rpc, _channel = self._session()
+        session.subscribe_whole_quote(["SH"], callback=lambda d: None)
+        sub_params = [p for m, p in rpc.calls if m == "subscribe_whole_quote"][0]
+        self.assertEqual(sub_params["client_id"], "client-test")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_whole_quote_e2e.py
+++ b/tests/bigqmt_signal_trader/test_whole_quote_e2e.py
@@ -1,0 +1,203 @@
+import os
+import sys
+import threading
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.quote_subscription_manager import (
+    QuoteSourceAdapter,
+    QuoteSubscriptionManager,
+)
+from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+from bigqmt_signal_trader.whole_quote_session import WholeQuoteClientSession
+
+
+class FakeQuoteSource(QuoteSourceAdapter):
+    def __init__(self):
+        self.subscriptions = {}
+        self.unsubscribed = []
+        self._next = 0
+
+    def subscribe(self, codes, on_push):
+        self._next += 1
+        handle = self._next
+        self.subscriptions[handle] = {"codes": list(codes), "on_push": on_push}
+        return handle
+
+    def unsubscribe(self, handle):
+        self.unsubscribed.append(handle)
+        self.subscriptions.pop(handle, None)
+
+    def fire(self, data_by_combo_codes):
+        # Fire every live subscription's on_push with the given data.
+        for handle, sub in list(self.subscriptions.items()):
+            sub["on_push"](data_by_combo_codes)
+
+
+class FakeMarketData:
+    def get_ticks(self, codes):
+        return {}
+
+
+class FakePositionProvider:
+    def get_positions(self, account_id):
+        return {}
+
+    def get_asset(self, account_id):
+        return None
+
+
+class InProcPushBus:
+    """Stands in for the QuotePushChannel: server publishes, every client channel
+    subscribed to the topic receives (topic, data)."""
+
+    def __init__(self):
+        self._subscribers = []  # list of _BusSubscriber
+
+    def register(self, subscriber):
+        self._subscribers.append(subscriber)
+
+    def publish(self, topic, data):
+        for sub in list(self._subscribers):
+            sub._deliver(topic, data)
+
+
+class ClientPushChannel:
+    """Client-side push channel wired to the bus. Mirrors QuotePushChannel's
+    subscriber surface used by WholeQuoteClientSession."""
+
+    def __init__(self, bus):
+        self.bus = bus
+        self.topics = []
+        self._on_msg = None
+        bus.register(self)
+
+    def start_subscriber(self, topics, on_msg):
+        self.topics = list(topics)
+        self._on_msg = on_msg
+
+    def _deliver(self, topic, data):
+        if self._on_msg is not None and topic in self.topics:
+            self._on_msg(topic, data)
+
+    def stop(self):
+        pass
+
+
+class WholeQuoteE2ETest(unittest.TestCase):
+    def _server(self, heartbeat_timeout=30.0, clock=None):
+        source = FakeQuoteSource()
+        bus = InProcPushBus()
+        manager = QuoteSubscriptionManager(
+            source,
+            heartbeat_timeout_seconds=heartbeat_timeout,
+            time_func=clock,
+            on_push_publisher=bus.publish,
+        )
+        handlers = BigQmtRpcHandlers(
+            account_id="acct",
+            market_data=FakeMarketData(),
+            position_provider=FakePositionProvider(),
+            quote_subscription_manager=manager,
+        )
+        return source, bus, manager, handlers
+
+    def _client(self, client_id, bus, handlers):
+        def rpc_call(method, params):
+            return handlers.handle(method, params)
+
+        return WholeQuoteClientSession(
+            rpc_call=rpc_call,
+            push_channel=ClientPushChannel(bus),
+            client_id=client_id,
+            heartbeat_interval_seconds=0.05,
+        )
+
+    def test_two_clients_share_one_qmt_subscription_and_both_receive(self):
+        source, bus, manager, handlers = self._server()
+        client_a = self._client("clientA", bus, handlers)
+        client_b = self._client("clientB", bus, handlers)
+        got_a, got_b = [], []
+        client_a.subscribe_whole_quote(["SH", "SZ"], callback=got_a.append)
+        client_b.subscribe_whole_quote(["sz", "sh"], callback=got_b.append)
+
+        # One shared big-QMT subscription for the same normalized combo.
+        self.assertEqual(len(source.subscriptions), 1)
+        source.fire({"000001.SZ": {"lastPrice": 10.5}})
+        self.assertEqual(len(got_a), 1)
+        self.assertEqual(len(got_b), 1)
+
+    def test_one_unsubscribe_keeps_other_receiving(self):
+        source, bus, manager, handlers = self._server()
+        client_a = self._client("clientA", bus, handlers)
+        client_b = self._client("clientB", bus, handlers)
+        got_a, got_b = [], []
+        sub_a = client_a.subscribe_whole_quote(["SH"], callback=got_a.append)
+        client_b.subscribe_whole_quote(["SH"], callback=got_b.append)
+
+        client_a.unsubscribe_quote(sub_a)
+        self.assertEqual(len(source.subscriptions), 1)  # still alive for clientB
+        source.fire({"x": 1})
+        self.assertEqual(got_a, [])
+        self.assertEqual(len(got_b), 1)
+
+    def test_all_unsubscribe_tears_down_qmt_subscription(self):
+        source, bus, manager, handlers = self._server()
+        client_a = self._client("clientA", bus, handlers)
+        client_b = self._client("clientB", bus, handlers)
+        sub_a = client_a.subscribe_whole_quote(["SH"], callback=lambda d: None)
+        sub_b = client_b.subscribe_whole_quote(["SH"], callback=lambda d: None)
+        client_a.unsubscribe_quote(sub_a)
+        client_b.unsubscribe_quote(sub_b)
+        self.assertEqual(len(source.subscriptions), 0)
+        self.assertEqual(len(source.unsubscribed), 1)
+
+    def test_server_restart_client_replay_restores_push(self):
+        source, bus, manager, handlers = self._server()
+        client = self._client("clientA", bus, handlers)
+        received = []
+        client.subscribe_whole_quote(["SH"], callback=received.append)
+        self.assertEqual(len(source.subscriptions), 1)
+
+        # Server "restarts": a brand-new manager/source/handlers on the same bus.
+        source2 = FakeQuoteSource()
+        manager2 = QuoteSubscriptionManager(source2, on_push_publisher=bus.publish)
+        handlers2 = BigQmtRpcHandlers(
+            account_id="acct",
+            market_data=FakeMarketData(),
+            position_provider=FakePositionProvider(),
+            quote_subscription_manager=manager2,
+        )
+        self.assertEqual(len(source2.subscriptions), 0)
+
+        # Client detects the restart and replays its subscriptions.
+        def rpc_call2(method, params):
+            return handlers2.handle(method, params)
+
+        client._rpc = rpc_call2
+        client.replay_subscriptions()
+
+        self.assertEqual(len(source2.subscriptions), 1)
+        source2.fire({"000001.SZ": {"lastPrice": 11.0}})
+        self.assertEqual(len(received), 1)
+        self.assertEqual(received[0]["000001.SZ"]["lastPrice"], 11.0)
+
+    def test_silent_client_reaped_and_qmt_subscription_torn_down(self):
+        clock = [1000.0]
+        source, bus, manager, handlers = self._server(clock=lambda: clock[0])
+        client = self._client("clientA", bus, handlers)
+        client.subscribe_whole_quote(["SH"], callback=lambda d: None)
+        self.assertEqual(len(source.subscriptions), 1)
+
+        # Client goes silent (no keepalive); clock advances past the timeout.
+        clock[0] += 31.0
+        manager.reap_expired()
+        self.assertEqual(len(source.subscriptions), 0)
+        self.assertEqual(len(source.unsubscribed), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_whole_quote_rpc_handlers.py
+++ b/tests/bigqmt_signal_trader/test_whole_quote_rpc_handlers.py
@@ -1,0 +1,117 @@
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.quote_subscription_manager import (
+    QuoteSourceAdapter,
+    QuoteSubscriptionManager,
+)
+from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+
+
+class FakeQuoteSource(QuoteSourceAdapter):
+    def __init__(self):
+        self.subscriptions = {}
+        self.unsubscribed = []
+        self._next_handle = 0
+
+    def subscribe(self, codes, on_push):
+        self._next_handle += 1
+        handle = self._next_handle
+        self.subscriptions[handle] = {"codes": list(codes), "on_push": on_push}
+        return handle
+
+    def unsubscribe(self, handle):
+        self.unsubscribed.append(handle)
+        self.subscriptions.pop(handle, None)
+
+
+class FakeMarketData:
+    def get_ticks(self, codes):
+        return {}
+
+
+class FakePositionProvider:
+    def get_positions(self, account_id):
+        return {}
+
+    def get_asset(self, account_id):
+        return None
+
+
+def _handlers(with_manager=True):
+    source = FakeQuoteSource()
+    manager = QuoteSubscriptionManager(source) if with_manager else None
+    handlers = BigQmtRpcHandlers(
+        account_id="acct",
+        market_data=FakeMarketData(),
+        position_provider=FakePositionProvider(),
+        quote_subscription_manager=manager,
+    )
+    return handlers, source
+
+
+class WholeQuoteRpcHandlersTest(unittest.TestCase):
+    def test_subscribe_whole_quote_allowed_and_creates_subscription(self):
+        handlers, source = _handlers()
+        result = handlers.handle(
+            "subscribe_whole_quote",
+            {"client_id": "c1", "sub_id": "s1", "codes": ["SH", "SZ"]},
+        )
+        self.assertEqual(len(source.subscriptions), 1)
+        self.assertEqual(result["combo_key"], "SH,SZ")
+        self.assertIn("topic", result)
+
+    def test_subscribe_whole_quote_idempotent_replay(self):
+        handlers, source = _handlers()
+        params = {"client_id": "c1", "sub_id": "s1", "codes": ["SH", "SZ"]}
+        handlers.handle("subscribe_whole_quote", params)
+        handlers.handle("subscribe_whole_quote", params)  # replay after recovery
+        self.assertEqual(len(source.subscriptions), 1)
+
+    def test_subscribe_whole_quote_requires_client_and_codes(self):
+        handlers, _source = _handlers()
+        with self.assertRaises(ValueError):
+            handlers.handle("subscribe_whole_quote", {"sub_id": "s1", "codes": ["SH"]})
+        with self.assertRaises(ValueError):
+            handlers.handle("subscribe_whole_quote", {"client_id": "c1", "sub_id": "s1", "codes": []})
+
+    def test_unsubscribe_whole_quote_tears_down_last_client(self):
+        handlers, source = _handlers()
+        handlers.handle("subscribe_whole_quote", {"client_id": "c1", "sub_id": "s1", "codes": ["SH"]})
+        handlers.handle("unsubscribe_whole_quote", {"client_id": "c1", "sub_id": "s1"})
+        self.assertEqual(len(source.subscriptions), 0)
+        self.assertEqual(len(source.unsubscribed), 1)
+
+    def test_quote_keepalive_ok(self):
+        handlers, _source = _handlers()
+        handlers.handle("subscribe_whole_quote", {"client_id": "c1", "sub_id": "s1", "codes": ["SH"]})
+        result = handlers.handle("quote_keepalive", {"client_id": "c1", "sub_id": "s1"})
+        self.assertEqual(result, {})
+
+    def test_quote_methods_rejected_without_manager(self):
+        handlers, _source = _handlers(with_manager=False)
+        with self.assertRaises(RuntimeError):
+            handlers.handle("subscribe_whole_quote", {"client_id": "c1", "sub_id": "s1", "codes": ["SH"]})
+        with self.assertRaises(RuntimeError):
+            handlers.handle("quote_keepalive", {"client_id": "c1", "sub_id": "s1"})
+
+    def test_quote_methods_in_default_allowed_set(self):
+        # The three methods must be reachable through the default whitelist (no
+        # explicit allowed_methods passed), same as every other read method.
+        handlers = BigQmtRpcHandlers(
+            account_id="acct",
+            market_data=FakeMarketData(),
+            position_provider=FakePositionProvider(),
+            quote_subscription_manager=QuoteSubscriptionManager(FakeQuoteSource()),
+        )
+        for method in ("subscribe_whole_quote", "unsubscribe_whole_quote", "quote_keepalive"):
+            self.assertIn(method, handlers.allowed_methods)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_xtdata_whole_quote.py
+++ b/tests/bigqmt_signal_trader/test_xtdata_whole_quote.py
@@ -1,0 +1,101 @@
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+import bigqmt_signal_trader.xtquant_compat as compat
+
+
+class FakeSession:
+    """Captures BigQmtXtData -> WholeQuoteClientSession delegation."""
+
+    def __init__(self):
+        self.subscribed = []
+        self.unsubscribed = []
+        self.started = False
+        self._next = 0
+        self._active = set()
+
+    def subscribe_whole_quote(self, code_list, callback=None):
+        self._next += 1
+        self._active.add(self._next)
+        self.subscribed.append((list(code_list), callback))
+        return self._next
+
+    def unsubscribe_quote(self, sub_id):
+        self.unsubscribed.append(sub_id)
+        self._active.discard(sub_id)
+        return 0
+
+    def has_subscription(self, sub_id):
+        return sub_id in self._active
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        pass
+
+
+class FakeClient:
+    def __init__(self):
+        self.account_id = "acct"
+        self.local_cache_config = {}
+        self.full_tick_cache_config = {}
+        self.transport_name = "redis"
+        self.calls = []
+
+    def call(self, method, params=None, **kwargs):
+        self.calls.append((method, params))
+        if method == "get_full_tick":
+            return {c: {"lastPrice": 1.0} for c in (params or {}).get("codes") or []}
+        return {}
+
+    def _redis(self):
+        raise AssertionError("redis not expected in this test")
+
+
+class XtDataWholeQuoteDelegationTest(unittest.TestCase):
+    def _xtdata(self, session):
+        client = FakeClient()
+        data = compat.BigQmtXtData(client)
+        data._quote_session_factory = lambda: session
+        return data, client
+
+    def test_subscribe_delegates_to_session_and_primes_full_tick(self):
+        session = FakeSession()
+        data, _client = self._xtdata(session)
+        received = []
+        sub_id = data.subscribe_whole_quote(["000001.SZ"], callback=received.append)
+        # Delegated to the session.
+        self.assertEqual(session.subscribed[0][0], ["000001.SZ"])
+        self.assertEqual(sub_id, 1)
+        # Primed via get_full_tick so the callback fires once with the snapshot.
+        self.assertEqual(received, [{"000001.SZ": {"lastPrice": 1.0}}])
+
+    def test_subscribe_starts_session_once(self):
+        session = FakeSession()
+        data, _client = self._xtdata(session)
+        data.subscribe_whole_quote(["SH"], callback=lambda d: None)
+        self.assertTrue(session.started)
+
+    def test_unsubscribe_delegates_to_session(self):
+        session = FakeSession()
+        data, _client = self._xtdata(session)
+        sub_id = data.subscribe_whole_quote(["SH"], callback=lambda d: None)
+        data.unsubscribe_quote(sub_id)
+        self.assertEqual(session.unsubscribed, [sub_id])
+
+    def test_session_reused_across_subscriptions(self):
+        session = FakeSession()
+        data, _client = self._xtdata(session)
+        data.subscribe_whole_quote(["SH"], callback=lambda d: None)
+        data.subscribe_whole_quote(["SZ"], callback=lambda d: None)
+        self.assertEqual(len(session.subscribed), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概述

实现 `xtdata.subscribe_whole_quote` 真实推送能力(此前为桩实现:一次性快照 + 事件)。
服务端大 QMT 行情回调 → 推送通道 → 客户端回调,对齐 MiniQMT 行为。

## 架构

三条逻辑通道:

1. **控制面 RPC(复用现有 transport)**:`subscribe_whole_quote` / `unsubscribe_whole_quote` / `quote_keepalive` 三个新方法
2. **数据面推送(新增)**:server→client 单向 PUB/SUB 通道,`QuotePushChannel` 抽象下 redis pub/sub 与 zmq PUB/SUB 两个实现,按部署 transport 选择;msgpack 编码、json 兜底
3. **大 QMT 行情源**:服务端 `QuoteSubscriptionManager` 引用计数管理 `ContextInfo.subscribe_whole_quote`,按组合去重共享订阅

客户端 `WholeQuoteClientSession` 持有订阅表、推送路由、心跳线程,以 `get_full_tick` 快照打底(大 QMT 回调是增量的)。

## 关键设计

- **组合去重共享**:`combo_key` 规范化(大写/去空白/排序),不同 client 同组合共享 1 个大 QMT 订阅
- **引用计数**:按 `(client_id, sub_id)` 粒度,全部退订或超时才拆订阅
- **心跳保活**:client 周期 `quote_keepalive`,服务端 30s 超时回收
- **重启恢复**:客户端推送静默检测(默认 10 个心跳周期无推送)自动重放订阅

## 真机联调验证(交易日实测)

- 单标的 / 20 / 50 / 100 只标的:推送节奏 3s 稳定,零丢失、零乱序
- 20 只活跃股 120s:每只 41~42 次推送,间隔 2.93~3.0s,数据单调零违规
- 多 client 共享订阅、退订隔离、同 client 多 sub_id、边界(空列表/非法代码/重复订阅)全部通过
- 服务端重启:42s 中断后自动恢复(两次独立验证)

## 测试

- 新增 9 个测试(编码回退 2 / 线程复用 4+重放 2 / 引用计数 1),另有 e2e、RPC handler、wiring 等覆盖
- 全量:`266 passed, 3 skipped, 1 failed`(唯一失败为 mysql transport 缺 DBUtils 依赖,预先存在)

## 文档

- `docs/SUBSCRIBE_WHOLE_QUOTE_PUSH.md`:推送机制设计(组合去重、引用计数、重启恢复、编码)
- `docs/SUBSCRIBE_WHOLE_QUOTE_LIVE_VERIFICATION.md`:真机联调验证报告(环境信息已脱敏)

## 兼容性

- 传输:redis(默认)/ zmq / mysql 均支持;推送通道按 transport 自动选择
- 编码:msgpack 可选依赖,服务端无 msgpack 时 json 兜底,双向兼容
- 不影响现有 `get_full_tick`、事件订阅等路径