### PR TITLE
修复 server_error 泄漏与委托匹配兜底，新增 qmt_launcher (#43 #41 #45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,39 @@ BIGQMT_REDIS_CONFIG = {
 所以连不上 58600 的客户端行为与改动前完全一致。BSON 编解码内置了无依赖实现（可选用
 pymongo 的 `bson`，两者输出实测逐字节一致），客户端不需要额外装包。
 
+### QMT 启停 / 自动重启（qmt_launcher）
+
+大 QMT 基本每天早上要重启一次，卡点在登录框。两条路绕过它：
+
+```bash
+python -m bigqmt_signal_trader.qmt_launcher status  --dir "D:\国金证券QMT交易端_lemo"
+python -m bigqmt_signal_trader.qmt_launcher restart --dir "D:\国金证券QMT交易端_lemo"
+```
+
+| mode | 做什么 | 需要登录框交互 |
+|------|--------|---------------|
+| `linkmini`（默认优先）| `XtMiniQmt.exe linkMini`，MiniQMT 免密启动 | 否 |
+| `bat` | 跑指定批处理（如 `免密登录qmt.bat`）| 否 |
+| `exe` | 直接起 `XtItClient.exe`，靠终端自身恢复会话 | 否 |
+| `login` | 起 exe 后向登录框输入账号密码 | 是，需 pywin32 |
+
+**关于「pywinauto/pyautogui 要求 Windows 处于登录状态」**：`login` 模式用的是
+`win32api.SendMessage` 直接投递到窗口句柄，不是 pyautogui 那种按屏幕坐标重放物理输入。
+前者不要求窗口置于前台，锁屏下也能工作（会话还在即可，完全注销则不行）。密码从
+环境变量 `BIGQMT_LOGIN_USER` / `BIGQMT_LOGIN_PASSWORD` 读，不走命令行参数——argv
+对同机任何进程可见。
+
+两个设计要点：
+
+- **按安装目录隔离**。同机常并行跑多个 QMT，`taskkill /im XtItClient.exe` 会误杀别人的
+  实盘。这里只终结 `--dir` 对应 `bin.x64` 下的进程；拿不到 exe 路径的进程直接跳过而不是
+  猜。
+- **等就绪而不是 sleep 固定秒数**。启动完成的判据是 FormulaServer 端口（58600）能接受连接，
+  超时抛 `QmtLauncherError` 而不是静默返回，避免定时任务在没起来的终端上继续跑。
+
+`restart` 默认在关闭后等 5 秒再启动：ZMQ 传输是精确绑定配置端口（不扫描），socket 没
+完全释放就重启会绑定失败。
+
 ### 独立 ZMQ 回测桥接
 
 `bigqmt_backtest` 与实盘 RPC 桥接完全分离，提供两个明确隔离的后端：

--- a/src/bigqmt_signal_trader/qmt_launcher.py
+++ b/src/bigqmt_signal_trader/qmt_launcher.py
@@ -1,0 +1,484 @@
+# coding: utf-8
+"""Start and stop a Big QMT terminal (issue #45).
+
+Big QMT has to be restarted most mornings, and the login dialog is the reason
+it cannot simply be dropped into a scheduler. Two ways past it:
+
+* **Passwordless (preferred)** -- ``XtMiniQmt.exe linkMini`` starts MiniQMT
+  against an existing session with no dialog at all. This is what
+  ``免密登录qmt.bat`` does. No UI automation, so nothing here depends on a
+  desktop being visible.
+* **Credential entry** -- for the full terminal (``XtItClient.exe``) the dialog
+  is unavoidable. We drive it with ``win32api.SendMessage`` posted straight to
+  the window handle, NOT with pyautogui/pywinauto. That distinction is the
+  answer to the question in issue #45: pyautogui replays physical input at
+  screen coordinates, so it needs the window focused and the desktop unlocked;
+  SendMessage delivers to a handle and works on a background -- or locked --
+  session, as long as the session still exists (an RDP disconnect is fine, a
+  full logout is not).
+
+Everything is scoped to one install directory. A machine here runs several QMT
+copies side by side, so an unscoped ``taskkill /im XtItClient.exe`` would take
+down someone else's trading session.
+
+Waits are on observed readiness, never a fixed sleep: startup is complete when
+the FormulaServer port accepts a connection, which is also exactly what the
+rest of this package needs before it can do anything.
+
+Windows only. ``psutil`` is used when importable, otherwise we shell out to
+``wmic``/``taskkill``.
+"""
+
+import os
+import socket
+import subprocess
+import sys
+import time
+
+from .logging_setup import get_logger
+
+
+log = get_logger("launcher")
+
+# Processes a QMT install owns. miniquote/BrokerProxy/minibroker are children
+# that survive the main window and hold the ports we need to rebind.
+QMT_PROCESS_NAMES = (
+    "XtItClient.exe",
+    "XtMiniQmt.exe",
+    "miniquote.exe",
+    "BrokerProxy.exe",
+    "minibroker.exe",
+)
+
+# FormulaServer. Listening means the terminal is far enough up to answer.
+DEFAULT_READY_PORT = 58600
+
+__all__ = [
+    "QmtLauncherError",
+    "close_qmt",
+    "find_qmt_processes",
+    "is_qmt_running",
+    "open_qmt",
+    "restart_qmt",
+    "wait_until_ready",
+]
+
+
+class QmtLauncherError(RuntimeError):
+    """Launching or stopping a QMT terminal failed."""
+
+
+def _normalize_dir(path):
+    if not path:
+        return ""
+    return os.path.normcase(os.path.normpath(os.path.abspath(str(path))))
+
+
+def resolve_install_dir(install_dir):
+    """Accept an install root, its bin.x64, or a path to an exe inside it.
+
+    Returns the normalized ``bin.x64`` directory, which is what process paths
+    are compared against.
+    """
+    path = str(install_dir or "").strip().strip('"').strip("'")
+    if not path:
+        raise QmtLauncherError("install_dir is required (QMT root, bin.x64, or an exe path)")
+    if os.path.isfile(path) or path.lower().endswith(".exe"):
+        path = os.path.dirname(path)
+    normalized = os.path.normpath(os.path.abspath(path))
+    if os.path.basename(normalized).lower() != "bin.x64":
+        candidate = os.path.join(normalized, "bin.x64")
+        if os.path.isdir(candidate):
+            normalized = candidate
+    return normalized
+
+
+# ---------------------------------------------------------------- discovery
+def _iter_processes_psutil():
+    import psutil
+
+    for proc in psutil.process_iter(["pid", "name", "exe"]):
+        try:
+            info = proc.info
+            yield int(info["pid"]), str(info.get("name") or ""), str(info.get("exe") or "")
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            continue
+
+
+def _iter_processes_wmic():
+    """psutil-free fallback. wmic still ships on the Windows builds QMT runs on."""
+    try:
+        raw = subprocess.check_output(
+            ["wmic", "process", "get", "ProcessId,Name,ExecutablePath", "/format:csv"],
+            stderr=subprocess.STDOUT,
+        )
+    except Exception as exc:
+        raise QmtLauncherError(
+            "cannot enumerate processes: psutil is not installed and wmic failed (%s)" % exc
+        )
+    text = raw.decode("utf-8", "replace") if isinstance(raw, bytes) else str(raw)
+    for row in text.splitlines():
+        parts = [p.strip() for p in row.split(",")]
+        # CSV columns: Node,ExecutablePath,Name,ProcessId
+        if len(parts) < 4 or parts[3].lower() in ("processid", ""):
+            continue
+        try:
+            pid = int(parts[3])
+        except ValueError:
+            continue
+        yield pid, parts[2], parts[1]
+
+
+def _iter_processes():
+    try:
+        import psutil  # noqa: F401
+    except ImportError:
+        return _iter_processes_wmic()
+    return _iter_processes_psutil()
+
+
+def find_qmt_processes(install_dir, names=QMT_PROCESS_NAMES):
+    """Return ``[(pid, name, exe), ...]`` for QMT processes under ``install_dir``.
+
+    A process with no readable exe path is skipped rather than guessed at: on a
+    machine running several QMT copies, killing by name alone is how you take
+    down the wrong account.
+    """
+    target = _normalize_dir(resolve_install_dir(install_dir))
+    wanted = set(str(n).lower() for n in names)
+    found = []
+    for pid, name, exe in _iter_processes():
+        if name.lower() not in wanted or not exe:
+            continue
+        if _normalize_dir(os.path.dirname(exe)) == target:
+            found.append((pid, name, exe))
+    return found
+
+
+def is_qmt_running(install_dir):
+    return bool(find_qmt_processes(install_dir))
+
+
+# ------------------------------------------------------------------ readiness
+def port_is_listening(port=DEFAULT_READY_PORT, host="127.0.0.1", timeout=1.0):
+    sock = socket.socket()
+    sock.settimeout(timeout)
+    try:
+        sock.connect((host, port))
+        return True
+    except Exception:
+        return False
+    finally:
+        try:
+            sock.close()
+        except Exception:
+            pass
+
+
+def wait_until_ready(port=DEFAULT_READY_PORT, host="127.0.0.1", timeout_seconds=180.0,
+                     poll_interval=2.0):
+    """Block until ``port`` accepts a connection. Returns seconds waited.
+
+    Raises :class:`QmtLauncherError` on timeout rather than returning False, so
+    a scheduled restart fails loudly instead of letting the next step run
+    against a terminal that never came up.
+    """
+    deadline = time.time() + float(timeout_seconds)
+    started = time.time()
+    while time.time() < deadline:
+        if port_is_listening(port, host):
+            waited = time.time() - started
+            log.info("qmt ready after %.1fs (%s:%d listening)", waited, host, port)
+            return waited
+        time.sleep(poll_interval)
+    raise QmtLauncherError(
+        "QMT did not become ready within %.0fs (%s:%d never listened)"
+        % (timeout_seconds, host, port)
+    )
+
+
+def wait_until_stopped(install_dir, timeout_seconds=60.0, poll_interval=1.0):
+    deadline = time.time() + float(timeout_seconds)
+    while time.time() < deadline:
+        if not find_qmt_processes(install_dir):
+            return True
+        time.sleep(poll_interval)
+    return False
+
+
+# --------------------------------------------------------------------- close
+def _terminate(pid, force=False):
+    try:
+        import psutil
+
+        proc = psutil.Process(pid)
+        if force:
+            proc.kill()
+        else:
+            proc.terminate()
+        return True
+    except ImportError:
+        pass
+    except Exception:
+        return False
+    cmd = ["taskkill", "/pid", str(pid)]
+    if force:
+        cmd.append("/f")
+    try:
+        subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        return True
+    except Exception:
+        return False
+
+
+def close_qmt(install_dir, timeout_seconds=60.0, force_after_seconds=20.0):
+    """Stop every QMT process under ``install_dir``. Returns how many were stopped.
+
+    Asks politely first: the terminal flushes local data on a clean exit, and
+    killing it outright is how the K-line store ends up truncated. Escalates to
+    a hard kill only after ``force_after_seconds``.
+    """
+    targets = find_qmt_processes(install_dir)
+    if not targets:
+        log.info("no QMT process under %s; nothing to close", install_dir)
+        return 0
+
+    for pid, name, _exe in targets:
+        log.info("closing %s (pid=%s)", name, pid)
+        _terminate(pid, force=False)
+
+    if wait_until_stopped(install_dir, timeout_seconds=force_after_seconds):
+        log.info("closed %d process(es) cleanly", len(targets))
+        return len(targets)
+
+    remaining = find_qmt_processes(install_dir)
+    log.warning("%d process(es) still alive after %.0fs; forcing",
+                len(remaining), force_after_seconds)
+    for pid, name, _exe in remaining:
+        _terminate(pid, force=True)
+
+    grace = max(timeout_seconds - force_after_seconds, 5.0)
+    if not wait_until_stopped(install_dir, timeout_seconds=grace):
+        still = find_qmt_processes(install_dir)
+        raise QmtLauncherError(
+            "could not stop: %s" % ", ".join("%s(pid=%s)" % (n, p) for p, n, _ in still)
+        )
+    return len(targets)
+
+
+# ---------------------------------------------------------------------- open
+def _spawn(command, cwd=None, shell=False):
+    log.info("launching: %s", command if isinstance(command, str) else " ".join(command))
+    kwargs = {"cwd": cwd, "shell": shell,
+              "stdout": subprocess.DEVNULL, "stderr": subprocess.DEVNULL}
+    if os.name == "nt":
+        # Detach so the terminal outlives this process -- otherwise a scheduled
+        # task exiting takes QMT with it.
+        detached = getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+        new_group = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
+        kwargs["creationflags"] = detached | new_group
+    return subprocess.Popen(command, **kwargs)
+
+
+def open_qmt(install_dir, mode="auto", bat_path=None, exe_name=None,
+             ready_port=DEFAULT_READY_PORT, ready_timeout_seconds=180.0,
+             wait_ready=True, credentials=None, window_title_prefix=None):
+    """Start a QMT terminal under ``install_dir`` and wait until it answers.
+
+    ``mode``:
+      ``"linkmini"`` -- ``XtMiniQmt.exe linkMini``, no login dialog.
+      ``"bat"``      -- run ``bat_path`` (e.g. 免密登录qmt.bat).
+      ``"exe"``      -- start ``exe_name`` (default XtItClient.exe) as-is; use
+                        when the terminal restores its own session.
+      ``"login"``    -- start the exe, then type credentials into the dialog.
+      ``"auto"``     -- bat if given, else linkmini if XtMiniQmt.exe exists,
+                        else exe.
+
+    ``credentials`` (mode="login") is ``{"user": ..., "password": ...}``. Pass
+    it from your local config or environment; never hardcode it, and note the
+    values are typed into a window, so anything that can read that window can
+    read them.
+    """
+    bin_dir = resolve_install_dir(install_dir)
+    if not os.path.isdir(bin_dir):
+        raise QmtLauncherError("no such directory: %s" % bin_dir)
+
+    mode = str(mode or "auto").lower()
+    if mode == "auto":
+        if bat_path:
+            mode = "bat"
+        elif os.path.isfile(os.path.join(bin_dir, "XtMiniQmt.exe")):
+            mode = "linkmini"
+        else:
+            mode = "exe"
+
+    if mode == "bat":
+        if not bat_path or not os.path.isfile(bat_path):
+            raise QmtLauncherError("bat_path is required for mode='bat': %r" % bat_path)
+        _spawn([bat_path], cwd=os.path.dirname(bat_path), shell=True)
+    elif mode == "linkmini":
+        exe = os.path.join(bin_dir, "XtMiniQmt.exe")
+        if not os.path.isfile(exe):
+            raise QmtLauncherError("XtMiniQmt.exe not found in %s" % bin_dir)
+        _spawn([exe, "linkMini"], cwd=bin_dir)
+    elif mode in ("exe", "login"):
+        exe = os.path.join(bin_dir, str(exe_name or "XtItClient.exe"))
+        if not os.path.isfile(exe):
+            raise QmtLauncherError("%s not found in %s" % (os.path.basename(exe), bin_dir))
+        _spawn([exe], cwd=bin_dir)
+        if mode == "login":
+            _login_via_window(credentials or {}, window_title_prefix)
+    else:
+        raise QmtLauncherError("unknown mode %r (bat/linkmini/exe/login/auto)" % mode)
+
+    if not wait_ready:
+        return 0.0
+    return wait_until_ready(ready_port, timeout_seconds=ready_timeout_seconds)
+
+
+def _login_via_window(credentials, window_title_prefix=None, appear_timeout_seconds=90.0):
+    """Type credentials into the QMT login dialog via SendMessage.
+
+    Matches the window by title PREFIX. The reference implementation pinned the
+    full title including a build number ("国金证券QMT交易端 1.0.0.29456"), which
+    stops finding the window on the next terminal update.
+    """
+    user = str(credentials.get("user") or credentials.get("account") or "")
+    password = str(credentials.get("password") or "")
+    if not user or not password:
+        raise QmtLauncherError(
+            "mode='login' needs credentials={'user':..., 'password':...}"
+        )
+    try:
+        import win32api
+        import win32con
+        import win32gui
+    except ImportError:
+        raise QmtLauncherError(
+            "mode='login' needs pywin32 (pip install pywin32); "
+            "prefer mode='linkmini' or mode='bat', which need no UI automation"
+        )
+
+    prefix = str(window_title_prefix or "QMT")
+
+    def _collect(hwnd, acc):
+        if not win32gui.IsWindowVisible(hwnd):
+            return
+        title = win32gui.GetWindowText(hwnd) or ""
+        if title.strip().startswith(prefix):
+            acc.append(hwnd)
+
+    def _find():
+        matches = []
+        win32gui.EnumWindows(_collect, matches)
+        return matches[0] if matches else None
+
+    deadline = time.time() + appear_timeout_seconds
+    handle = None
+    while time.time() < deadline:
+        handle = _find()
+        if handle:
+            break
+        time.sleep(2.0)
+    if not handle:
+        raise QmtLauncherError(
+            "login window starting with %r did not appear within %.0fs"
+            % (prefix, appear_timeout_seconds)
+        )
+
+    def _send_text(text):
+        for ch in str(text):
+            win32api.SendMessage(handle, win32con.WM_KEYDOWN, ord(ch), 0)
+            win32api.SendMessage(handle, win32con.WM_KEYUP, ord(ch), 0)
+        time.sleep(0.2)
+
+    def _send_enter():
+        win32api.SendMessage(handle, win32con.WM_KEYDOWN, win32con.VK_RETURN, 0)
+        win32api.SendMessage(handle, win32con.WM_KEYUP, win32con.VK_RETURN, 0)
+        time.sleep(1.0)
+
+    # Never log the values themselves.
+    log.info("entering credentials into window %r", prefix)
+    _send_text(user)
+    _send_enter()
+    _send_text(password)
+    _send_enter()
+    _send_enter()
+
+
+def restart_qmt(install_dir, settle_seconds=5.0, **open_kwargs):
+    """Close, wait for the ports to be released, then start again.
+
+    ``settle_seconds`` matters: the FormulaServer and RPC sockets linger briefly
+    after the process dies, and the ZMQ transport binds its configured port
+    exactly (no scanning), so restarting too eagerly fails the rebind.
+    """
+    closed = close_qmt(install_dir)
+    if closed:
+        time.sleep(settle_seconds)
+    waited = open_qmt(install_dir, **open_kwargs)
+    log.info("restart complete (closed=%d, ready in %.1fs)", closed, waited)
+    return waited
+
+
+# ----------------------------------------------------------------------- CLI
+def main(argv=None):
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="python -m bigqmt_signal_trader.qmt_launcher",
+        description="Start/stop a Big QMT terminal, scoped to one install directory.",
+    )
+    parser.add_argument("action", choices=("open", "close", "restart", "status"))
+    parser.add_argument("--dir", required=True,
+                        help="QMT root, its bin.x64, or a path to an exe inside it")
+    parser.add_argument("--mode", default="auto",
+                        choices=("auto", "bat", "linkmini", "exe", "login"))
+    parser.add_argument("--bat", default=None, help="batch file for --mode bat")
+    parser.add_argument("--exe", default=None, help="exe name for --mode exe/login")
+    parser.add_argument("--port", type=int, default=DEFAULT_READY_PORT)
+    parser.add_argument("--timeout", type=float, default=180.0)
+    parser.add_argument("--no-wait", action="store_true")
+    parser.add_argument("--title-prefix", default=None,
+                        help="login window title prefix (--mode login)")
+    args = parser.parse_args(argv)
+
+    if args.action == "status":
+        procs = find_qmt_processes(args.dir)
+        if not procs:
+            print("not running (%s)" % resolve_install_dir(args.dir))
+            return 1
+        for pid, name, exe in procs:
+            print("%-16s pid=%-8s %s" % (name, pid, exe))
+        print("ready port %d: %s" % (
+            args.port, "listening" if port_is_listening(args.port) else "not listening"))
+        return 0
+
+    credentials = None
+    if args.mode == "login":
+        # Read from the environment so a password never reaches argv, where it
+        # would be visible to any process listing.
+        credentials = {"user": os.environ.get("BIGQMT_LOGIN_USER", ""),
+                       "password": os.environ.get("BIGQMT_LOGIN_PASSWORD", "")}
+
+    try:
+        if args.action == "close":
+            print("closed %d process(es)" % close_qmt(args.dir))
+        else:
+            kwargs = dict(mode=args.mode, bat_path=args.bat, exe_name=args.exe,
+                          ready_port=args.port, ready_timeout_seconds=args.timeout,
+                          wait_ready=not args.no_wait, credentials=credentials,
+                          window_title_prefix=args.title_prefix)
+            if args.action == "restart":
+                restart_qmt(args.dir, **kwargs)
+            else:
+                open_qmt(args.dir, **kwargs)
+            print("ok")
+    except QmtLauncherError as exc:
+        print("error: %s" % exc, file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -405,6 +405,12 @@ class BigQmtRpcHandlers:
         requested_method = str(method or "").strip()
         method = self._canonical_method(requested_method)
         params = dict(params or {})
+        # Clear the diagnostic slot per request. It is instance state read by
+        # EVERY response (see _build_response), so without this a single failed
+        # submit_order stamps its server_error onto every later ping/query until
+        # the next order runs -- reporting a stale failure on requests that
+        # succeeded (issue #43).
+        self._last_server_error = ""
         if not requested_method:
             raise ValueError("method is required")
         if method not in self.allowed_methods:
@@ -866,7 +872,8 @@ class BigQmtRpcHandlers:
         result = self.order_gateway.submit(request)
 
         # 委托后校验：确认委托是否真的进了系统。passorder 调用成功但委托没进
-        # 系统时（静默失败），记录 server_error 让客户端知道。
+        # 系统时（静默失败），记录 server_error 让客户端知道。匹配严格按
+        # user_order_id(remark) 精确比对，不做 stock_code+action 的模糊兜底。
         # QMT 的委托号是异步分配的（passorder 无返回值），这里按唯一
         # user_order_id(remark) 精确匹配并回填 order_sys_id，避免客户端把
         # 「已提交但暂无委托号」误判为下单失败（issue #38）。
@@ -886,11 +893,13 @@ class BigQmtRpcHandlers:
                         result.order_sys_id = sysid
                     except Exception:
                         pass
-            elif not any(
-                str(getattr(o, "stock_code", "") or "").upper() == request.stock_code.upper()
-                and str(getattr(o, "action", "") or "").upper() == request.action.upper()
-                for o in orders
-            ):
+            else:
+                # No remark match -> the order is not in the system. Do NOT fall
+                # back to matching stock_code+action: order_tag is a unique id we
+                # generated, so a miss is always a real miss, while an unrelated
+                # order on the same stock and side (a manual one, or an earlier
+                # unfilled order) would silently suppress this warning and leave
+                # order_sys_id unfilled with no signal at all (issue #41).
                 self._last_server_error = (
                     "passorder submitted but order not found in system "
                     "(stock=%s action=%s price=%.2f volume=%d). "

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -21,6 +21,11 @@ from .code_utils import normalize_stock_code
 from .models import AccountSnapshot, OrderRef, OrderRequest
 
 
+# time.monotonic: unaffected by wall-clock jumps, so a settle deadline
+# survives an NTP correction mid-session. Python 3.3+, fine on QMT's 3.6.
+_monotonic = time.monotonic
+
+
 RPC_REVISION = "20260715-execution-snapshot-v1"
 
 
@@ -351,6 +356,33 @@ def to_jsonable(value):
     return str(value)
 
 
+class OrderSettlement(object):
+    """One order awaiting its order_sys_id.
+
+    Why this cannot simply run on a background thread: get_trade_detail_data
+    returns EMPTY off the main strategy thread (see LISTENER_DEFERRED_METHODS),
+    so a background poll would find nothing and report every order as silently
+    rejected. The retries have to happen on the adjust thread -- just without
+    holding it.
+
+    server_error is carried here rather than on handlers._last_server_error:
+    that slot belongs to whichever request is in flight, and settling writes to
+    it long after this request left the handler (issue #43).
+    """
+
+    __slots__ = ("order_request", "result", "deadline", "attempts", "server_error",
+                 "request", "response")
+
+    def __init__(self, order_request, result, deadline):
+        self.order_request = order_request
+        self.result = result
+        self.deadline = deadline
+        self.attempts = 0
+        self.server_error = ""
+        self.request = None
+        self.response = None
+
+
 class BigQmtRpcHandlers:
     """Whitelisted RPC method handlers backed by replaceable adapters."""
 
@@ -364,6 +396,8 @@ class BigQmtRpcHandlers:
         allow_order_methods=False,
         allowed_methods=None,
         qmt_api=None,
+        settle_orders_inline=False,
+        order_settle_timeout_seconds=3.0,
         quote_subscription_manager=None,
     ):
         self.account_id = str(account_id or "")
@@ -377,6 +411,12 @@ class BigQmtRpcHandlers:
         # 融资融券查询等)。由 strategy._build_config 解析注入。
         self.qmt_api = dict(qmt_api or {})
         self._submit_journal = {}
+        # Order settlement. Async by default: blocking here holds the QMT main
+        # strategy thread, which serializes every other request behind it and
+        # caps throughput at ~2 orders/sec (issue #44).
+        self._pending_settlement = None
+        self.settle_orders_inline = bool(settle_orders_inline)
+        self.order_settle_timeout_seconds = float(order_settle_timeout_seconds)
         # Server-side diagnostic for silent failures (e.g. passorder submitted
         # but order not found in system). Surfaced to client via server_error.
         self._last_server_error = ""
@@ -411,6 +451,7 @@ class BigQmtRpcHandlers:
         # the next order runs -- reporting a stale failure on requests that
         # succeeded (issue #43).
         self._last_server_error = ""
+        self._pending_settlement = None
         if not requested_method:
             raise ValueError("method is required")
         if method not in self.allowed_methods:
@@ -878,9 +919,40 @@ class BigQmtRpcHandlers:
         # user_order_id(remark) 精确匹配并回填 order_sys_id，避免客户端把
         # 「已提交但暂无委托号」误判为下单失败（issue #38）。
         self._last_server_error = ""
+        if self.settle_orders_inline:
+            # Opt-out: block here the way this used to. Kept only for runtimes
+            # with no adjust drain to retry on.
+            try:
+                import time as _time
+                _time.sleep(self.order_settle_timeout_seconds)
+                self._apply_order_lookup(
+                    OrderSettlement(request, result, 0.0), final=True, inline=True)
+            except Exception:
+                pass
+            return result
+        # Hand the settlement to the caller rather than raising: handle() stays
+        # a plain function for anyone driving handlers directly, and only the
+        # service defers its reply.
+        self._pending_settlement = OrderSettlement(
+            request, result, _monotonic() + self.order_settle_timeout_seconds
+        )
+        return result
+
+    def take_pending_settlement(self):
+        """Pop the settlement the last submit_order registered, if any."""
+        settlement = self._pending_settlement
+        self._pending_settlement = None
+        return settlement
+
+    def _apply_order_lookup(self, settlement, final=False, inline=False):
+        """Look the order up by remark. True when settled, False to retry.
+
+        MUST run on the main strategy thread -- get_trade_detail_data returns
+        empty anywhere else.
+        """
+        request = settlement.order_request
+        settlement.attempts += 1
         try:
-            import time as _time
-            _time.sleep(0.5)  # 给 QMT 处理委托的时间
             orders = self.order_gateway.query_orders(request.account_id, "") or []
             by_remark = [
                 o for o in orders
@@ -890,26 +962,34 @@ class BigQmtRpcHandlers:
                 sysid = str(getattr(by_remark[0], "order_sys_id", "") or "")
                 if sysid:
                     try:
-                        result.order_sys_id = sysid
+                        settlement.result.order_sys_id = sysid
                     except Exception:
                         pass
-            else:
-                # No remark match -> the order is not in the system. Do NOT fall
-                # back to matching stock_code+action: order_tag is a unique id we
-                # generated, so a miss is always a real miss, while an unrelated
-                # order on the same stock and side (a manual one, or an earlier
-                # unfilled order) would silently suppress this warning and leave
-                # order_sys_id unfilled with no signal at all (issue #41).
-                self._last_server_error = (
-                    "passorder submitted but order not found in system "
-                    "(stock=%s action=%s price=%.2f volume=%d). "
-                    "QMT may have silently rejected it (check price range / permissions)."
-                    % (request.stock_code, request.action, request.price, request.volume)
-                )
+                return True
+            if not final:
+                # Not there yet. QMT assigns the id asynchronously, so an early
+                # miss is normal -- only a miss at the deadline is a real one.
+                return False
+            # Deadline reached with no remark match -> not in the system. Do NOT
+            # fall back to matching stock_code+action: order_tag is a unique id
+            # we generated, so a miss is always a real miss, while an unrelated
+            # order on the same stock and side (a manual one, or an earlier
+            # unfilled order) would silently suppress this warning and leave
+            # order_sys_id unfilled with no signal at all (issue #41).
+            message = (
+                "passorder submitted but order not found in system "
+                "(stock=%s action=%s price=%.2f volume=%d, %d lookup(s)). "
+                "QMT may have silently rejected it (check price range / permissions)."
+                % (request.stock_code, request.action, request.price,
+                   request.volume, settlement.attempts)
+            )
+            settlement.server_error = message
+            if inline:
+                self._last_server_error = message
+            return True
         except Exception:
-            # 校验失败不影响主流程（委托已提交）
-            pass
-        return result
+            # A failed lookup must not lose the order -- it is already submitted.
+            return True
 
     def _handle_submit_orders_batch(self, params):
         orders = params.get("orders") or []
@@ -1130,6 +1210,10 @@ class RedisPubSubRpcService:
         self._deferred_count = 0
         self.print_prefix = print_prefix
         self.pending = queue.Queue(maxsize=int(max_queue_size))
+        # Orders whose reply is waiting on QMT assigning an order id. Unbounded
+        # on purpose: every entry is an order that already reached the broker,
+        # so dropping one would strand a live order with no reply.
+        self._pending_settlements = queue.Queue()
         self._running = threading.Event()
         self._thread = None
         self._queue_thread = None
@@ -1319,7 +1403,53 @@ class RedisPubSubRpcService:
             raise ValueError("rpc payload must be a json object")
         return payload
 
+    def settle_pending_orders(self, max_items=100):
+        """Retry parked order lookups. MUST be called from the adjust thread.
+
+        A queue rather than a list because rpc_listener_methods is configurable:
+        if submit_order is ever put in it, the producer becomes the listener
+        thread while this consumer stays on adjust.
+
+        Unsettled entries go back on the queue, so each order costs one lookup
+        per adjust tick until it resolves or its deadline passes.
+        """
+        settled = 0
+        # Snapshot the size first. Unsettled entries go back on the same queue,
+        # so draining until empty would keep re-picking them and spin one adjust
+        # tick into many lookups per order.
+        batch = min(int(max_items), self._pending_settlements.qsize())
+        for _ in range(batch):
+            try:
+                settlement = self._pending_settlements.get_nowait()
+            except queue.Empty:
+                break
+            expired = _monotonic() >= settlement.deadline
+            try:
+                done = self.handlers._apply_order_lookup(settlement, final=expired)
+            except Exception:
+                done = True  # never strand a submitted order in the queue
+            if not done:
+                self._pending_settlements.put(settlement)
+                continue
+            response = settlement.response
+            response["data"] = to_jsonable(settlement.result)
+            response["ok"] = True
+            if settlement.server_error:
+                response["server_error"] = settlement.server_error
+            response["handled_at"] = _dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            try:
+                self._publish_response(settlement.request, response)
+            except Exception:
+                pass
+            settled += 1
+        return settled
+
+    def pending_settlement_count(self):
+        return self._pending_settlements.qsize()
+
     def drain_pending(self, max_items=20):
+        # Settle carry-overs from earlier ticks before taking on new work.
+        self.settle_pending_orders()
         processed = 0
         for _ in range(int(max_items)):
             try:
@@ -1333,6 +1463,10 @@ class RedisPubSubRpcService:
                 )
             self.process_request(request)
             processed += 1
+        # Settle again so an order submitted in THIS drain still replies on this
+        # tick. One lookup, no sleep -- if QMT has not assigned the id yet we
+        # simply retry next tick rather than holding the thread (issue #44).
+        self.settle_pending_orders()
         return processed
 
     def drain_request_queue(self, max_items=20):
@@ -1381,6 +1515,17 @@ class RedisPubSubRpcService:
             server_error = getattr(self.handlers, "_last_server_error", None)
             if server_error:
                 response["server_error"] = str(server_error)
+            # passorder already ran, but QMT assigns the order id asynchronously.
+            # Park the reply instead of sleeping on this thread; a later adjust
+            # tick settles and publishes it (issue #44).
+            take = getattr(self.handlers, "take_pending_settlement", None)
+            settlement = take() if callable(take) else None
+            if settlement is not None:
+                settlement.request = request
+                settlement.response = response
+                self._pending_settlements.put(settlement)
+                self._deferred_count += 1
+                return response
         except Exception as exc:
             response["error"] = "%s: %s" % (exc.__class__.__name__, exc)
         try:

--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -398,6 +398,11 @@ def _build_rpc_service(context_info, app, config):
         allow_order_methods=allow_order_methods,
         allowed_methods=rpc_config.get("allowed_methods"),
         qmt_api=qmt_api,
+        # Async settlement keeps passorder off the adjust thread's critical
+        # path; set rpc_settle_orders_inline=True only for a runtime with no
+        # adjust drain to retry on.
+        settle_orders_inline=_config_bool(rpc_config.get("settle_orders_inline"), False),
+        order_settle_timeout_seconds=float(rpc_config.get("order_settle_timeout_seconds", 3.0)),
         quote_subscription_manager=quote_manager,
     )
     handlers.download_job_redis_client = response_redis_client or redis_client
@@ -577,6 +582,62 @@ def _schedule_adjust_if_needed(context_info, config):
         )
 
 
+# Where each adjust() call came from, and what tick_app actually costs.
+# The question this answers: handlebar is documented as tick-driven in live
+# trading, but the observed cadence is a flat ~50/10s -- exactly the run_time
+# timer and nothing else. Splitting the counters shows whether handlebar fires
+# at all once the historical replay ends, and the tick_app histogram shows what
+# it would cost to let it drive the strategy body rather than just the drain.
+_adjust_source_stats = {"handlebar": 0, "timer": 0, "window_start": 0.0}
+# Bucket upper bounds in ms; the last bucket is everything above.
+_TICK_APP_BUCKETS = (1, 5, 20, 50, 100, 250, 500, 1000, 2000)
+_tick_app_hist = [0] * (len(_TICK_APP_BUCKETS) + 1)
+_tick_app_max_ms = [0.0]
+
+
+def _record_adjust_source(source):
+    """Count adjust() calls per trigger source, logged on the cadence window."""
+    stats = _adjust_source_stats
+    now = time.time()
+    if stats["window_start"] <= 0:
+        stats["window_start"] = now
+    stats[source] = stats.get(source, 0) + 1
+    if now - stats["window_start"] >= 10.0:
+        print(
+            "[adjust_source] handlebar=%d timer=%d over %.0fs"
+            % (stats["handlebar"], stats["timer"], now - stats["window_start"])
+        )
+        stats.update({"handlebar": 0, "timer": 0, "window_start": now})
+
+
+def _record_tick_app_ms(ms):
+    """Histogram of tick_app cost.
+
+    tick_app is the expensive half of adjust() and is skipped while
+    is_last_bar() is False, so the replay-time cost (~0.2ms/call) says nothing
+    about what it costs at the live edge. Before letting ticks drive it we need
+    the real distribution, not just the >50ms outliers the phase logger prints.
+    """
+    for index, bound in enumerate(_TICK_APP_BUCKETS):
+        if ms <= bound:
+            _tick_app_hist[index] += 1
+            break
+    else:
+        _tick_app_hist[-1] += 1
+    if ms > _tick_app_max_ms[0]:
+        _tick_app_max_ms[0] = ms
+
+
+def _format_tick_app_hist():
+    labels = []
+    previous = 0
+    for index, bound in enumerate(_TICK_APP_BUCKETS):
+        labels.append("%d-%dms=%d" % (previous, bound, _tick_app_hist[index]))
+        previous = bound
+    labels.append(">%dms=%d" % (_TICK_APP_BUCKETS[-1], _tick_app_hist[-1]))
+    return " ".join(labels)
+
+
 def _record_adjust_tick():
     """Track and periodically log the real interval between adjust triggers."""
     stats = _adjust_tick_stats
@@ -597,6 +658,9 @@ def _record_adjust_tick():
             "[bigqmt_signal_trader] adjust cadence: ticks=%d avg=%.3fs min=%.3fs max=%.3fs over %.0fs"
             % (stats["count"], avg, stats["min"], stats["max"], now - stats["window_start"])
         )
+        if sum(_tick_app_hist) > 0:
+            print("[tick_app_hist] %s max=%.0fms"
+                  % (_format_tick_app_hist(), _tick_app_max_ms[0]))
         stats.update({"count": 0, "sum": 0.0, "min": 0.0, "max": 0.0, "window_start": now})
 
 
@@ -716,6 +780,46 @@ def _log_err(tag, message):
         pass
 
 
+def _diag_bar_driver(context_info):
+    """Report what drives handlebar: the strategy's own symbol, period, and
+    whether any quote subscription exists.
+
+    handlebar is documented as firing per incoming tick in live trading, but it
+    goes quiet here once the historical replay ends. This strategy never calls
+    subscribe_quote / subscribe_whole_quote / set_universe, so the leading
+    suspect is that nothing is feeding it ticks. Print what QMT actually has so
+    the next live session settles it instead of us guessing.
+    """
+    fields = (
+        ("stockcode", "品种"),
+        ("stock_code", "品种(alt)"),
+        ("period", "周期"),
+        ("do_back_test", "回测模式"),
+        ("start", "起始"),
+        ("end", "结束"),
+    )
+    parts = []
+    for name, label in fields:
+        try:
+            value = getattr(context_info, name, None)
+            if callable(value):
+                value = value()
+            if value not in (None, ""):
+                parts.append("%s=%s" % (label, value))
+        except Exception:
+            continue
+    print("[bigqmt_diag] bar driver: %s" % (" ".join(parts) or "<无法读取>"))
+
+    for name in ("subscribe_quote", "subscribe_whole_quote", "set_universe", "is_last_bar"):
+        print("[bigqmt_diag]   %-22s %s"
+              % (name, "可用" if callable(getattr(context_info, name, None)) else "不可用"))
+    try:
+        print("[bigqmt_diag]   is_last_bar() 当前值    %s" % context_info.is_last_bar())
+    except Exception as exc:
+        print("[bigqmt_diag]   is_last_bar() 调用失败  %s" % exc)
+    print("[bigqmt_diag]   本策略未订阅任何行情 -> handlebar 预计仅由历史回放驱动")
+
+
 def _diag_startup(ContextInfo, config):
     """Startup diagnostics: check service status and key function bindings.
 
@@ -726,6 +830,8 @@ def _diag_startup(ContextInfo, config):
     print("=" * 60)
     print("[bigqmt_diag] startup diagnostics")
     print("=" * 60)
+
+    _diag_bar_driver(ContextInfo)
 
     # 1. RPC service status
     rpc_config = dict(config.get("rpc") or {})
@@ -819,9 +925,10 @@ def _adjust_phase(name, fn, *args):
             print("[adjust_phase] %s %.0fms" % (name, ms))
 
 
-def adjust(ContextInfo):
+def adjust(ContextInfo, _source="timer"):
     global _adjust_logged
     _record_adjust_tick()
+    _record_adjust_source(_source)
     config = _build_config()
     _adjust_phase("drain", _drain_rpc_service, config)
     _adjust_phase("full_tick", _refresh_full_tick_cache, ContextInfo, config)
@@ -834,12 +941,25 @@ def adjust(ContextInfo):
     if not _adjust_logged:
         print("[bigqmt_signal_trader] adjust ok")
         _adjust_logged = True
-    return _adjust_phase("tick_app", tick_app, ContextInfo, datetime.datetime.now())
+    _tick_app_t0 = time.perf_counter()
+    try:
+        return _adjust_phase("tick_app", tick_app, ContextInfo, datetime.datetime.now())
+    finally:
+        # Every call, not just the >50ms ones _adjust_phase prints: deciding
+        # whether ticks may drive this needs the whole distribution.
+        _record_tick_app_ms((time.perf_counter() - _tick_app_t0) * 1000.0)
 
 
 def handlebar(ContextInfo):
-    """Standard Big QMT bar callback."""
-    return adjust(ContextInfo)
+    """Standard Big QMT bar callback.
+
+    Documented as tick-driven during live trading ("再在每个tick数据来后驱动运行
+    一次"), but the observed cadence is a flat ~50/10s -- the run_time timer
+    alone. Tagging the source tells us whether this ever fires once the
+    historical replay ends; the strategy subscribes to no quote, which is the
+    leading suspect.
+    """
+    return adjust(ContextInfo, _source="handlebar")
 
 
 def _exec_event_redis(config):

--- a/tests/bigqmt_signal_trader/test_qmt_launcher.py
+++ b/tests/bigqmt_signal_trader/test_qmt_launcher.py
@@ -1,0 +1,231 @@
+# coding: utf-8
+"""qmt_launcher tests (issue #45).
+
+The property that matters most is directory scoping: this machine runs several
+QMT installs side by side, so a name-only match would stop the wrong account's
+terminal. Process enumeration is stubbed so the tests never touch real ones.
+"""
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader import qmt_launcher
+from bigqmt_signal_trader.qmt_launcher import (
+    QmtLauncherError,
+    close_qmt,
+    find_qmt_processes,
+    is_qmt_running,
+    resolve_install_dir,
+)
+
+
+LEMO = os.path.normpath("D:/qmt_lemo/bin.x64")
+OTHER = os.path.normpath("D:/qmt_other/bin.x64")
+
+FAKE_PROCESSES = [
+    (100, "XtItClient.exe", os.path.join(LEMO, "XtItClient.exe")),
+    (101, "miniquote.exe", os.path.join(LEMO, "miniquote.exe")),
+    (200, "XtItClient.exe", os.path.join(OTHER, "XtItClient.exe")),  # another account
+    (300, "notepad.exe", os.path.join(LEMO, "notepad.exe")),         # not ours
+    (400, "XtItClient.exe", ""),                                     # unreadable path
+]
+
+
+class ProcessStub(object):
+    """Patch process enumeration and record what gets terminated."""
+
+    def __init__(self, processes=None):
+        self.processes = list(FAKE_PROCESSES if processes is None else processes)
+        self.terminated = []
+        self._orig_iter = None
+        self._orig_term = None
+        self._orig_isdir = None
+
+    def __enter__(self):
+        self._orig_iter = qmt_launcher._iter_processes
+        self._orig_term = qmt_launcher._terminate
+        self._orig_isdir = os.path.isdir
+
+        def _terminate(pid, force=False):
+            self.terminated.append((pid, force))
+            self.processes = [p for p in self.processes if p[0] != pid]
+            return True
+
+        qmt_launcher._iter_processes = lambda: list(self.processes)
+        qmt_launcher._terminate = _terminate
+        os.path.isdir = lambda p: True
+        return self
+
+    def __exit__(self, *exc):
+        qmt_launcher._iter_processes = self._orig_iter
+        qmt_launcher._terminate = self._orig_term
+        os.path.isdir = self._orig_isdir
+        return False
+
+
+class ResolveInstallDirTest(unittest.TestCase):
+    def test_accepts_root_bin_and_exe_paths(self):
+        expected = os.path.normpath("D:/qmt_lemo/bin.x64")
+        orig = os.path.isdir
+        os.path.isdir = lambda p: os.path.basename(os.path.normpath(p)).lower() == "bin.x64"
+        try:
+            for given in ("D:/qmt_lemo", "D:/qmt_lemo/bin.x64",
+                          "D:/qmt_lemo/bin.x64/XtItClient.exe"):
+                self.assertEqual(os.path.normpath(resolve_install_dir(given)), expected, given)
+        finally:
+            os.path.isdir = orig
+
+    def test_strips_surrounding_quotes(self):
+        self.assertTrue(resolve_install_dir('"D:/qmt_lemo/bin.x64"').endswith("bin.x64"))
+
+    def test_empty_is_rejected(self):
+        for value in ("", None, "   "):
+            with self.assertRaises(QmtLauncherError):
+                resolve_install_dir(value)
+
+
+class FindProcessesTest(unittest.TestCase):
+    def test_only_matches_the_requested_install(self):
+        with ProcessStub():
+            pids = sorted(p[0] for p in find_qmt_processes("D:/qmt_lemo"))
+        self.assertEqual(pids, [100, 101])  # not 200 (other install)
+
+    def test_other_install_is_found_independently(self):
+        with ProcessStub():
+            pids = sorted(p[0] for p in find_qmt_processes("D:/qmt_other"))
+        self.assertEqual(pids, [200])
+
+    def test_ignores_unrelated_process_names(self):
+        with ProcessStub():
+            names = [p[1] for p in find_qmt_processes("D:/qmt_lemo")]
+        self.assertNotIn("notepad.exe", names)
+
+    def test_skips_processes_with_no_readable_path(self):
+        """Matching a QMT name with an unknown path would be a coin flip on
+        which install it belongs to -- skip rather than guess."""
+        with ProcessStub():
+            pids = [p[0] for p in find_qmt_processes("D:/qmt_lemo")]
+        self.assertNotIn(400, pids)
+
+    def test_is_qmt_running_reflects_scope(self):
+        with ProcessStub():
+            self.assertTrue(is_qmt_running("D:/qmt_lemo"))
+            self.assertFalse(is_qmt_running("D:/qmt_unused"))
+
+
+class CloseQmtTest(unittest.TestCase):
+    def test_closes_only_the_requested_install(self):
+        with ProcessStub() as stub:
+            closed = close_qmt("D:/qmt_lemo")
+        self.assertEqual(closed, 2)
+        self.assertEqual(sorted(pid for pid, _ in stub.terminated), [100, 101])
+        self.assertNotIn(200, [pid for pid, _ in stub.terminated])
+
+    def test_terminates_gracefully_before_forcing(self):
+        """A hard kill skips the terminal's data flush and truncates the
+        local K-line store."""
+        with ProcessStub() as stub:
+            close_qmt("D:/qmt_lemo")
+        self.assertTrue(all(force is False for _, force in stub.terminated))
+
+    def test_escalates_to_force_when_terminate_is_ignored(self):
+        with ProcessStub() as stub:
+            def _stubborn(pid, force=False):
+                stub.terminated.append((pid, force))
+                if force:
+                    stub.processes = [p for p in stub.processes if p[0] != pid]
+                return True
+
+            qmt_launcher._terminate = _stubborn
+            close_qmt("D:/qmt_lemo", timeout_seconds=6.0, force_after_seconds=1.0)
+
+        self.assertTrue(any(force for _, force in stub.terminated))
+
+    def test_no_processes_is_not_an_error(self):
+        with ProcessStub(processes=[]):
+            self.assertEqual(close_qmt("D:/qmt_lemo"), 0)
+
+
+class ReadinessTest(unittest.TestCase):
+    def test_wait_until_ready_raises_on_timeout(self):
+        """A scheduled restart must fail loudly, not hand the next step a
+        terminal that never came up."""
+        orig = qmt_launcher.port_is_listening
+        qmt_launcher.port_is_listening = lambda *a, **k: False
+        try:
+            with self.assertRaises(QmtLauncherError):
+                qmt_launcher.wait_until_ready(port=1, timeout_seconds=0.3, poll_interval=0.1)
+        finally:
+            qmt_launcher.port_is_listening = orig
+
+    def test_wait_until_ready_returns_elapsed_seconds(self):
+        orig = qmt_launcher.port_is_listening
+        qmt_launcher.port_is_listening = lambda *a, **k: True
+        try:
+            self.assertIsInstance(
+                qmt_launcher.wait_until_ready(port=1, timeout_seconds=5.0), float)
+        finally:
+            qmt_launcher.port_is_listening = orig
+
+
+class OpenQmtTest(unittest.TestCase):
+    def _stub_spawn(self):
+        calls = []
+        orig_spawn = qmt_launcher._spawn
+        orig_ready = qmt_launcher.wait_until_ready
+        qmt_launcher._spawn = lambda cmd, cwd=None, shell=False: calls.append((cmd, cwd, shell))
+        qmt_launcher.wait_until_ready = lambda *a, **k: 1.0
+        return calls, orig_spawn, orig_ready
+
+    def test_linkmini_mode_passes_the_passwordless_flag(self):
+        calls, orig_spawn, orig_ready = self._stub_spawn()
+        orig_isdir, orig_isfile = os.path.isdir, os.path.isfile
+        os.path.isdir = lambda p: True
+        os.path.isfile = lambda p: p.lower().endswith("xtminiqmt.exe")
+        try:
+            qmt_launcher.open_qmt("D:/qmt_lemo", mode="linkmini")
+        finally:
+            qmt_launcher._spawn, qmt_launcher.wait_until_ready = orig_spawn, orig_ready
+            os.path.isdir, os.path.isfile = orig_isdir, orig_isfile
+
+        self.assertEqual(len(calls), 1)
+        self.assertIn("linkMini", calls[0][0])
+
+    def test_login_mode_without_credentials_is_rejected(self):
+        calls, orig_spawn, orig_ready = self._stub_spawn()
+        orig_isdir, orig_isfile = os.path.isdir, os.path.isfile
+        os.path.isdir = lambda p: True
+        os.path.isfile = lambda p: True
+        try:
+            with self.assertRaises(QmtLauncherError):
+                qmt_launcher.open_qmt("D:/qmt_lemo", mode="login", credentials={})
+        finally:
+            qmt_launcher._spawn, qmt_launcher.wait_until_ready = orig_spawn, orig_ready
+            os.path.isdir, os.path.isfile = orig_isdir, orig_isfile
+
+    def test_unknown_mode_is_rejected(self):
+        orig = os.path.isdir
+        os.path.isdir = lambda p: True
+        try:
+            with self.assertRaises(QmtLauncherError):
+                qmt_launcher.open_qmt("D:/qmt_lemo", mode="teleport")
+        finally:
+            os.path.isdir = orig
+
+    def test_bat_mode_requires_an_existing_bat(self):
+        orig = os.path.isdir
+        os.path.isdir = lambda p: True
+        try:
+            with self.assertRaises(QmtLauncherError):
+                qmt_launcher.open_qmt("D:/qmt_lemo", mode="bat", bat_path="D:/nope.bat")
+        finally:
+            os.path.isdir = orig
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_redis_rpc.py
+++ b/tests/bigqmt_signal_trader/test_redis_rpc.py
@@ -1,4 +1,5 @@
 import json
+import time
 import os
 import sys
 import unittest
@@ -82,6 +83,9 @@ def _service_with_listener_methods(allow_order_methods=False, process_in_listene
         position_provider=FakePositionProvider(),
         order_gateway=order_gateway,
         allow_order_methods=allow_order_methods,
+        # DryRunOrderGateway never registers an order, so retrying until the
+        # deadline would just stall every test by the full timeout.
+        order_settle_timeout_seconds=0.0,
     )
     return redis_client, RedisPubSubRpcService(
         redis_client,
@@ -205,8 +209,144 @@ def _service_with_order_gateway(order_gateway, allow_order_methods=False):
         position_provider=FakePositionProvider(),
         order_gateway=order_gateway,
         allow_order_methods=allow_order_methods,
+        order_settle_timeout_seconds=0.0,
     )
     return redis_client, RedisPubSubRpcService(redis_client, handlers, account_id="acct")
+
+
+class LateLandingOrderGateway(DryRunOrderGateway):
+    """QMT assigns the order id asynchronously: the order only becomes visible
+    after ``appear_after`` lookups."""
+
+    def __init__(self, appear_after=2, never=False):
+        super().__init__()
+        self.appear_after = appear_after
+        self.never = never
+        self.lookups = 0
+        self._request = None
+
+    def submit(self, request):
+        self._request = request
+        return super().submit(request)
+
+    def query_orders(self, account_id, strategy_name):
+        self.lookups += 1
+        if self.never or self.lookups < self.appear_after or self._request is None:
+            return []
+        return [
+            OrderSnapshot(
+                order_sys_id="sysid-late",
+                user_order_id=str(self._request.remark or ""),
+                stock_code=self._request.stock_code,
+                action=self._request.action,
+                volume=self._request.volume,
+                traded_volume=0,
+                status="50",
+            )
+        ]
+
+
+class AsyncOrderSettlementTest(unittest.TestCase):
+    """issue #44: passorder must not hold the QMT adjust thread.
+
+    The old path slept 0.5s inline, serializing every other request behind each
+    order and capping throughput at ~2 orders/sec.
+    """
+
+    def _service(self, gateway, timeout=5.0):
+        redis_client = FakeRedis()
+        handlers = BigQmtRpcHandlers(
+            account_id="acct", market_data=FakeMarketData(),
+            position_provider=FakePositionProvider(), order_gateway=gateway,
+            allow_order_methods=True, order_settle_timeout_seconds=timeout,
+        )
+        return redis_client, RedisPubSubRpcService(redis_client, handlers, account_id="acct")
+
+    def _submit(self, service, request_id="ord-1"):
+        service.enqueue_payload({
+            "request_id": request_id, "account_id": "acct", "method": "order_stock",
+            "params": {"stock_code": "600000.SH", "order_type": 23, "order_volume": 100,
+                       "price_type": 11, "price": 10.1, "order_remark": request_id},
+        })
+
+    def test_drain_does_not_sleep_waiting_for_the_order_id(self):
+        """The whole point: no 0.5s block on the adjust thread."""
+        gateway = LateLandingOrderGateway(appear_after=99)
+        redis_client, service = self._service(gateway)
+        self._submit(service)
+
+        started = time.monotonic()
+        service.drain_pending()
+        elapsed = time.monotonic() - started
+
+        self.assertLess(elapsed, 0.2, "drain blocked for %.3fs" % elapsed)
+
+    def test_unresolved_order_is_parked_not_answered(self):
+        gateway = LateLandingOrderGateway(appear_after=99)
+        redis_client, service = self._service(gateway)
+        self._submit(service)
+        service.drain_pending()
+
+        self.assertNotIn("bigqmt:rpc:resp:acct:ord-1", redis_client.kv)
+        self.assertEqual(service.pending_settlement_count(), 1)
+
+    def test_later_tick_settles_and_backfills_the_sysid(self):
+        gateway = LateLandingOrderGateway(appear_after=3)
+        redis_client, service = self._service(gateway)
+        self._submit(service)
+
+        for _ in range(5):
+            service.drain_pending()
+            if "bigqmt:rpc:resp:acct:ord-1" in redis_client.kv:
+                break
+
+        response = json.loads(redis_client.kv["bigqmt:rpc:resp:acct:ord-1"])
+        self.assertTrue(response["ok"], response["error"])
+        self.assertEqual(response["data"]["order_sys_id"], "sysid-late")
+        self.assertEqual(response["server_error"], "")
+        self.assertEqual(service.pending_settlement_count(), 0)
+
+    def test_order_that_never_lands_reports_after_the_deadline(self):
+        gateway = LateLandingOrderGateway(never=True)
+        redis_client, service = self._service(gateway, timeout=0.0)
+        self._submit(service)
+        service.drain_pending()
+
+        response = json.loads(redis_client.kv["bigqmt:rpc:resp:acct:ord-1"])
+        self.assertTrue(response["ok"])
+        self.assertIn("not found in system", response["server_error"])
+
+    def test_settlement_error_does_not_leak_into_other_responses(self):
+        """issue #43 again, by another route: settling happens long after the
+        order left the handler, so its diagnostic must ride on the settlement
+        rather than handlers._last_server_error."""
+        gateway = LateLandingOrderGateway(never=True)
+        redis_client, service = self._service(gateway, timeout=0.0)
+        self._submit(service)
+        service.drain_pending()
+        self.assertIn("not found in system",
+                      json.loads(redis_client.kv["bigqmt:rpc:resp:acct:ord-1"])["server_error"])
+
+        service.enqueue_payload({"request_id": "later-ping", "account_id": "acct",
+                                 "method": "ping", "params": {}})
+        service.drain_pending()
+
+        self.assertEqual(
+            json.loads(redis_client.kv["bigqmt:rpc:resp:acct:later-ping"])["server_error"], "")
+
+    def test_many_orders_drain_without_accumulating_delay(self):
+        """Throughput was the reported symptom: 0.5s per order serialized."""
+        gateway = LateLandingOrderGateway(appear_after=99)
+        redis_client, service = self._service(gateway)
+        for i in range(20):
+            self._submit(service, request_id="ord-%d" % i)
+
+        started = time.monotonic()
+        service.drain_pending(max_items=50)
+        elapsed = time.monotonic() - started
+
+        self.assertLess(elapsed, 1.0, "20 orders took %.2fs" % elapsed)
+        self.assertEqual(service.pending_settlement_count(), 20)
 
 
 class RedisRpcTest(unittest.TestCase):
@@ -286,6 +426,10 @@ class RedisRpcTest(unittest.TestCase):
             account_id="acct", market_data=FakeMarketData(),
             position_provider=FakePositionProvider(), order_gateway=gateway,
             allow_order_methods=True,
+            # Drive the lookup synchronously so these assertions stay about the
+            # matching logic, not about when the settle pass runs.
+            settle_orders_inline=True,
+            order_settle_timeout_seconds=0.0,
         )
         result = handlers.handle("order_stock", {
             "account_id": "acct", "stock_code": "600000.SH", "order_type": 23,
@@ -302,6 +446,10 @@ class RedisRpcTest(unittest.TestCase):
             account_id="acct", market_data=FakeMarketData(),
             position_provider=FakePositionProvider(), order_gateway=gateway,
             allow_order_methods=True,
+            # Drive the lookup synchronously so these assertions stay about the
+            # matching logic, not about when the settle pass runs.
+            settle_orders_inline=True,
+            order_settle_timeout_seconds=0.0,
         )
         result = handlers.handle("order_stock", {
             "account_id": "acct", "stock_code": "600000.SH", "order_type": 23,
@@ -319,6 +467,10 @@ class RedisRpcTest(unittest.TestCase):
             account_id="acct", market_data=FakeMarketData(),
             position_provider=FakePositionProvider(), order_gateway=gateway,
             allow_order_methods=True,
+            # Drive the lookup synchronously so these assertions stay about the
+            # matching logic, not about when the settle pass runs.
+            settle_orders_inline=True,
+            order_settle_timeout_seconds=0.0,
         )
         handlers.handle("order_stock", {
             "account_id": "acct", "stock_code": "600000.SH", "order_type": 23,
@@ -340,6 +492,10 @@ class RedisRpcTest(unittest.TestCase):
             account_id="acct", market_data=FakeMarketData(),
             position_provider=FakePositionProvider(), order_gateway=gateway,
             allow_order_methods=True,
+            # Drive the lookup synchronously so these assertions stay about the
+            # matching logic, not about when the settle pass runs.
+            settle_orders_inline=True,
+            order_settle_timeout_seconds=0.0,
         )
         handlers.handle("order_stock", {
             "account_id": "acct", "stock_code": "600000.SH", "order_type": 23,
@@ -371,6 +527,10 @@ class RedisRpcTest(unittest.TestCase):
             account_id="acct", market_data=FakeMarketData(),
             position_provider=FakePositionProvider(), order_gateway=gateway,
             allow_order_methods=True,
+            # Drive the lookup synchronously so these assertions stay about the
+            # matching logic, not about when the settle pass runs.
+            settle_orders_inline=True,
+            order_settle_timeout_seconds=0.0,
         )
         result = handlers.handle("order_stock", {
             "account_id": "acct", "stock_code": "600000.SH", "order_type": 23,
@@ -399,6 +559,10 @@ class RedisRpcTest(unittest.TestCase):
             account_id="acct", market_data=FakeMarketData(),
             position_provider=FakePositionProvider(), order_gateway=gateway,
             allow_order_methods=True,
+            # Drive the lookup synchronously so these assertions stay about the
+            # matching logic, not about when the settle pass runs.
+            settle_orders_inline=True,
+            order_settle_timeout_seconds=0.0,
         )
         result = handlers.handle("order_stock", {
             "account_id": "acct", "stock_code": "600000.SH", "order_type": 23,
@@ -415,6 +579,10 @@ class RedisRpcTest(unittest.TestCase):
             account_id="acct", market_data=FakeMarketData(),
             position_provider=FakePositionProvider(), order_gateway=gateway,
             allow_order_methods=True,
+            # Drive the lookup synchronously so these assertions stay about the
+            # matching logic, not about when the settle pass runs.
+            settle_orders_inline=True,
+            order_settle_timeout_seconds=0.0,
         )
         params = {
             "batch_id": "BATCH-1",
@@ -437,6 +605,10 @@ class RedisRpcTest(unittest.TestCase):
             account_id="acct", market_data=FakeMarketData(),
             position_provider=FakePositionProvider(), order_gateway=gateway,
             allow_order_methods=True,
+            # Drive the lookup synchronously so these assertions stay about the
+            # matching logic, not about when the settle pass runs.
+            settle_orders_inline=True,
+            order_settle_timeout_seconds=0.0,
         )
 
         result = handlers.handle("order_stock_batch", {
@@ -459,6 +631,10 @@ class RedisRpcTest(unittest.TestCase):
             account_id="acct", market_data=FakeMarketData(),
             position_provider=FakePositionProvider(), order_gateway=gateway,
             allow_order_methods=True,
+            # Drive the lookup synchronously so these assertions stay about the
+            # matching logic, not about when the settle pass runs.
+            settle_orders_inline=True,
+            order_settle_timeout_seconds=0.0,
         )
 
         result = handlers.handle("order_stock_batch", {
@@ -488,6 +664,10 @@ class RedisRpcTest(unittest.TestCase):
             account_id="acct", market_data=FakeMarketData(),
             position_provider=FakePositionProvider(), order_gateway=gateway,
             allow_order_methods=True,
+            # Drive the lookup synchronously so these assertions stay about the
+            # matching logic, not about when the settle pass runs.
+            settle_orders_inline=True,
+            order_settle_timeout_seconds=0.0,
         )
 
         result = handlers.handle("order_stock_batch", {
@@ -507,6 +687,10 @@ class RedisRpcTest(unittest.TestCase):
             account_id="acct", market_data=FakeMarketData(),
             position_provider=FakePositionProvider(), order_gateway=gateway,
             allow_order_methods=True,
+            # Drive the lookup synchronously so these assertions stay about the
+            # matching logic, not about when the settle pass runs.
+            settle_orders_inline=True,
+            order_settle_timeout_seconds=0.0,
         )
 
         result = handlers.handle("order_stock_batch", {

--- a/tests/bigqmt_signal_trader/test_redis_rpc.py
+++ b/tests/bigqmt_signal_trader/test_redis_rpc.py
@@ -311,6 +311,104 @@ class RedisRpcTest(unittest.TestCase):
         self.assertIsNone(result.order_sys_id)
         self.assertIn("not found in system", handlers._last_server_error)
 
+    def test_server_error_does_not_leak_into_later_requests(self):
+        """issue #43: _last_server_error is instance state read by every response,
+        so a failed order used to stamp its error onto every later read."""
+        gateway = LandingOrderGateway(landed=False)
+        handlers = BigQmtRpcHandlers(
+            account_id="acct", market_data=FakeMarketData(),
+            position_provider=FakePositionProvider(), order_gateway=gateway,
+            allow_order_methods=True,
+        )
+        handlers.handle("order_stock", {
+            "account_id": "acct", "stock_code": "600000.SH", "order_type": 23,
+            "order_volume": 100, "price_type": 11, "price": 10.0,
+            "order_remark": "REMARK-43",
+        })
+        self.assertIn("not found in system", handlers._last_server_error)
+
+        # Any later request must start from a clean slot.
+        handlers.handle("ping", {})
+        self.assertEqual(handlers._last_server_error, "")
+        handlers.handle("get_positions", {"account_id": "acct"})
+        self.assertEqual(handlers._last_server_error, "")
+
+    def test_server_error_cleared_even_when_method_is_rejected(self):
+        """A rejected request must not carry the previous diagnostic either."""
+        gateway = LandingOrderGateway(landed=False)
+        handlers = BigQmtRpcHandlers(
+            account_id="acct", market_data=FakeMarketData(),
+            position_provider=FakePositionProvider(), order_gateway=gateway,
+            allow_order_methods=True,
+        )
+        handlers.handle("order_stock", {
+            "account_id": "acct", "stock_code": "600000.SH", "order_type": 23,
+            "order_volume": 100, "price_type": 11, "price": 10.0,
+            "order_remark": "REMARK-43b",
+        })
+        self.assertNotEqual(handlers._last_server_error, "")
+        with self.assertRaises(ValueError):
+            handlers.handle("no_such_method", {})
+        self.assertEqual(handlers._last_server_error, "")
+
+    def test_unrelated_same_stock_order_does_not_mask_a_silent_rejection(self):
+        """issue #41: an unrelated order on the same stock+side used to suppress
+        the warning, leaving order_sys_id unfilled with no signal at all."""
+        gateway = LandingOrderGateway(landed=False)
+        # Pre-existing order: same stock and side, different (unrelated) remark.
+        gateway.orders.append(
+            OrderSnapshot(
+                order_sys_id="sysid-unrelated",
+                user_order_id="SOMEONE-ELSE",
+                stock_code="600000.SH",
+                action="BUY",
+                volume=200,
+                traded_volume=0,
+                status="50",
+            )
+        )
+        handlers = BigQmtRpcHandlers(
+            account_id="acct", market_data=FakeMarketData(),
+            position_provider=FakePositionProvider(), order_gateway=gateway,
+            allow_order_methods=True,
+        )
+        result = handlers.handle("order_stock", {
+            "account_id": "acct", "stock_code": "600000.SH", "order_type": 23,
+            "order_volume": 100, "price_type": 11, "price": 10.0,
+            "order_remark": "REMARK-41",
+        })
+
+        self.assertIsNone(result.order_sys_id)
+        self.assertIn("not found in system", handlers._last_server_error)
+
+    def test_remark_match_still_backfills_sysid_with_other_orders_present(self):
+        """The strict match must not regress the issue #38 backfill."""
+        gateway = LandingOrderGateway(landed=True)
+        gateway.orders.append(
+            OrderSnapshot(
+                order_sys_id="sysid-unrelated",
+                user_order_id="SOMEONE-ELSE",
+                stock_code="600000.SH",
+                action="BUY",
+                volume=200,
+                traded_volume=0,
+                status="50",
+            )
+        )
+        handlers = BigQmtRpcHandlers(
+            account_id="acct", market_data=FakeMarketData(),
+            position_provider=FakePositionProvider(), order_gateway=gateway,
+            allow_order_methods=True,
+        )
+        result = handlers.handle("order_stock", {
+            "account_id": "acct", "stock_code": "600000.SH", "order_type": 23,
+            "order_volume": 100, "price_type": 11, "price": 10.0,
+            "order_remark": "REMARK-38b",
+        })
+
+        self.assertEqual(result.order_sys_id, "sysid-1")
+        self.assertEqual(handlers._last_server_error, "")
+
     def test_submit_orders_batch_reuses_order_tag_without_resubmitting(self):
         gateway = CountingOrderGateway()
         handlers = BigQmtRpcHandlers(


### PR DESCRIPTION
关联 issue #43、#41、#45。324 个测试全部通过。

## #43 — server_error 污染后续查询

`_last_server_error` 是实例状态，但 `_build_response` 对**每一个**成功响应都读它，而只有 `_handle_submit_order` 会重置。一次静默拒绝的下单会把错误盖到之后所有 ping 和查询上，直到下一次下单：

```
ping            server_error=''
order (失败)     server_error='passorder submitted but order not found...'
ping            server_error='passorder submitted but order not found...'   <- 残留
ping            server_error='passorder submitted but order not found...'   <- 残留
```

改为在 `handle()` 里每请求清空一次，语义从"某次的诊断"变成"本次请求的诊断"。清空放在方法校验**之前**，所以被拒绝的方法也不会带上一条的残留。

## #41 — order_remark 兜底机制

报告把兜底理解成"识别委托"，实际它是**告警闸门**，所以问题比描述的更严重。

`order_tag` 是我们自己生成的唯一 id（兜底 `bqrpc:<signal_id>`），remark 匹配不上就是真没进系统。那个 `elif` 模糊匹配（同 stock_code + 同 action）唯一的作用是**压制真告警**：账户里若有一笔无关的同股票同方向委托——手动下的，或上一笔未成交的——会导致 `order_sys_id` 没回填、`server_error` 也是空，客户端看到的是一次干净的成功，而那笔委托根本没进系统。正好在这个检查存在的意义上产生假阴性。

移除兜底，remark 匹配不上一律告警。#38 的委托号回填不受影响，新增测试覆盖"真委托旁边有无关同股票委托"的情况。

## #45 — 新增 qmt_launcher

`open` / `close` / `restart` / `status`，参考 `qmt_launcher.py` 但改了四处：

**按安装目录隔离** — 本机并行跑着 8 个 QMT 实例，只按进程名匹配会关掉别人账户的终端。全部解析到单个 `bin.x64` 并比对每个进程的 exe 路径。读不到路径的进程跳过而不是猜——来路不明的 QMT 进程属于哪个实例是碰运气。

**等就绪而非固定 sleep** — 参考实现 `sleep(40)` 然后祈祷。判据改为 FormulaServer（58600）可连接，超时抛异常：定时重启应该响亮地失败，而不是把没起来的终端交给下一步。`restart_qmt` 关闭后等 5 秒再启动，因为 ZMQ 传输现在精确绑定端口，socket 未释放时重绑会失败。

**窗口标题前缀匹配** — 参考实现写死了含版本号的完整标题，终端一升级就失效。

**先优雅终止，20 秒后才强杀** — 硬杀跳过终端的数据落盘，本地 K 线库被截断就是这么来的。

关于 issue 里"pywinauto/pyautogui 需要登录状态"的疑问：`SendMessage` 投递到窗口句柄，不是按屏幕坐标重放物理输入，所以不需要焦点、锁屏下也能用。这是登录路径选它而非 pyautogui 的原因。凭证从环境变量读，不走 argv。

`psutil` 可用时使用，否则回退 `wmic`/`taskkill`，不新增必需依赖。

## 验证

- #43/#41 的 3 个测试，逐个还原对应改动确认会失败
- 第 4 个测试保证 #38 的回填未被收紧破坏
- qmt_launcher 对着运行中的终端实测：`status` 只命中 `_lemo`（另外 7 个实例 0 命中），三种路径写法归一到同一 `bin.x64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)