### PR TITLE
补齐 order_time、修正未复权下载空跑、宽列表分批 (#48 #47)

### DIFF
--- a/src/bigqmt_signal_trader/adapters/order_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/order_bigqmt.py
@@ -24,6 +24,67 @@ def _action_from_offset_flag(offset_flag):
     return SignalAction.BUY.value if int(offset_flag or 0) == 48 else SignalAction.SELL.value
 
 
+# 报单时间。大 QMT 的 ORDER 行把日期和时间分成两个字段, MiniQMT 的
+# XtOrder.order_time 是 Unix 秒, 所以要拼接后转换。成交那条路径早就读了
+# m_strTradeTime, 委托这边一直漏掉 (issue #48)。
+_ORDER_DATE_FIELDS = ("m_strInsertDate", "m_strOrderDate", "insert_date", "order_date")
+_ORDER_TIME_FIELDS = ("m_strInsertTime", "m_strOrderTime", "insert_time", "order_time")
+
+# 取不到时打印该行实际有哪些 m_*, 每进程一次。字段名无法离线核实,
+# 猜一个然后静默返回 0 正是订单方向那个 bug 的成因。
+_missing_order_time_reported = []
+
+
+def _report_missing_order_time(row):
+    if _missing_order_time_reported:
+        return
+    _missing_order_time_reported.append(True)
+    try:
+        available = sorted(n for n in dir(row) if n.startswith("m_"))
+    except Exception:
+        available = []
+    print(
+        "[bigqmt_order] order_time not found (tried %s / %s); ORDER row exposes: %s"
+        % (", ".join(_ORDER_DATE_FIELDS), ", ".join(_ORDER_TIME_FIELDS),
+           ", ".join(available) or "<none>")
+    )
+
+
+def _order_time_seconds(row):
+    """把 ORDER 行的报单日期+时间转成 Unix 秒, 拿不到返回 0。
+
+    容忍几种实际会遇到的写法: 日期 '20260819' 或 '2026-08-19',
+    时间 '093015'、'09:30:15' 或 '09:30:15.123'。已经是数字时间戳的直接用
+    (毫秒会被归一到秒)。
+    """
+    raw_time = _attr(row, _ORDER_TIME_FIELDS)
+    raw_date = _attr(row, _ORDER_DATE_FIELDS)
+    if raw_time is None and raw_date is None:
+        _report_missing_order_time(row)
+        return 0
+
+    # 已是数字: 当成时间戳 (>1e11 视为毫秒)。
+    if isinstance(raw_time, (int, float)) and not isinstance(raw_time, bool):
+        value = float(raw_time)
+        if value > 1e11:
+            value /= 1000.0
+        if value > 1e8:      # 像时间戳而不是 093015 这种时分秒
+            return int(value)
+
+    date_text = "".join(ch for ch in str(raw_date or "") if ch.isdigit())
+    time_text = "".join(ch for ch in str(raw_time or "") if ch.isdigit())
+    if not date_text or len(date_text) < 8:
+        return 0
+    time_text = (time_text + "000000")[:6]   # 补齐到 HHMMSS, 丢掉毫秒
+    try:
+        import time as _time
+
+        parsed = _time.strptime(date_text[:8] + time_text, "%Y%m%d%H%M%S")
+        return int(_time.mktime(parsed))
+    except Exception:
+        return 0
+
+
 def _price_type_value(value, default):
     if value is None or value == "":
         return int(default)
@@ -141,6 +202,7 @@ class BigQmtOrderGateway:
                     price=float(_attr(row, ("m_dLimitPrice", "m_dPrice", "price"), 0.0) or 0.0),
                     strategy_name=str(_attr(row, ("m_strStrategyName", "strategy_name"), "") or ""),
                     remark=str(_attr(row, ("m_strRemark", "remark"), "") or ""),
+                    order_time=_order_time_seconds(row),
                 )
             )
         return result

--- a/src/bigqmt_signal_trader/models.py
+++ b/src/bigqmt_signal_trader/models.py
@@ -266,6 +266,7 @@ class OrderSnapshot:
         price=0.0,
         strategy_name="",
         remark="",
+        order_time=0,
     ):
         self.order_sys_id = order_sys_id
         self.user_order_id = user_order_id
@@ -277,6 +278,9 @@ class OrderSnapshot:
         self.price = price
         self.strategy_name = strategy_name
         self.remark = remark
+        # 报单时间, Unix 秒 -- MiniQMT XtOrder.order_time 的语义。0 = 未上报。
+        # 追加在末尾并给默认值, 保持既有位置参数调用不受影响。
+        self.order_time = order_time
 
 
 class TradeSnapshot:

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -21,6 +21,9 @@ from .redis_rpc import call_redis_rpc
 
 # Default OHLCV fields pulled + cached by get_local_data fallback_rpc.
 DEFAULT_DOWNLOAD_FIELDS = ["open", "high", "low", "close", "volume", "amount"]
+# Codes per get_market_data_ex request. One request carries a single RPC timeout,
+# so a wide stock_list either fits or loses everything (issue #47).
+DEFAULT_MARKET_DATA_CHUNK = 100
 _TIME_COL_NAMES = ("stime", "time", "index", "date", "datetime", "timetag")
 
 
@@ -897,6 +900,16 @@ class BigQmtXtData:
         # Self-heal adjusted reads (all-zero bars -> server raw download + retry).
         return self._heal_adjusted("get_market_data", params, data)
 
+    def _get_market_data_ex_batch(self, params, timeout_seconds=None):
+        """One RPC's worth of bars, healed and normalized. No caching."""
+        data = self._call("get_market_data_ex", timeout_seconds=timeout_seconds, **params)
+        # Self-heal adjusted reads (all-zero bars -> server raw download + retry).
+        data = self._heal_adjusted("get_market_data_ex", params, data)
+        # Normalize Big QMT's stime-indexed frame to MiniQMT shape (time-indexed).
+        if isinstance(data, dict):
+            data = _normalize_market_data_result(data, field_list=params.get("field_list"))
+        return data
+
     def get_market_data_ex(
         self,
         field_list=None,
@@ -907,13 +920,26 @@ class BigQmtXtData:
         count=-1,
         dividend_type="none",
         fill_data=True,
+        chunk_size=None,
+        timeout_seconds=None,
     ):
-        # Live pull over RPC. Cache-through: whatever we fetch is written to the
-        # local cache (keyed by dividend_type), so it stays the latest — important
-        # for 前复权 (front-adjusted) data, whose history re-scales on each dividend.
-        params = dict(
+        """Pull bars over RPC, in batches of ``chunk_size`` codes.
+
+        Cache-through: whatever is fetched is written to the local cache (keyed
+        by dividend_type), so it stays the latest -- important for 前复权 data,
+        whose history re-scales on each dividend.
+
+        Batching exists because one request carrying every code shares a single
+        RPC timeout (6s by default), so a wide stock_list times out and loses
+        the whole pull rather than degrading (issue #47). Splitting keeps each
+        request small enough to answer, and a batch that still fails only costs
+        its own codes -- the rest are returned.
+
+        ``chunk_size=0`` restores the old single-request behaviour.
+        """
+        codes = list(stock_list or [])
+        base = dict(
             field_list=list(field_list or []),
-            stock_list=list(stock_list or []),
             period=period,
             start_time=start_time,
             end_time=end_time,
@@ -921,12 +947,36 @@ class BigQmtXtData:
             dividend_type=dividend_type,
             fill_data=fill_data,
         )
-        data = self._call("get_market_data_ex", **params)
-        # Self-heal adjusted reads (all-zero bars -> server raw download + retry).
-        data = self._heal_adjusted("get_market_data_ex", params, data)
-        # Normalize Big QMT's stime-indexed frame to MiniQMT shape (time-indexed).
-        if isinstance(data, dict):
-            data = _normalize_market_data_result(data, field_list=params.get("field_list"))
+        step = DEFAULT_MARKET_DATA_CHUNK if chunk_size is None else int(chunk_size)
+
+        if step <= 0 or len(codes) <= step:
+            data = self._get_market_data_ex_batch(
+                dict(base, stock_list=codes), timeout_seconds=timeout_seconds
+            )
+        else:
+            data = {}
+            failures = []
+            for index in range(0, len(codes), step):
+                batch = codes[index:index + step]
+                try:
+                    part = self._get_market_data_ex_batch(
+                        dict(base, stock_list=batch), timeout_seconds=timeout_seconds
+                    )
+                except Exception as exc:
+                    # Losing one batch must not lose the others: a partial
+                    # result beats an exception when 500 codes were asked for.
+                    failures.append((batch, exc))
+                    continue
+                if isinstance(part, dict):
+                    data.update(part)
+            if failures and not data:
+                # Nothing came back at all -- surface the first cause rather
+                # than returning a silent empty dict.
+                raise failures[0][1]
+            for batch, exc in failures:
+                print("[bigqmt_client] get_market_data_ex batch failed (%d codes, first=%s): %s"
+                      % (len(batch), batch[0] if batch else "", exc))
+
         cache = self._local_cache()
         if cache is not None and isinstance(data, dict):
             for code, df in data.items():
@@ -1197,7 +1247,7 @@ class BigQmtXtData:
     def get_divid_factors(self, stock_code, start_time="", end_time=""):
         return self._call("get_divid_factors", stock_code=stock_code, start_time=start_time, end_time=end_time)
 
-    def download_history_data2(self, stock_list, period, start_time="", end_time="", callback=None, incrementally=None, dividend_type="none", chunk_size=None):
+    def download_history_data2(self, stock_list, period, start_time="", end_time="", callback=None, incrementally=None, dividend_type="none", chunk_size=None, download_timeout_seconds=180.0):
         """Pull bars from Big QMT over RPC and cache them locally, in batches.
 
         Mirrors xtdata.download_history_data2: after this, get_local_data(..., the
@@ -1206,12 +1256,18 @@ class BigQmtXtData:
         (front-adjusted) data. ``callback`` (optional) is invoked once per stock with
         {finished, total, stockcode} — xtdata-style. Returns {finished, total}.
 
-        Adjusted data (dividend_type != none): Big QMT can only compute adjusted
-        bars after the RAW history + dividend factors are downloaded server-side.
-        Without that, get_market_data_ex(dividend_type='front') returns all-zero
-        closes (verified live). So we first trigger the server-side download
-        (download_history_data2 via RPC, which pulls raw bars + factors), then
-        pull the adjusted bars.
+        The server-side download runs for EVERY dividend_type, matching
+        xtdata semantics ("populate the local QMT store"). It used to be skipped
+        for unadjusted pulls, which made an unadjusted download a no-op that
+        still reported progress (issue #47).
+
+        Adjusted data (dividend_type != none) additionally depends on it: Big QMT
+        computes adjusted bars from the RAW history + dividend factors, and
+        without both, get_market_data_ex(dividend_type='front') returns all-zero
+        closes (verified live).
+
+        ``download_timeout_seconds`` covers the server-side download only; it is
+        generous because a cold code with a wide window can take minutes.
         """
         codes = [str(c) for c in (stock_list or []) if str(c or "").strip()]
         if not codes:
@@ -1219,26 +1275,38 @@ class BigQmtXtData:
         if self._local_cache() is None:
             raise RuntimeError("local cache is disabled (set local_cache_enabled=True to download)")
 
-        # Server-side raw download first when adjustment is requested: QMT
-        # computes front/back-adjusted bars from raw bars + dividend factors,
-        # and both must already exist server-side or the result is all zeros.
-        normalized = str(dividend_type or "none").lower()
-        if normalized not in ("", "none"):
-            try:
-                self.client.call(
-                    "download_history_data2",
-                    {
-                        "stock_list": codes,
-                        "period": period,
-                        "start_time": start_time,
-                        "end_time": end_time,
-                    },
-                    timeout_seconds=60.0,
-                )
-            except Exception:
-                # Best-effort: some deployments lack the QMT global; the pull
-                # below may still work if raw data already exists server-side.
-                pass
+        # Server-side download first, for EVERY dividend_type.
+        #
+        # This used to run only when adjustment was requested, on the reasoning
+        # that an unadjusted pull can be served straight from get_market_data_ex.
+        # That reads whatever Big QMT already has -- it does not fetch anything.
+        # So an unadjusted "download" left the QMT-side store untouched while
+        # still reporting {finished: N} through the callback: a progress bar for
+        # work that never happened (issue #47, and the real cause behind #39,
+        # which was closed on an incomplete reading of this function).
+        #
+        # xtdata.download_history_data means "populate the local QMT store", and
+        # callers depend on that: FormulaServer and get_local_data both read it,
+        # and codes "downloaded" this way had zero bars there.
+        #
+        # Adjusted data additionally NEEDS this: QMT computes front/back-adjusted
+        # bars from raw bars + dividend factors, and both must exist server-side
+        # or the result is all zeros.
+        try:
+            self.client.call(
+                "download_history_data2",
+                {
+                    "stock_list": codes,
+                    "period": period,
+                    "start_time": start_time,
+                    "end_time": end_time,
+                },
+                timeout_seconds=float(download_timeout_seconds),
+            )
+        except Exception:
+            # Best-effort: some deployments lack the QMT global; the pull below
+            # may still work if the data already exists server-side.
+            pass
 
         total = len(codes)
         step = int(chunk_size or 300)
@@ -2396,6 +2464,9 @@ class BigQmtXtTrader:
             order_id=order_sysid or str(item.get("user_order_id") or ""),
             strategy_name=str(item.get("strategy_name") or ""),
             order_remark=str(item.get("remark") or item.get("user_order_id") or ""),
+            # MiniQMT XtOrder.order_time 是 Unix 秒。0 = 服务端未上报
+            # (旧服务端不带这个字段), 不要当成 1970 年 (issue #48)。
+            order_time=_safe_int(item.get("order_time"), 0),
         )
 
     def _trade_from_dict(self, account_id, item):

--- a/tests/bigqmt_signal_trader/test_local_cache.py
+++ b/tests/bigqmt_signal_trader/test_local_cache.py
@@ -224,14 +224,42 @@ class AdjustedDownloadTest(unittest.TestCase):
         self.assertEqual(raw_call["period"], "1d")
         self.assertEqual(raw_call["start_time"], "20200101")
 
-    def test_none_download_skips_server_side_raw_download(self):
+    def test_none_download_still_triggers_server_side_download(self):
+        """issue #47: an unadjusted download used to skip the server RPC and
+        only read what Big QMT already had -- a no-op that still reported
+        {finished: N}. xtdata semantics are "populate the local QMT store", and
+        callers (FormulaServer, get_local_data) depend on that actually happening."""
         xt = self._xt()
         xt.download_history_data2(["600000.SH"], "1d", dividend_type="none")
 
-        # Unadjusted pulls need no server-side download.
         method_calls = [m for m, _ in xt.client.call_params]
-        self.assertNotIn("download_history_data2", method_calls)
+        self.assertIn("download_history_data2", method_calls)
         self.assertIn("get_market_data_ex", method_calls)
+        self.assertLess(
+            method_calls.index("download_history_data2"),
+            method_calls.index("get_market_data_ex"),
+            "the download must precede the pull, or the pull reads stale data",
+        )
+        raw_call = next(p for m, p in xt.client.call_params if m == "download_history_data2")
+        self.assertEqual(raw_call["stock_list"], ["600000.SH"])
+        self.assertEqual(raw_call["period"], "1d")
+
+    def test_none_download_survives_server_download_failure(self):
+        """Same best-effort contract the adjusted path already had: a deployment
+        without the QMT global must still get its bars."""
+        xt = self._xt()
+        original_call = xt.client.call
+
+        def failing_download(method, params=None, account_id=None, timeout_seconds=None):
+            if method == "download_history_data2":
+                raise RuntimeError("global not available")
+            return original_call(method, params, account_id=account_id, timeout_seconds=timeout_seconds)
+
+        xt.client.call = failing_download
+        result = xt.download_history_data2(["600000.SH"], "1d", dividend_type="none")
+
+        self.assertEqual(result["finished"], 1)
+        self.assertIn("get_market_data_ex", [m for m, _ in xt.client.call_params])
 
     def test_front_download_survives_server_download_failure(self):
         # Deployments without the QMT global must still get the adjusted pull

--- a/tests/bigqmt_signal_trader/test_order_time_and_chunking.py
+++ b/tests/bigqmt_signal_trader/test_order_time_and_chunking.py
@@ -1,0 +1,250 @@
+"""issue #48 (order_time missing) and issue #47 (get_market_data_ex chunking).
+
+Both are gaps between what Big QMT hands us and what the MiniQMT-shaped API
+promises: the ORDER row carries a submit time we never read, and a wide
+stock_list shares one RPC timeout so it either fits or loses everything.
+"""
+
+import os
+import sys
+import time
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.adapters import order_bigqmt
+from bigqmt_signal_trader.adapters.order_bigqmt import BigQmtOrderGateway, _order_time_seconds
+from bigqmt_signal_trader.models import OrderSnapshot
+from bigqmt_signal_trader.xtquant_compat import BigQmtXtData, BigQmtXtTrader, StockAccount
+
+
+class Row(object):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _order_row(**overrides):
+    base = dict(
+        m_strOrderSysID="sys-1",
+        m_strRemark="tag-1",
+        m_strInstrumentID="601398",
+        m_strExchangeID="SH",
+        m_nOffsetFlag=48,
+        m_nVolumeTotalOriginal=100,
+        m_nVolumeTraded=0,
+        m_nOrderStatus=50,
+        m_dLimitPrice=7.66,
+        m_strStrategyName="s1",
+    )
+    base.update(overrides)
+    return Row(**base)
+
+
+def _gateway(rows):
+    return BigQmtOrderGateway(
+        context_info=None,
+        passorder_func=None,
+        cancel_func=None,
+        get_trade_detail_data_func=lambda acct, atype, dtype, sname="": (
+            list(rows) if dtype == "ORDER" else []
+        ),
+    )
+
+
+class OrderTimeParsingTest(unittest.TestCase):
+    def setUp(self):
+        del order_bigqmt._missing_order_time_reported[:]
+
+    def _expected(self, text):
+        return int(time.mktime(time.strptime(text, "%Y%m%d%H%M%S")))
+
+    def test_parses_split_date_and_time(self):
+        row = _order_row(m_strInsertDate="20260819", m_strInsertTime="093015")
+        self.assertEqual(_order_time_seconds(row), self._expected("20260819093015"))
+
+    def test_tolerates_separators(self):
+        row = _order_row(m_strInsertDate="2026-08-19", m_strInsertTime="09:30:15")
+        self.assertEqual(_order_time_seconds(row), self._expected("20260819093015"))
+
+    def test_drops_sub_second_precision(self):
+        row = _order_row(m_strInsertDate="20260819", m_strInsertTime="09:30:15.123")
+        self.assertEqual(_order_time_seconds(row), self._expected("20260819093015"))
+
+    def test_accepts_alternate_field_spellings(self):
+        for date_field, time_field in (("m_strInsertDate", "m_strInsertTime"),
+                                       ("m_strOrderDate", "m_strOrderTime"),
+                                       ("insert_date", "insert_time")):
+            row = _order_row(**{date_field: "20260819", time_field: "093015"})
+            self.assertEqual(_order_time_seconds(row), self._expected("20260819093015"),
+                             "%s/%s" % (date_field, time_field))
+
+    def test_passes_through_an_epoch_value(self):
+        stamp = self._expected("20260819093015")
+        self.assertEqual(_order_time_seconds(_order_row(m_strInsertTime=stamp)), stamp)
+
+    def test_normalizes_millisecond_epoch(self):
+        stamp = self._expected("20260819093015")
+        self.assertEqual(_order_time_seconds(_order_row(m_strInsertTime=stamp * 1000)), stamp)
+
+    def test_missing_fields_yield_zero_not_epoch_start(self):
+        """0 means "not reported"; 1970-01-01 would look like a real timestamp."""
+        self.assertEqual(_order_time_seconds(_order_row()), 0)
+
+    def test_missing_fields_report_what_the_row_actually_has(self):
+        import contextlib
+        import io as _io
+
+        buffer = _io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            _order_time_seconds(_order_row(m_strSomethingElse="x"))
+        output = buffer.getvalue()
+
+        self.assertIn("order_time not found", output)
+        self.assertIn("m_strSomethingElse", output)
+
+    def test_missing_field_reported_once_not_per_row(self):
+        import contextlib
+        import io as _io
+
+        buffer = _io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            for _ in range(5):
+                _order_time_seconds(_order_row())
+
+        self.assertEqual(buffer.getvalue().count("order_time not found"), 1)
+
+    def test_unparseable_date_yields_zero(self):
+        self.assertEqual(
+            _order_time_seconds(_order_row(m_strInsertDate="oops", m_strInsertTime="093015")), 0)
+
+
+class OrderSnapshotTest(unittest.TestCase):
+    def setUp(self):
+        del order_bigqmt._missing_order_time_reported[:]
+
+    def test_defaults_keep_existing_positional_callers_working(self):
+        snapshot = OrderSnapshot("sys", "tag", "601398.SH", "BUY", 100, 0, "50")
+        self.assertEqual(snapshot.order_time, 0)
+
+    def test_gateway_fills_order_time(self):
+        rows = [_order_row(m_strInsertDate="20260819", m_strInsertTime="093015")]
+        order = _gateway(rows).query_orders("acct", "")[0]
+
+        self.assertEqual(order.order_time,
+                         int(time.mktime(time.strptime("20260819093015", "%Y%m%d%H%M%S"))))
+        self.assertEqual(order.stock_code, "601398.SH")
+
+
+class ClientOrderTimeTest(unittest.TestCase):
+    """The reported symptom: XtOrder.order_time simply is not there."""
+
+    def _trader(self, payload):
+        trader = BigQmtXtTrader(account_id="acct")
+        trader.client.call = lambda method, params=None, account_id=None, **kw: payload
+        return trader
+
+    def test_order_time_is_exposed(self):
+        stamp = int(time.mktime(time.strptime("20260819093015", "%Y%m%d%H%M%S")))
+        orders = self._trader([{
+            "stock_code": "601398.SH", "action": "BUY", "order_sys_id": "sys-1",
+            "volume": 100, "order_time": stamp,
+        }]).query_stock_orders(StockAccount("acct"))
+
+        self.assertEqual(orders[0].order_time, stamp)
+
+    def test_missing_order_time_defaults_to_zero(self):
+        """A server predating this field must not raise AttributeError."""
+        orders = self._trader([{
+            "stock_code": "601398.SH", "action": "BUY", "order_sys_id": "sys-1", "volume": 100,
+        }]).query_stock_orders(StockAccount("acct"))
+
+        self.assertEqual(orders[0].order_time, 0)
+
+
+class ChunkingClient(object):
+    """Records the code count of each request, and can fail chosen codes."""
+
+    def __init__(self, fail_codes=(), max_codes_per_call=None):
+        self.account_id = "acct"
+        self.batches = []
+        self.local_cache_config = {"enabled": False}
+        self.fail_codes = set(fail_codes)
+        self.max_codes_per_call = max_codes_per_call
+
+    def _redis(self):
+        return None
+
+    def call(self, method, params=None, account_id=None, timeout_seconds=None):
+        codes = list((params or {}).get("stock_list") or [])
+        self.batches.append(codes)
+        if self.max_codes_per_call is not None and len(codes) > self.max_codes_per_call:
+            raise TimeoutError("rpc timeout: %d codes" % len(codes))
+        if self.fail_codes & set(codes):
+            raise TimeoutError("rpc timeout")
+        import pandas as pd
+
+        return {c: pd.DataFrame({"stime": ["20260819"], "close": [7.66]}) for c in codes}
+
+
+class MarketDataChunkingTest(unittest.TestCase):
+    """issue #47 comment: one request carries every code and one timeout, so a
+    wide stock_list times out and loses the whole pull."""
+
+    def _xt(self, **kwargs):
+        return BigQmtXtData(ChunkingClient(**kwargs))
+
+    def test_wide_list_is_split(self):
+        xt = self._xt()
+        codes = ["C%03d.SH" % i for i in range(250)]
+
+        data = xt.get_market_data_ex(stock_list=codes, period="1d")
+
+        self.assertEqual([len(b) for b in xt.client.batches], [100, 100, 50])
+        self.assertEqual(len(data), 250)
+
+    def test_small_list_stays_a_single_request(self):
+        xt = self._xt()
+        xt.get_market_data_ex(stock_list=["600000.SH", "601398.SH"], period="1d")
+
+        self.assertEqual(len(xt.client.batches), 1)
+
+    def test_chunk_size_zero_restores_single_request(self):
+        xt = self._xt()
+        codes = ["C%03d.SH" % i for i in range(250)]
+
+        xt.get_market_data_ex(stock_list=codes, period="1d", chunk_size=0)
+
+        self.assertEqual(len(xt.client.batches), 1)
+
+    def test_a_wide_pull_that_would_time_out_now_succeeds(self):
+        """The actual report: the server cannot answer 250 codes at once."""
+        xt = self._xt(max_codes_per_call=120)
+        codes = ["C%03d.SH" % i for i in range(250)]
+
+        data = xt.get_market_data_ex(stock_list=codes, period="1d")
+
+        self.assertEqual(len(data), 250)
+
+    def test_one_failed_batch_does_not_lose_the_others(self):
+        xt = self._xt(fail_codes=["C150.SH"])
+        codes = ["C%03d.SH" % i for i in range(250)]
+
+        data = xt.get_market_data_ex(stock_list=codes, period="1d")
+
+        # The 100-code batch holding C150 is lost; the other 150 survive.
+        self.assertEqual(len(data), 150)
+        self.assertNotIn("C150.SH", data)
+        self.assertIn("C000.SH", data)
+
+    def test_total_failure_raises_rather_than_returning_empty(self):
+        xt = self._xt(max_codes_per_call=0)
+        codes = ["C%03d.SH" % i for i in range(250)]
+
+        with self.assertRaises(TimeoutError):
+            xt.get_market_data_ex(stock_list=codes, period="1d")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
关联 issue #48、#47。323 个测试全部通过，py3.6 兼容已校验。

## #48 — query_stock_orders 缺 order_time

大 QMT 的 ORDER 行带着报单日期和时间，但三层都没读：`OrderSnapshot` 没有时间字段，adapter 读了 8 个 `m_*` 字段没有一个是时间，`_order_from_dict` 也没映射。

一个旁证说明这是遗漏而非设计：**成交那条路径一直有** `m_strTradeTime` → `traded_at`。

三层都补上，并按 MiniQMT `XtOrder.order_time` 的语义转成 Unix 秒。

ThinkTrader 的确切字段名离线确认不了（今天查 ORDER 明细返回 0 条），所以用多候选名 + 取不到时打印该行真实字段——和当初定位 `m_dFrozenCash` 同一套做法。猜一个名字然后静默返回 0，正是订单方向那个 bug 的成因。

`0` 表示「未上报」，和真实时间戳区分开；对接旧服务端的客户端拿到 0 而不是 1970-01-01。

## #47 — 未复权的「下载」什么都没下

服务端下载**只在请求复权时**才执行，理由是未复权可以直接由 `get_market_data_ex` 提供。但那个接口读的是大 QMT **已有**的数据，不会去取。所以未复权下载完全没碰 QMT 侧数据仓，却照常通过 callback 报 `{finished: N}`——**为一件没发生的事显示进度条**。而 1d 和 tick 默认就是 `dividend_type="none"`，这是最常走的路径。

这也是 **#39 的真正答案**。我当时只核对了 `download_history_data` 转发给 `download_history_data2`，就以「不复现」关闭了。转发从来不是问题，被调函数里的跳过才是。**报告人是对的，我关错了。**

影响不止于 API 契约：FormulaServer 和 `get_local_data` 读的都是 QMT 侧数据仓，用这种方式「下载」过的代码在那里是零根 K 线——这正是探测 58600 覆盖面时在 601398.SH 上撞见的现象。

现在所有 `dividend_type` 都执行下载，保留原有的 best-effort 契约（缺 QMT 全局函数的部署照样拿得到数据）。下载超时和拉取超时分开，默认 180s，因为冷代码配宽时间窗可能要几分钟。`test_none_download_skips_server_side_raw_download` 固化的是旧行为，已替换成它的反面。

## #47 评论（@wsmh）— 宽列表超时

`get_market_data_ex` 把所有代码塞进一次请求、共用一个 RPC 超时（默认 6s），所以宽 `stock_list` 要么装得下要么整批丢失。

改为按 100 个代码一批：某一批仍然失败只损失它自己的代码，其余照常返回；全部失败则抛异常而不是悄悄回一个空 dict。`chunk_size=0` 可恢复单请求行为。

## 验证

每处修复都**逐一还原确认对应测试会失败**：

| 还原 | 变红的测试 |
|---|---|
| `order_time` 采集 | `test_gateway_fills_order_time` |
| 分批（chunk=0） | `test_wide_list_is_split`、`test_a_wide_pull_that_would_time_out_now_succeeds`、`test_one_failed_batch_does_not_lose_the_others` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)