### PR TITLE
order_stock_async 立即返回，不再同步等待 (#50)

### DIFF
--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -919,6 +919,17 @@ class BigQmtRpcHandlers:
         # user_order_id(remark) 精确匹配并回填 order_sys_id，避免客户端把
         # 「已提交但暂无委托号」误判为下单失败（issue #38）。
         self._last_server_error = ""
+
+        # Async callers opt out of waiting for the order id. MiniQMT's
+        # order_stock_async returns a seq immediately and delivers the id through
+        # order_callback, so holding the reply until settlement is exactly the
+        # latency the async API exists to avoid (issue #50). The order_callback
+        # push already carries order_sys_id, so nothing is lost -- only the
+        # post-submit "did it land?" check is skipped, and a silent rejection
+        # surfaces as the absence of that push rather than as server_error.
+        if not _bool_value(params.get("wait_settlement"), True):
+            return result
+
         if self.settle_orders_inline:
             # Opt-out: block here the way this used to. Kept only for runtimes
             # with no adjust drain to retry on.

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -9,6 +9,7 @@ import os
 import json
 import time
 import uuid
+import queue as _queue
 import threading
 import importlib
 import datetime as _dt
@@ -1710,6 +1711,11 @@ class BigQmtXtTrader:
         self.callback = None
         self._event_thread = None
         self._event_running = False
+        # Async order submission (issue #50). One worker, started on first use,
+        # so a client that never calls order_stock_async pays nothing.
+        self._async_order_queue = _queue.Queue()
+        self._async_order_thread = None
+        self._async_order_lock = threading.Lock()
 
     def _cached_position_snapshot(self, account_id):
         key = "bigqmt:positions:%s" % str(account_id or self.client.account_id or "")
@@ -2077,8 +2083,15 @@ class BigQmtXtTrader:
 
     def order_stock_result(
         self, account, stock_code, order_type, order_volume, price_type,
-        price, strategy_name, order_remark,
+        price, strategy_name, order_remark, wait_settlement=True,
     ):
+        """Submit one order over RPC.
+
+        ``wait_settlement=False`` tells the server to reply as soon as passorder
+        returns instead of holding the reply until QMT assigns the order id.
+        The async path uses it; the id then arrives through order_callback
+        (issue #50).
+        """
         account_id = _account_id(account, self.client.account_id)
         user_order_id = str(order_remark or "").strip()
         if not user_order_id:
@@ -2093,6 +2106,8 @@ class BigQmtXtTrader:
             "strategy_name": strategy_name,
             "order_remark": user_order_id,
         }
+        if not wait_settlement:
+            payload["wait_settlement"] = False
         try:
             return self.client.call("order_stock", payload, account_id=account_id) or {}
         except TimeoutError as exc:
@@ -2101,17 +2116,47 @@ class BigQmtXtTrader:
                 % (user_order_id, exc)
             )
 
-    def order_stock_async(self, *args, **kwargs):
-        # MiniQMT semantics: returns a seq; the result comes back through
-        # on_order_stock_async_response(seq, order_error|None). Our RPC is
-        # synchronous under the hood, so we fire the response callback
-        # immediately with the seq and the submitted order.
-        seq = self._next_async_seq()
+    def _async_order_worker(self):
+        """Drain queued async orders, one at a time.
+
+        A single worker rather than a pool: the server handles order RPCs on
+        the QMT adjust thread serially anyway, so concurrency here buys little,
+        while serializing keeps on_order_stock_async_response arriving in
+        submission order. For real batch throughput use order_stock_batch.
+        """
+        while True:
+            job = self._async_order_queue.get()
+            if job is None:          # shutdown sentinel
+                self._async_order_queue.task_done()
+                return
+            seq, args, kwargs = job
+            try:
+                self._run_async_order(seq, args, kwargs)
+            except Exception:
+                # A worker that dies takes every later async order with it.
+                pass
+            finally:
+                self._async_order_queue.task_done()
+
+    def _ensure_async_order_worker(self):
+        with self._async_order_lock:
+            if self._async_order_thread is not None and self._async_order_thread.is_alive():
+                return
+            thread = threading.Thread(
+                target=self._async_order_worker, name="bigqmt-async-order", daemon=True
+            )
+            self._async_order_thread = thread
+            thread.start()
+
+    def _run_async_order(self, seq, args, kwargs):
+        """Do the actual submit and fire the matching callback. Worker thread."""
         stock_code = str(kwargs.get("stock_code") or (args[1] if len(args) > 1 else ""))
+        callback = self.callback
         try:
-            result = self.order_stock(*args, **kwargs)
+            # wait_settlement=False: return as soon as passorder ran. The order
+            # id arrives via order_callback, which is what MiniQMT does too.
+            result = self.order_stock_result(*args, wait_settlement=False, **kwargs)
         except Exception as exc:
-            callback = self.callback
             if callback is not None:
                 try:
                     callback.on_order_error(
@@ -2121,19 +2166,25 @@ class BigQmtXtTrader:
                             order_sys_id="",
                             order_id="",
                             stock_code=stock_code,
+                            seq=seq,
                         )
                     )
                 except Exception:
                     pass
-            return seq
-        # MiniQMT: order_stock returns -1 when the order failed to submit.
-        # NOTE: the server also pushes an order_error event for 废单 (via
-        # exec_events), so a client may see this -1 error AND the server's
-        # order_error — they carry different info (RPC submit failure vs QMT
-        # rejection detail). We fire it only when the callback was registered,
-        # keeping both signals available to the client.
-        if isinstance(result, int) and result == -1:
-            callback = self.callback
+            return
+
+        order_sys_id = ""
+        user_order_id = ""
+        if isinstance(result, dict):
+            order_sys_id = str(result.get("order_sys_id") or result.get("order_sysid") or "")
+            user_order_id = str(result.get("user_order_id") or "")
+        elif result is not None:
+            order_sys_id = str(result)
+
+        # order_stock returns -1 when the submit itself failed. The server also
+        # pushes an order_error for a 废单; the two carry different information
+        # (RPC submit failure vs QMT rejection detail), so both stay available.
+        if order_sys_id == "-1" or result == -1:
             if callback is not None:
                 try:
                     callback.on_order_error(
@@ -2143,22 +2194,24 @@ class BigQmtXtTrader:
                             order_sys_id="",
                             order_id="",
                             stock_code=stock_code,
+                            seq=seq,
                         )
                     )
                 except Exception:
                     pass
-            return seq
-        callback = self.callback
+            return
+
         if callback is not None:
             try:
-                # Align with native XtOrderResponse: callback takes ONE arg
-                # (response) carrying account_id/order_id/seq/error_msg.
-                order_sys_id = str(result.get("order_sys_id") or result.get("order_sysid") or "") if isinstance(result, dict) else str(result)
+                # Native XtOrderResponse shape: one argument carrying
+                # account_id/order_id/seq/error_msg. order_id may be empty here
+                # -- the id is assigned asynchronously and lands in the
+                # order_callback push (issue #50).
                 callback.on_order_stock_async_response(
                     CompatObject(
                         account_id=self.client.account_id,
                         seq=seq,
-                        order_id=order_sys_id or str(result.get("user_order_id") or "") if isinstance(result, dict) else str(result),
+                        order_id=order_sys_id or user_order_id,
                         order_sys_id=order_sys_id,
                         stock_code=stock_code,
                         strategy_name=str(kwargs.get("strategy_name") or (args[6] if len(args) > 6 else "")),
@@ -2168,7 +2221,40 @@ class BigQmtXtTrader:
                 )
             except Exception:
                 pass
+
+    def order_stock_async(self, *args, **kwargs):
+        """Queue an order and return its seq immediately (MiniQMT semantics).
+
+        This used to call order_stock inline, so it blocked for the full RPC
+        round trip plus -- after the issue #44 change -- however long the server
+        waited for QMT to assign an order id. That is 0.5-1s per order, which
+        defeats the point of an async API (issue #50).
+
+        Now the submit runs on a worker thread and the outcome arrives through
+        on_order_stock_async_response / on_order_error, both carrying the seq so
+        callers can correlate. Returns the seq without touching the network.
+        """
+        seq = self._next_async_seq()
+        self._ensure_async_order_worker()
+        self._async_order_queue.put((seq, args, kwargs))
         return seq
+
+    def wait_async_orders(self, timeout=10.0):
+        """Block until every queued async order has been submitted.
+
+        For tests and for shutdown; the API itself is fire-and-forget. Returns
+        False on timeout rather than hanging. Uses task_done bookkeeping, so it
+        waits for the in-flight job too, not merely for the queue to drain.
+        """
+        queue_obj = getattr(self, "_async_order_queue", None)
+        if queue_obj is None:
+            return True
+        deadline = time.time() + float(timeout)
+        while queue_obj.unfinished_tasks:
+            if time.time() > deadline:
+                return False
+            time.sleep(0.005)
+        return True
 
     def order_stock_batch(self, account, orders, batch_id=""):
         account_id = _account_id(account, self.client.account_id)

--- a/tests/bigqmt_signal_trader/test_exec_events.py
+++ b/tests/bigqmt_signal_trader/test_exec_events.py
@@ -1,4 +1,6 @@
 import json
+import time
+import threading
 import os
 import sys
 import unittest
@@ -449,22 +451,56 @@ class ExecEventsClientDispatchTest(unittest.TestCase):
         self.assertEqual(err.error_id, 99)
         self.assertEqual(err.error_msg, "撤单失败")
 
-    def test_order_stock_async_returns_seq_and_fires_response(self):
-        trader, cb = self._trader()
-        # order_stock is stubbed? No — it would do an RPC. Instead call the
-        # helper directly with a dict-like result via monkeypatching is heavy;
-        # here we only verify the seq increments and the async-response path
-        # fires when order_stock returns a dict (mocked below).
-        original_order_stock = trader.order_stock
+    def _run_async(self, trader, result=None, raises=None):
+        """Submit one async order with order_stock_result stubbed, and wait.
 
-        def fake_order_stock(*args, **kwargs):
-            return {"order_sys_id": "sys-ok-1", "user_order_id": "u-1"}
+        order_stock_async is fire-and-forget since issue #50: it returns the seq
+        without touching the network and the submit happens on a worker thread,
+        so the callback assertions need the queue drained first. The stub is
+        restored only after the worker is done with it.
+        """
+        original = trader.order_stock_result
 
-        trader.order_stock = fake_order_stock
+        def fake(*args, **kwargs):
+            if raises is not None:
+                raise raises
+            return result
+
+        trader.order_stock_result = fake
         try:
             seq = trader.order_stock_async("acct", "600654.SH", 23, 100, 11, 10.0, "s", "r")
+            self.assertTrue(trader.wait_async_orders(timeout=5.0), "async order did not finish")
         finally:
-            trader.order_stock = original_order_stock
+            trader.order_stock_result = original
+        return seq
+
+    def test_order_stock_async_returns_seq_without_submitting(self):
+        """issue #50: the seq must come back before any RPC happens."""
+        trader, _cb = self._trader()
+        started = threading.Event()
+        release = threading.Event()
+
+        def blocking(*args, **kwargs):
+            started.set()
+            release.wait(5.0)
+            return {"order_sys_id": "sys-slow"}
+
+        trader.order_stock_result = blocking
+        try:
+            t0 = time.time()
+            seq = trader.order_stock_async("acct", "600654.SH", 23, 100, 11, 10.0, "s", "r")
+            elapsed = time.time() - t0
+
+            self.assertGreater(seq, 0)
+            self.assertLess(elapsed, 0.2, "order_stock_async blocked for %.3fs" % elapsed)
+            self.assertTrue(started.wait(5.0), "submit never ran on the worker")
+        finally:
+            release.set()
+            trader.wait_async_orders(timeout=5.0)
+
+    def test_order_stock_async_fires_response_when_submitted(self):
+        trader, cb = self._trader()
+        seq = self._run_async(trader, result={"order_sys_id": "sys-ok-1", "user_order_id": "u-1"})
 
         self.assertGreater(seq, 0)
         self.assertEqual(len(cb.async_responses), 1)
@@ -472,41 +508,46 @@ class ExecEventsClientDispatchTest(unittest.TestCase):
         self.assertEqual(resp.order_id, "sys-ok-1")
         self.assertEqual(resp.account_id, "acct")
         self.assertEqual(resp.seq, seq)
+
+    def test_order_stock_async_requests_no_settlement_wait(self):
+        """The server must not hold the reply for the order id on this path."""
+        trader, _cb = self._trader()
+        seen = {}
+        original = trader.order_stock_result
+
+        def fake(*args, **kwargs):
+            seen.update(kwargs)
+            return {"order_sys_id": "sys-1"}
+
+        trader.order_stock_result = fake
+        try:
+            trader.order_stock_async("acct", "600654.SH", 23, 100, 11, 10.0, "s", "r")
+            trader.wait_async_orders(timeout=5.0)
+        finally:
+            trader.order_stock_result = original
+
+        self.assertIs(seen.get("wait_settlement"), False)
+
     def test_order_stock_async_minus_one_fires_order_error(self):
         trader, cb = self._trader()
-        original_order_stock = trader.order_stock
-
-        def fake_order_stock(*args, **kwargs):
-            return -1  # MiniQMT: submit failed
-
-        trader.order_stock = fake_order_stock
-        try:
-            seq = trader.order_stock_async("acct", "600654.SH", 23, 100, 11, 10.0, "s", "r")
-        finally:
-            trader.order_stock = original_order_stock
+        seq = self._run_async(trader, result=-1)  # MiniQMT: submit failed
 
         self.assertGreater(seq, 0)
         self.assertEqual(len(cb.order_errors), 1)
         err = cb.order_errors[0]
         self.assertEqual(err.error_id, -1)
         self.assertEqual(err.stock_code, "600654.SH")
+        self.assertEqual(err.seq, seq)          # correlate the failure to the seq
         # No success response for a failed submit.
         self.assertEqual(len(cb.async_responses), 0)
 
     def test_order_stock_async_submitted_without_sysid_fires_response_not_error(self):
         # issue #38: passorder 已提交但委托号还没分配到（order_sys_id 为空）时，
-        # 必须回调成功响应而不是误报 on_order_error。
+        # 必须回调成功响应而不是误报 on_order_error。issue #50 之后这是常态：
+        # 异步路径不再等待委托号，它由 order_callback 推送。
         trader, cb = self._trader()
-        original_order_stock = trader.order_stock
-
-        def fake_order_stock(*args, **kwargs):
-            return {"status": "SUBMITTED", "user_order_id": "u-1", "order_sys_id": ""}
-
-        trader.order_stock = fake_order_stock
-        try:
-            seq = trader.order_stock_async("acct", "600654.SH", 23, 100, 11, 10.0, "s", "r")
-        finally:
-            trader.order_stock = original_order_stock
+        seq = self._run_async(
+            trader, result={"status": "SUBMITTED", "user_order_id": "u-1", "order_sys_id": ""})
 
         self.assertGreater(seq, 0)
         self.assertEqual(len(cb.order_errors), 0)
@@ -519,20 +560,10 @@ class ExecEventsClientDispatchTest(unittest.TestCase):
         # server_error（委托没进系统）由 call() 转成异常后，async 必须把真实
         # 原因回调给 on_order_error（issue #38）。
         trader, cb = self._trader()
-        original_order_stock = trader.order_stock
-
-        def fake_order_stock(*args, **kwargs):
-            raise RuntimeError(
-                "Big QMT order_stock server_error: passorder submitted but "
-                "order not found in system (stock=600654.SH action=BUY price=10.00 "
-                "volume=100). QMT may have silently rejected it."
-            )
-
-        trader.order_stock = fake_order_stock
-        try:
-            seq = trader.order_stock_async("acct", "600654.SH", 23, 100, 11, 10.0, "s", "r")
-        finally:
-            trader.order_stock = original_order_stock
+        seq = self._run_async(trader, raises=RuntimeError(
+            "Big QMT order_stock server_error: passorder submitted but "
+            "order not found in system (stock=600654.SH action=BUY price=10.00 "
+            "volume=100). QMT may have silently rejected it."))
 
         self.assertGreater(seq, 0)
         self.assertEqual(len(cb.async_responses), 0)
@@ -540,6 +571,27 @@ class ExecEventsClientDispatchTest(unittest.TestCase):
         err = cb.order_errors[0]
         self.assertIn("not found in system", err.error_msg)
         self.assertEqual(err.stock_code, "600654.SH")
+
+    def test_async_orders_keep_submission_order(self):
+        """One worker, so responses arrive in the order the calls were made."""
+        trader, cb = self._trader()
+        original = trader.order_stock_result
+
+        def fake(*args, **kwargs):
+            return {"order_sys_id": "sys-%s" % args[1]}
+
+        trader.order_stock_result = fake
+        try:
+            for code in ("A.SH", "B.SH", "C.SH"):
+                trader.order_stock_async("acct", code, 23, 100, 11, 10.0, "s", "r")
+            self.assertTrue(trader.wait_async_orders(timeout=5.0))
+        finally:
+            trader.order_stock_result = original
+
+        self.assertEqual([r.order_id for r in cb.async_responses],
+                         ["sys-A.SH", "sys-B.SH", "sys-C.SH"])
+        self.assertEqual([r.seq for r in cb.async_responses],
+                         sorted(r.seq for r in cb.async_responses))
 
     def test_cancel_order_stock_async_fires_response(self):
         trader, cb = self._trader()


### PR DESCRIPTION
关联 issue #50。354 个测试通过，py3.6 兼容已校验。

## 问题

`order_stock_async` 内部直接调用 `order_stock`，因此阻塞整个 RPC 往返——而且自 #44 改动后，服务端还会继续等待 QMT 分配委托号才回复。这就是报告里说的每笔 0.5~1 秒，也让异步接口失去了意义。

## 为什么要两端一起改

只改客户端提前返回，等待只是被藏进线程里，`async_response` 仍然要几秒才到；只改服务端不等结算，调用方依旧被 RPC 往返阻塞。

**服务端**：`submit_order` 新增 `wait_settlement` 参数。为 false 时，`passorder` 一返回就立即回复，不再把响应停放到结算队列。

这不丢信息——`order_callback` 本来就会推送 `order_sys_id`，MiniQMT 也是这么给的。唯一的代价是跳过了提交后的「委托是否真的进系统」检查，因此这条路径上静默拒绝表现为**那个推送不出现**，而不是 `server_error`。

**客户端**：提交移到工作线程，`order_stock_async` 不碰网络直接返回 `seq`。结果通过 `on_order_stock_async_response` / `on_order_error` 送达，两者现在都带 `seq`——**此前 `on_order_error` 完全没有 seq，无法判断是哪一笔异步委托失败**。

## 单工作线程而非线程池

服务端本来就在 QMT adjust 线程上串行处理下单 RPC，客户端并发收益有限；而串行能保证 `async_response` 按提交顺序到达——这也是面向 #51 排序问题最廉价的一步。真正的批量吞吐应该用 `order_stock_batch`。

## 关于「直接走 passorder」

报告人建议让异步接口直接走 QMT 的 `passorder`。方向是对的，但客户端够不着——`passorder` 在 QMT 进程内。`wait_settlement` 就是同一个想法在 RPC 边界上的表达：提交完就返回，委托号交给回调带。

## 测试

原有 4 个异步测试假设同步调用、且打桩的是 `order_stock`（新路径走 `order_stock_result`），已按异步契约重写。新增 3 个：

- `test_order_stock_async_returns_seq_without_submitting` —— 提交仍被阻塞时调用已返回（<0.2s）
- `test_order_stock_async_requests_no_settlement_wait` —— 确认真的请求了 `wait_settlement=False`
- `test_async_orders_keep_submission_order` —— 响应保持提交顺序

把改动还原成同步调用，第一个测试立刻变红（阻塞 5 秒）。

## 未验证

实盘下单验证仍待补——需要真实委托才能确认端到端延迟。与 #44 相同的限制。

🤖 Generated with [Claude Code](https://claude.com/claude-code)