### PR TITLE
保证同一订单的 async_response 先于其 order/trade (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/) 和 [语义化版本](https://semver.org/)。
 
+## [Unreleased]
+
+### 修复
+
+- **异步下单的 order/trade 事件先于 async_response 到达**（Issue #51）：两条回调走不同通道——`async_response` 在异步下单工作线程触发，`order`/`trade` 来自 Redis pub/sub 监听线程；服务端 `order_callback` 先推事件、后回 RPC，顺序颠倒是常态。客户端按 `order_remark` 设屏障：命中待响应委托的事件先暂存，response（或 error）触发后按到达顺序放行；10 秒超时兜底，提交失败的事件也不会被永久扣住（丢事件比顺序错乱更糟）。仅 `order_stock_async` 路径受影响，手工/同步/无 remark 委托直通。成交事件无 remark 时按委托事件学到的 `order_sys_id` 关联。已验证：9 个单测（含 4 个反向验证）+ 盘后真实 Redis 注入实测（部署环境 `async_response → stock_order → stock_trade` 保序成立）。盘中真实下单验证待交易时段进行。
+- **重复 order_remark 导致暂存事件丢失**（Issue #51 后续）：`order_remark` 不强制唯一（网格类策略常复用同一 remark），同 remark 的第二笔下单会让 `_arm_order_barrier` 直接覆盖前一笔的屏障，暂存事件被静默丢弃；且前一笔的 response 会误放后一笔的屏障，使后一笔失去保序。改为接管旧屏障时先放行其暂存事件；`_release_order_barrier` 增加 seq 校验，只有 arm 时的那笔委托的 response 才能放行对应屏障。回归测试对任一半修复回退均失败。
+
 ## [0.2.2] - 2026-08-19
 
 ### 修复

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ seq = xt_trader.order_stock_async(acc, "600654.SH", 23, 100, 11, 2.95, "rpc_test
 | `on_cancel_error(err)` | 撤单失败 | ✅ |
 | `on_cancel_order_stock_async_response` | 异步撤单回报 | ✅ |
 
+**异步下单的事件顺序**（Issue #51）：`on_order_stock_async_response`（异步下单工作线程）与 `on_stock_order` / `on_stock_trade`（Redis pub/sub 监听线程）走不同通道，服务端在 `order_callback` 里先推事件、后回 RPC，事件先于响应是**常态**而非偶发竞态。客户端按 `order_remark` 设屏障：命中待响应委托的事件先暂存，response（或 error）触发后按到达顺序放行；屏障 10 秒超时兜底——丢事件比顺序错乱更糟。延迟只加在 `order_stock_async` 路径上：手工下单、同步下单、无 remark 的委托一律直通。成交事件可能没有 remark，此时按委托事件学到的 `order_sys_id` 关联。`order_remark` 不强制唯一（网格类策略常复用）：同 remark 的后一笔下单会接管前一笔的屏障并先放行其暂存事件，response 按 seq 精确匹配，前一笔的 response 不会误放后一笔的屏障。已验证：单测（含反向验证）+ 盘后真实 Redis 注入实测（部署环境保序成立）。
+
 **`*_async` 查询方法**（对齐 MiniQMT 签名，callback 可选）：
 
 ```python

--- a/src/bigqmt_signal_trader/exec_events.py
+++ b/src/bigqmt_signal_trader/exec_events.py
@@ -386,6 +386,12 @@ def normalize_trade_event(trade, account_id=""):
         "action": _action_from_direction(direction),
         "offset_flag": _attr(trade, ["m_nOffsetFlag", "offset_flag"]),
         "traded_at": str(_attr(trade, ["m_strTradeTime", "traded_at", "trade_time"], "") or ""),
+        # 和委托事件一致带上 remark。客户端要在拿到 order_sys_id 之前就把成交
+        # 关联到某笔异步委托 (issue #51)，而那时唯一已知的标识就是 remark。
+        # QMT 的成交行不一定有这个字段，取不到则为空，客户端退回按
+        # order_sys_id 关联。
+        "remark": str(_attr(trade, ["m_strRemark", "order_remark", "remark", "user_order_id"], "") or ""),
+        "user_order_id": str(_attr(trade, ["m_strRemark", "user_order_id", "order_remark", "remark"], "") or ""),
         "created_at": time.strftime("%Y-%m-%d %H:%M:%S"),
         "created_at_ts": time.time(),
     }

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -1860,6 +1860,19 @@ class BigQmtXtTrader:
             return
         if not isinstance(event, dict):
             return
+        # 放行超时的屏障, 再决定这条事件是直通还是暂存 (issue #51)。
+        try:
+            self._sweep_order_barriers()
+            if event.get("event_type") in ("order", "trade") and self._hold_if_pending(event):
+                return
+        except Exception:
+            pass  # 屏障故障绝不能吞掉事件
+        self._deliver_event(event)
+
+    def _deliver_event(self, event):
+        callback = self.callback
+        if callback is None:
+            return
         account_id = str(event.get("account_id") or self.client.account_id or "")
         try:
             event_type = event.get("event_type")
@@ -2148,9 +2161,96 @@ class BigQmtXtTrader:
             self._async_order_thread = thread
             thread.start()
 
+    # ------------------------------------------------------------------
+    # issue #51 A: 同一笔委托的 async_response 必须先于它的 order/trade 到达。
+    #
+    # 两条回调走的是不同线程和不同通道: async_response 在异步下单的工作线程上
+    # 触发, order/trade 来自 Redis pub/sub 监听线程。服务端在 order_callback
+    # 里先推事件再回 RPC, 所以顺序颠倒是常态而非偶发。
+    #
+    # 做法是给「已提交但尚未收到 async_response」的委托设一道屏障: 它的
+    # order/trade 事件先暂存, 等 response 触发后按到达顺序放行。延迟只加在
+    # 异步下单这一条路径上——手工下单、同步下单、以及任何未登记的委托一律直通。
+    # ------------------------------------------------------------------
+    ASYNC_BARRIER_TIMEOUT_SECONDS = 10.0
+
+    def _order_barrier(self):
+        barrier = getattr(self, "_async_barrier", None)
+        if barrier is None:
+            barrier = {}
+            self._async_barrier = barrier
+            self._async_barrier_lock = threading.Lock()
+        return barrier
+
+    @staticmethod
+    def _async_remark(args, kwargs):
+        """下单调用里的 order_remark —— 拿到 order_sys_id 之前唯一的关联键。"""
+        return str(kwargs.get("order_remark") or (args[7] if len(args) > 7 else "") or "")
+
+    def _arm_order_barrier(self, remark, seq):
+        """登记一笔待响应的委托。remark 为空则不设屏障(无从关联)。"""
+        if not remark:
+            return
+        self._order_barrier()
+        with self._async_barrier_lock:
+            self._async_barrier[remark] = {
+                "seq": seq,
+                "sys_ids": set(),
+                "events": [],
+                "deadline": time.time() + self.ASYNC_BARRIER_TIMEOUT_SECONDS,
+            }
+
+    def _release_order_barrier(self, remark):
+        """response 已触发, 按到达顺序放行暂存的事件。"""
+        if not remark:
+            return
+        self._order_barrier()
+        with self._async_barrier_lock:
+            entry = self._async_barrier.pop(remark, None)
+        for event in (entry or {}).get("events", []):
+            self._deliver_event(event)
+
+    def _sweep_order_barriers(self):
+        """放行超时未收到 response 的委托。
+
+        没有这一步, 一次失败的提交会把它的事件永久扣住——丢事件比顺序错乱更糟。
+        """
+        now = time.time()
+        expired = []
+        with self._async_barrier_lock:
+            for remark, entry in list(self._async_barrier.items()):
+                if now >= entry["deadline"]:
+                    expired.append(self._async_barrier.pop(remark))
+        for entry in expired:
+            for event in entry.get("events", []):
+                self._deliver_event(event)
+
+    def _hold_if_pending(self, event):
+        """属于待响应委托则暂存并返回 True, 否则返回 False 直通。"""
+        barrier = self._order_barrier()
+        if not barrier:
+            return False
+        remark = str(event.get("remark") or event.get("user_order_id") or "")
+        sys_id = str(event.get("order_sys_id") or "")
+        with self._async_barrier_lock:
+            entry = barrier.get(remark) if remark else None
+            if entry is None and sys_id:
+                # 成交事件可能没有 remark; 用委托事件里学到的 order_sys_id 关联。
+                for candidate in barrier.values():
+                    if sys_id in candidate["sys_ids"]:
+                        entry = candidate
+                        break
+            if entry is None:
+                return False
+            if sys_id:
+                entry["sys_ids"].add(sys_id)
+            entry["events"].append(event)
+            return True
+
     def _run_async_order(self, seq, args, kwargs):
         """Do the actual submit and fire the matching callback. Worker thread."""
         stock_code = str(kwargs.get("stock_code") or (args[1] if len(args) > 1 else ""))
+        remark = self._async_remark(args, kwargs)
         callback = self.callback
         try:
             # wait_settlement=False: return as soon as passorder ran. The order
@@ -2171,6 +2271,7 @@ class BigQmtXtTrader:
                     )
                 except Exception:
                     pass
+            self._release_order_barrier(remark)
             return
 
         order_sys_id = ""
@@ -2199,6 +2300,7 @@ class BigQmtXtTrader:
                     )
                 except Exception:
                     pass
+            self._release_order_barrier(remark)
             return
 
         if callback is not None:
@@ -2221,6 +2323,8 @@ class BigQmtXtTrader:
                 )
             except Exception:
                 pass
+        # response 已触发 -> 放行这笔委托暂存的 order/trade (issue #51)。
+        self._release_order_barrier(remark)
 
     def order_stock_async(self, *args, **kwargs):
         """Queue an order and return its seq immediately (MiniQMT semantics).
@@ -2235,6 +2339,8 @@ class BigQmtXtTrader:
         callers can correlate. Returns the seq without touching the network.
         """
         seq = self._next_async_seq()
+        # 屏障要在入队之前设好: 委托可能在本函数返回之前就被推送出来。
+        self._arm_order_barrier(self._async_remark(args, kwargs), seq)
         self._ensure_async_order_worker()
         self._async_order_queue.put((seq, args, kwargs))
         return seq

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -2193,19 +2193,31 @@ class BigQmtXtTrader:
             return
         self._order_barrier()
         with self._async_barrier_lock:
+            # remark 不强制唯一(网格类策略常复用同一 remark)。同 remark 的上一笔
+            # 可能还扣着暂存事件, 直接覆盖会把它们永久丢掉——丢事件比顺序错乱
+            # 更糟, 所以接管旧 entry 并在锁外放行它的事件。
+            superseded = self._async_barrier.pop(remark, None)
             self._async_barrier[remark] = {
                 "seq": seq,
                 "sys_ids": set(),
                 "events": [],
                 "deadline": time.time() + self.ASYNC_BARRIER_TIMEOUT_SECONDS,
             }
+        for event in (superseded or {}).get("events", []):
+            self._deliver_event(event)
 
-    def _release_order_barrier(self, remark):
+    def _release_order_barrier(self, remark, seq=None):
         """response 已触发, 按到达顺序放行暂存的事件。"""
         if not remark:
             return
         self._order_barrier()
         with self._async_barrier_lock:
+            entry = self._async_barrier.get(remark)
+            if entry is None:
+                return
+            if seq is not None and entry["seq"] != seq:
+                # 同 remark 的后一笔委托已接管屏障; 前一笔的 response 不该放它。
+                return
             entry = self._async_barrier.pop(remark, None)
         for event in (entry or {}).get("events", []):
             self._deliver_event(event)
@@ -2271,7 +2283,7 @@ class BigQmtXtTrader:
                     )
                 except Exception:
                     pass
-            self._release_order_barrier(remark)
+            self._release_order_barrier(remark, seq)
             return
 
         order_sys_id = ""
@@ -2300,7 +2312,7 @@ class BigQmtXtTrader:
                     )
                 except Exception:
                     pass
-            self._release_order_barrier(remark)
+            self._release_order_barrier(remark, seq)
             return
 
         if callback is not None:
@@ -2324,7 +2336,7 @@ class BigQmtXtTrader:
             except Exception:
                 pass
         # response 已触发 -> 放行这笔委托暂存的 order/trade (issue #51)。
-        self._release_order_barrier(remark)
+        self._release_order_barrier(remark, seq)
 
     def order_stock_async(self, *args, **kwargs):
         """Queue an order and return its seq immediately (MiniQMT semantics).

--- a/tests/bigqmt_signal_trader/test_async_callback_order.py
+++ b/tests/bigqmt_signal_trader/test_async_callback_order.py
@@ -1,0 +1,198 @@
+"""issue #51 A: an order's async_response must arrive before its order/trade.
+
+The two callbacks travel different paths -- async_response fires on the submit
+worker, order/trade come off the Redis pub/sub listener -- and the server pushes
+the event before it answers the RPC, so the inversion is the normal case rather
+than a race that shows up occasionally.
+
+The barrier only applies to orders submitted through order_stock_async. Manual
+orders, synchronous orders, and anything without a remark pass straight through.
+"""
+
+import json
+import os
+import queue
+import sys
+import threading
+import time
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.xtquant_compat import BigQmtXtTrader, XtQuantTraderCallback
+
+
+class Recorder(XtQuantTraderCallback):
+    """Records callback names in arrival order."""
+
+    def __init__(self):
+        self.seen = []
+        self.lock = threading.Lock()
+
+    def _add(self, name, obj):
+        with self.lock:
+            self.seen.append((name, obj))
+
+    def on_order_stock_async_response(self, r):
+        self._add("response", r)
+
+    def on_order_error(self, e):
+        self._add("error", e)
+
+    def on_stock_order(self, o):
+        self._add("order", o)
+
+    def on_stock_trade(self, t):
+        self._add("trade", t)
+
+    def names(self):
+        with self.lock:
+            return [n for n, _ in self.seen]
+
+
+def _event(event_type, remark="", order_sys_id="", **extra):
+    payload = {
+        "event_type": event_type,
+        "account_id": "acct",
+        "stock_code": "601398.SH",
+        "order_sys_id": order_sys_id,
+        "remark": remark,
+        "user_order_id": remark,
+        "action": "BUY",
+    }
+    payload.update(extra)
+    return json.dumps(payload).encode("utf-8")
+
+
+class AsyncCallbackOrderTest(unittest.TestCase):
+    def _trader(self, submit=None):
+        trader = BigQmtXtTrader(account_id="acct")
+        recorder = Recorder()
+        trader.register_callback(recorder)
+        gate = threading.Event()
+
+        def default_submit(*args, **kwargs):
+            gate.wait(5.0)
+            return {"order_sys_id": "sys-1", "user_order_id": "TAG-1"}
+
+        trader.order_stock_result = submit or default_submit
+        return trader, recorder, gate
+
+    def _submit(self, trader, remark="TAG-1"):
+        return trader.order_stock_async(
+            "acct", "601398.SH", 23, 100, 11, 6.80, "s", remark)
+
+    def test_order_event_waits_for_the_response(self):
+        trader, rec, gate = self._trader()
+        self._submit(trader)
+
+        # The push beats the RPC reply -- the normal case, not a rare race.
+        trader._dispatch_event(_event("order", remark="TAG-1", order_sys_id="sys-1"))
+        self.assertEqual(rec.names(), [], "order was delivered before the response")
+
+        gate.set()
+        trader.wait_async_orders(timeout=5.0)
+
+        self.assertEqual(rec.names(), ["response", "order"])
+
+    def test_trade_without_remark_is_matched_through_the_order_sys_id(self):
+        """QMT's deal row may not carry the remark, so the trade is correlated
+        through the id learned from the order event."""
+        trader, rec, gate = self._trader()
+        self._submit(trader)
+
+        trader._dispatch_event(_event("order", remark="TAG-1", order_sys_id="sys-1"))
+        trader._dispatch_event(_event("trade", remark="", order_sys_id="sys-1"))
+        self.assertEqual(rec.names(), [])
+
+        gate.set()
+        trader.wait_async_orders(timeout=5.0)
+
+        self.assertEqual(rec.names(), ["response", "order", "trade"])
+
+    def test_held_events_keep_their_arrival_order(self):
+        trader, rec, gate = self._trader()
+        self._submit(trader)
+
+        trader._dispatch_event(_event("order", remark="TAG-1", order_sys_id="sys-1",
+                                      status=50))
+        trader._dispatch_event(_event("trade", remark="TAG-1", order_sys_id="sys-1",
+                                      trade_id="t1"))
+        trader._dispatch_event(_event("order", remark="TAG-1", order_sys_id="sys-1",
+                                      status=56))
+
+        gate.set()
+        trader.wait_async_orders(timeout=5.0)
+
+        self.assertEqual(rec.names(), ["response", "order", "trade", "order"])
+
+    def test_unrelated_orders_are_not_held(self):
+        """A manual order, or one from another process, must not be delayed."""
+        trader, rec, gate = self._trader()
+        self._submit(trader, remark="TAG-1")
+
+        trader._dispatch_event(_event("order", remark="SOMEONE-ELSE",
+                                      order_sys_id="sys-other"))
+
+        self.assertEqual(rec.names(), ["order"], "an unrelated order was held")
+        gate.set()
+        trader.wait_async_orders(timeout=5.0)
+
+    def test_no_barrier_without_a_remark(self):
+        """Nothing to correlate on -- deliver rather than hold blindly."""
+        trader, rec, gate = self._trader()
+        trader.order_stock_async("acct", "601398.SH", 23, 100, 11, 6.80, "s", "")
+
+        trader._dispatch_event(_event("order", remark="", order_sys_id="sys-1"))
+
+        self.assertEqual(rec.names(), ["order"])
+        gate.set()
+        trader.wait_async_orders(timeout=5.0)
+
+    def test_events_are_released_when_the_submit_fails(self):
+        """A failed submit must not strand its events: losing them would be
+        worse than delivering them out of order."""
+        def failing(*args, **kwargs):
+            raise RuntimeError("rpc down")
+
+        trader, rec, _ = self._trader(submit=failing)
+        self._submit(trader)
+        trader.wait_async_orders(timeout=5.0)
+
+        trader._dispatch_event(_event("order", remark="TAG-1", order_sys_id="sys-1"))
+
+        self.assertEqual(rec.names(), ["error", "order"])
+
+    def test_barrier_expires_so_events_are_never_stranded(self):
+        trader, rec, gate = self._trader()
+        trader.ASYNC_BARRIER_TIMEOUT_SECONDS = 0.2
+        self._submit(trader)
+
+        trader._dispatch_event(_event("order", remark="TAG-1", order_sys_id="sys-1"))
+        self.assertEqual(rec.names(), [])
+
+        time.sleep(0.3)
+        # Any later event triggers the sweep, which releases the expired hold.
+        trader._dispatch_event(_event("order", remark="OTHER", order_sys_id="sys-9"))
+
+        self.assertIn("order", rec.names())
+        self.assertEqual(len(rec.names()), 2)
+        gate.set()
+        trader.wait_async_orders(timeout=5.0)
+
+    def test_response_still_first_when_the_push_arrives_late(self):
+        """The already-correct ordering must not regress."""
+        trader, rec, gate = self._trader()
+        self._submit(trader)
+        gate.set()
+        trader.wait_async_orders(timeout=5.0)
+
+        trader._dispatch_event(_event("order", remark="TAG-1", order_sys_id="sys-1"))
+
+        self.assertEqual(rec.names(), ["response", "order"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_async_callback_order.py
+++ b/tests/bigqmt_signal_trader/test_async_callback_order.py
@@ -193,6 +193,33 @@ class AsyncCallbackOrderTest(unittest.TestCase):
 
         self.assertEqual(rec.names(), ["response", "order"])
 
+    def test_a_reused_remark_releases_the_previous_hold(self):
+        """Remarks are not unique (grid-style strategies reuse them). Arming a
+        second barrier on the same remark must release the first order's held
+        events rather than drop them -- losing events is worse than order.
+        And the second order's barrier must stay armed until ITS response."""
+        trader, rec, gate = self._trader()
+        self._submit(trader, remark="TAG-1")
+
+        # The first order's event arrives before its response and is held.
+        trader._dispatch_event(_event("order", remark="TAG-1", order_sys_id="sys-A"))
+        self.assertEqual(rec.names(), [])
+
+        # A second order reuses the remark; the held event must be released
+        # immediately instead of being discarded with the superseded barrier.
+        self._submit(trader, remark="TAG-1")
+        self.assertEqual(rec.names(), ["order"])
+
+        # The second order's own event still waits for ITS response: the
+        # first order's response must not release a barrier it does not own.
+        trader._dispatch_event(_event("order", remark="TAG-1", order_sys_id="sys-B"))
+        self.assertEqual(rec.names(), ["order"])
+
+        gate.set()
+        trader.wait_async_orders(timeout=5.0)
+
+        self.assertEqual(rec.names(), ["order", "response", "response", "order"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
关联 issue #51，采用你选的**方案 A**。362 个测试通过。

## 问题不是偶发竞态

两条回调走的是不同线程和不同通道：

```
on_order_stock_async_response  <- 异步下单的工作线程
on_stock_order / on_stock_trade <- Redis pub/sub 监听线程
```

而服务端在 `order_callback` 里**先推事件、后回 RPC**，所以顺序颠倒是**常态**，不是偶尔撞上。#50 的改动（提交还没开始就返回 seq）又把这个间隔拉大了。

## 实现

`order_stock_async` 按 `order_remark` 设一道屏障；命中待响应委托的 order/trade 事件先暂存，等 response（或 error）触发后**按到达顺序**放行。

其余一律直通——手工下单、同步下单、无 remark 的委托都不受影响，**延迟只加在异步下单这一条路径上**，正如你描述的。

## 关联键为什么是 remark

屏障建立时 `order_sys_id` **还不存在**，所以只能用 remark。

委托事件本来就带 remark；**成交事件不带**——这是实现中发现的。因此 `normalize_trade_event` 也去读 `m_strRemark` 了。但 QMT 的成交行不一定有这个字段，所以还留了第二条路径：**用委托事件里学到的 `order_sys_id` 关联成交**。两条都覆盖了测试。

## 不能扣住事件不放

屏障 10 秒过期，且每来一条事件就清扫一次。提交失败的委托如果把事件永久扣住，**丢事件比顺序错乱更糟**。工作线程的三个出口（正常响应、提交异常、返回 -1）都会放行。

## 验证

8 个测试，其中 4 个**逐一确认关掉屏障就会失败**：

| 测试 | 覆盖 |
|---|---|
| `test_order_event_waits_for_the_response` | 核心保证 |
| `test_trade_without_remark_is_matched_through_the_order_sys_id` | 成交无 remark 的退路 |
| `test_held_events_keep_their_arrival_order` | order→trade→order 顺序保持 |
| `test_barrier_expires_so_events_are_never_stranded` | 超时放行 |
| `test_unrelated_orders_are_not_held` | 手工下单不被延迟 |
| `test_no_barrier_without_a_remark` | 无关联键时直通 |
| `test_events_are_released_when_the_submit_fails` | 失败也放行 |
| `test_response_still_first_when_the_push_arrives_late` | 本来就对的情况不回归 |

## 未处理

issue 里的**第 2 点**（最后一笔成交时 trade 和 order 谁先到）**没有做**。那个顺序由 QMT 决定——`order_callback` 和 `deal_callback` 是它分别回调的，我们只是各自转发。要强行定序就得在客户端缓冲重排，给所有成交事件都加延迟，代价和收益不成比例。如果你确实需要，可以单开一个 issue 讨论。

🤖 Generated with [Claude Code](https://claude.com/claude-code)