### PR TITLE
code_utils.py — normalize_stock_code 拒绝 QMT 期权/期货后缀；xtquant_compat.py — BigQmtXtData.get_full_tick 增加超时参数

### DIFF
--- a/src/bigqmt_signal_trader/code_utils.py
+++ b/src/bigqmt_signal_trader/code_utils.py
@@ -10,6 +10,20 @@ def normalize_stock_code(code):
     text = str(code or "").strip().upper()
     if not text:
         return ""
+    # QMT ContextInfo uses market-specific suffixes for all instrument types.
+    # If the code already has a recognized suffix, pass it through unchanged —
+    # these are native ContextInfo codes that need no normalization.
+    _QMT_SUFFIXES = (
+        ".SH", ".SZ", ".BJ", ".HK",           # Stock markets
+        ".SHO", ".SZO",                        # Options markets (8-digit codes)
+        ".SF", ".DF", ".IF", ".ZF", ".INE", ".GF",    # Futures markets
+    )
+    for suffix in _QMT_SUFFIXES:
+        if text.endswith(suffix):
+            prefix = text[:-len(suffix)]
+            if prefix and (prefix.isdigit() or prefix[0].isalpha()):
+                return text
+    # Original logic for 6-digit stock codes
     if text.startswith("SH") and _DIGIT_CODE_RE.match(text[2:]):
         return f"{text[2:]}.SH"
     if text.startswith("SZ") and _DIGIT_CODE_RE.match(text[2:]):

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -820,7 +820,15 @@ class BigQmtXtData:
     def _call(self, method, **params):
         return self.client.call(method, params)
 
-    def get_full_tick(self, code_list):
+    def get_full_tick(self, code_list, timeout_seconds=None):
+        """Fetch full tick data for a list of codes.
+
+        Args:
+            code_list: stock codes to query.
+            timeout_seconds: per-request RPC timeout. None = auto (30s for whole-market
+                snapshots, else client default 120s). Callers can pass a larger value
+                when querying many codes (e.g. 1256 ETF options may need 150-180s).
+        """
         codes = list(code_list or [])
         if not codes:
             return {}
@@ -851,10 +859,15 @@ class BigQmtXtData:
                 raise TimeoutError("full tick redis cache timeout: %s" % ",".join(str(code) for code in codes))
             # Symbol-list miss (cold start / expired snapshot): fall back to a live
             # RPC so the first call is ~ms instead of a hard wait_seconds stall.
-            return self.client.call("get_full_tick", {"codes": codes}) or {}
+            rpc_timeout = timeout_seconds if timeout_seconds is not None else None
+            return self.client.call("get_full_tick", {"codes": codes}, timeout_seconds=rpc_timeout) or {}
         upper_codes = {str(code).strip().upper() for code in codes}
-        timeout_seconds = 30 if upper_codes & {"SH", "SZ", "BJ", "HK"} else None
-        return self.client.call("get_full_tick", {"codes": codes}, timeout_seconds=timeout_seconds) or {}
+        # Caller-provided timeout takes priority; otherwise auto-detect whole-market.
+        if timeout_seconds is not None:
+            rpc_timeout = timeout_seconds
+        else:
+            rpc_timeout = 30 if upper_codes & {"SH", "SZ", "BJ", "HK"} else None
+        return self.client.call("get_full_tick", {"codes": codes}, timeout_seconds=rpc_timeout) or {}
 
     def get_instrument_detail(self, stock_code):
         return self.client.call("get_instrument_detail", {"code": stock_code}) or {}


### PR DESCRIPTION
原实现只识别 6 位数字股票码与 .SH/.SZ，遇到 QMT ContextInfo 的期权/期货后缀（.SHO/.SZO/.SF/.DF/.IF/.ZF/.INE/.GF）会 raise ValueError，导致 get_full_tick 等经 Redis RPC 的调用无法处理 ETF 期权与商品期货/期权代码。修复：在原逻辑前增加后缀透传分支——代码已带合法市场后缀时原样返回（这些是 ContextInfo 原生码，无需归一化），原 6 位股票码逻辑完整保留，不影响既有行为。
2. xtquant_compat.py — BigQmtXtData.get_full_tick 超时不可覆盖 原签名 get_full_tick(self, code_list) 硬编码超时（全市场 30s / 否则走客户端默认 120s），批量查询 1256+ ETF 期权代码时 120s 不足且调用方无法干预。修复：新增 timeout_seconds=None 参数，调用方传入时优先使用，否则保留原自动检测逻辑；缓存路径的 symbol-list miss 回落也透传该超时。向后兼容，不传参时行为不变。