### PR TITLE
get_full_tick 保留调用方代码大小写；透传柜台拒单原因 (#58 #60)

### DIFF
--- a/src/bigqmt_signal_trader/adapters/market_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/market_bigqmt.py
@@ -424,9 +424,43 @@ class BigQmtMarketDataProvider:
         ]
 
     def get_ticks(self, codes):
-        normalized_codes = [normalize_market_or_stock_code(code) for code in codes]
-        data = self.context_info.get_full_tick(normalized_codes)
-        return data or {}
+        """Snapshot quotes, keyed the way the CALLER spelled each code.
+
+        Codes go to QMT upper-cased, but the futures exchanges use lower-case
+        instrument codes ('rb2708.SF', 'a2609.DF'), so returning QMT's keys made
+        ``code in result`` fail for every one of them and the level-2 book look
+        missing (issue #58). get_market_data_ex already echoes the caller's
+        spelling; this brings get_full_tick in line.
+
+        Only the CASE is restored, not the normalization: '600000' still comes
+        back as '600000.SH', because completing the suffix is useful and callers
+        rely on it. Only codes that differ from their normalized form purely by
+        case -- which is exactly the futures situation -- are mapped back.
+
+        A code QMT answers under a key we did not ask for is passed through
+        untouched rather than dropped: losing a quote is worse than an
+        unexpected key.
+        """
+        requested = list(codes or [])
+        normalized_codes = [normalize_market_or_stock_code(code) for code in requested]
+        data = self.context_info.get_full_tick(normalized_codes) or {}
+        if not isinstance(data, dict):
+            return data or {}
+
+        # Case-only differences map back; structural ones (added suffix) do not.
+        # Later duplicates keep the first spelling.
+        original_by_normalized = {}
+        for original, normalized in zip(requested, normalized_codes):
+            original, normalized = str(original), str(normalized)
+            if original != normalized and original.upper() == normalized.upper():
+                original_by_normalized.setdefault(normalized, original)
+
+        if not original_by_normalized:
+            return data
+        return dict(
+            (original_by_normalized.get(str(key), key), value)
+            for key, value in data.items()
+        )
 
     def get_instrument(self, code):
         normalized = normalize_stock_code(code)

--- a/src/bigqmt_signal_trader/adapters/order_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/order_bigqmt.py
@@ -51,6 +51,29 @@ def _report_missing_order_time(row):
     )
 
 
+# 委托状态描述。官方字段表 (docs/BIGQMT_INNER_PYTHON_API_REFERENCE.md):
+#   m_strCancelInfo  废单原因      <- 状态 57 时柜台的拒单理由在这里
+#   m_strErrorMsg    状态信息
+# 柜台消息形如 "[COUNTER] 资金可用余额不足，尚需[4789.630]"; 两个字段都空过,
+# 客户端就只能看到一个没有原因的失败 (issue #60)。废单原因优先, 它更具体。
+_STATUS_MSG_FIELDS = (
+    "m_strCancelInfo",
+    "m_strErrorMsg",
+    "m_strStatusMsg",
+    "status_msg",
+    "error_msg",
+)
+
+
+def _status_message(row):
+    for name in _STATUS_MSG_FIELDS:
+        value = _attr(row, (name,))
+        text = str(value or "").strip()
+        if text:
+            return text
+    return ""
+
+
 def _order_time_seconds(row):
     """把 ORDER 行的报单日期+时间转成 Unix 秒, 拿不到返回 0。
 
@@ -204,6 +227,7 @@ class BigQmtOrderGateway:
                     strategy_name=str(_attr(row, ("m_strStrategyName", "strategy_name"), "") or ""),
                     remark=str(_attr(row, ("m_strRemark", "remark"), "") or ""),
                     order_time=_order_time_seconds(row),
+                    status_msg=_status_message(row),
                 )
             )
         return result

--- a/src/bigqmt_signal_trader/exec_events.py
+++ b/src/bigqmt_signal_trader/exec_events.py
@@ -376,6 +376,13 @@ def normalize_order_event(order, account_id=""):
         "remark": str(_attr(order, ["m_strRemark", "order_remark", "remark", "user_order_id"], "") or ""),
         "user_order_id": str(_attr(order, ["m_strRemark", "user_order_id", "order_remark", "remark"], "") or ""),
         "opt_name": str(_attr(order, ["m_strOptName", "opt_name"], "") or ""),
+        # 委托状态描述。官方字段表: m_strCancelInfo=废单原因, m_strErrorMsg=状态信息。
+        # 柜台的拒单理由 ("[COUNTER] 资金可用余额不足，尚需[...]") 只在这里,
+        # 此前完全没有透传, 客户端看到的是一个没有原因的失败 (issue #60)。
+        "status_msg": str(
+            _attr(order, ["m_strCancelInfo", "m_strErrorMsg", "m_strStatusMsg",
+                          "status_msg", "error_msg"], "") or ""
+        ),
         # 官方 Order 字段 m_strInsertDate+m_strInsertTime -> 真实报单 Unix 秒。
         # 0 = 回调对象未携带 (老版本), 客户端会退回 created_at_ts。
         "order_time": date_time_seconds(
@@ -506,7 +513,13 @@ def normalize_order_error_event(order_error, account_id=""):
         "stock_code": str(_attr(order_error, ["m_strInstrumentID", "stock_code"], "") or ""),
         "order_sys_id": str(_attr(order_error, ["m_strOrderSysID", "order_sys_id", "order_sysid", "order_id"], "") or ""),
         "error_id": _attr(order_error, ["m_nErrorID", "error_id", "m_nOrderStatus"]),
-        "error_msg": str(_attr(order_error, ["m_strErrorMsg", "error_msg", "m_strMsg"], "") or ""),
+        # m_strCancelInfo 排在最前: 官方字段表把它标为「废单原因」, 而柜台的
+        # 拒单理由 ("[COUNTER] 资金可用余额不足，尚需[...]") 正是走这个字段。
+        # 之前只读 m_strErrorMsg, 于是 error_msg 常常是空的 (issue #60)。
+        "error_msg": str(
+            _attr(order_error, ["m_strCancelInfo", "m_strErrorMsg", "error_msg",
+                                "m_strMsg", "m_strStatusMsg", "status_msg"], "") or ""
+        ),
         "created_at": time.strftime("%Y-%m-%d %H:%M:%S"),
         "created_at_ts": time.time(),
     }

--- a/src/bigqmt_signal_trader/models.py
+++ b/src/bigqmt_signal_trader/models.py
@@ -267,6 +267,7 @@ class OrderSnapshot:
         strategy_name="",
         remark="",
         order_time=0,
+        status_msg="",
     ):
         self.order_sys_id = order_sys_id
         self.user_order_id = user_order_id
@@ -281,6 +282,10 @@ class OrderSnapshot:
         # 报单时间, Unix 秒 -- MiniQMT XtOrder.order_time 的语义。0 = 未上报。
         # 追加在末尾并给默认值, 保持既有位置参数调用不受影响。
         self.order_time = order_time
+        # 委托状态描述 —— MiniQMT XtOrder.status_msg 的语义 (如废单原因)。
+        # 柜台的拒单理由只在这里, 例如
+        # "[COUNTER] 资金可用余额不足，尚需[4789.630]" (issue #60)。
+        self.status_msg = status_msg
 
 
 class TradeSnapshot:

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -2757,6 +2757,8 @@ class BigQmtXtTrader:
             # created_at_ts 不发 order_time，所以没有显式 order_time 时
             # 用 created_at_ts 兜底；两者都没有才落到 0（不要当成 1970 年）。
             order_time=_safe_int(item.get("order_time") or item.get("created_at_ts"), 0),
+            # MiniQMT XtOrder.status_msg —— 废单时柜台给的原因 (issue #60)。
+            status_msg=str(item.get("status_msg") or ""),
         )
 
     def _trade_from_dict(self, account_id, item):

--- a/tests/bigqmt_signal_trader/test_bigqmt_adapters.py
+++ b/tests/bigqmt_signal_trader/test_bigqmt_adapters.py
@@ -87,6 +87,46 @@ class BigQmtAdaptersTest(unittest.TestCase):
         self.assertEqual(context.instrument_codes, ["000001.SZ"])
         self.assertEqual(instrument["InstrumentStatus"], 0)
 
+    def test_get_ticks_keys_keep_the_caller_case_for_futures(self):
+        """issue #58: futures instrument codes are lower-case ('rb2708.SF'), but
+        the keys came back upper-cased, so `code in result` failed for every
+        futures code and the book looked missing."""
+        class EchoContext:
+            def __init__(self):
+                self.tick_codes = []
+
+            def get_full_tick(self, codes):
+                self.tick_codes.append(list(codes))
+                return dict((c, {"lastPrice": 1.0}) for c in codes)
+
+        context = EchoContext()
+        provider = BigQmtMarketDataProvider(context)
+
+        ticks = provider.get_ticks(["rb2708.SF", "a2609.DF"])
+
+        # QMT is still asked in upper case...
+        self.assertEqual(context.tick_codes, [["RB2708.SF", "A2609.DF"]])
+        # ...but the caller gets its own spelling back.
+        self.assertEqual(sorted(ticks), ["a2609.DF", "rb2708.SF"])
+
+    def test_get_ticks_still_completes_the_suffix(self):
+        """Only case is restored. Completing '600000' to '600000.SH' is useful
+        normalization that callers depend on, so it must survive."""
+        context = FakeContext()
+        provider = BigQmtMarketDataProvider(context)
+
+        self.assertIn("600000.SH", provider.get_ticks(["600000"]))
+
+    def test_get_ticks_passes_through_an_unrequested_key(self):
+        """Dropping a quote QMT volunteered would be worse than an odd key."""
+        class ExtraContext:
+            def get_full_tick(self, codes):
+                return {"RB2708.SF": {"lastPrice": 1.0}, "SURPRISE.SF": {"lastPrice": 2.0}}
+
+        ticks = BigQmtMarketDataProvider(ExtraContext()).get_ticks(["rb2708.SF"])
+
+        self.assertEqual(sorted(ticks), ["SURPRISE.SF", "rb2708.SF"])
+
     def test_market_provider_passes_market_codes_to_full_tick(self):
         context = FakeContext()
         provider = BigQmtMarketDataProvider(context)

--- a/tests/bigqmt_signal_trader/test_order_status_msg.py
+++ b/tests/bigqmt_signal_trader/test_order_status_msg.py
@@ -1,0 +1,140 @@
+"""issue #60: the counter's reason for rejecting an order never reached callers.
+
+status_msg and error_msg both came back empty, so a rejection like
+"[COUNTER] 资金可用余额不足，尚需[4789.630]" surfaced as a failure with no cause.
+
+Field names come from the official table in
+docs/BIGQMT_INNER_PYTHON_API_REFERENCE.md: m_strCancelInfo is 废单原因 (the
+counter's text lands there), m_strErrorMsg is 状态信息.
+"""
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.adapters.order_bigqmt import BigQmtOrderGateway, _status_message
+from bigqmt_signal_trader.exec_events import (
+    normalize_order_error_event,
+    normalize_order_event,
+)
+from bigqmt_signal_trader.models import OrderSnapshot
+from bigqmt_signal_trader.xtquant_compat import BigQmtXtTrader, StockAccount
+
+
+COUNTER_MSG = "[COUNTER] 资金可用余额不足，尚需[4789.630]"
+
+
+class Row(object):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _order_row(**overrides):
+    base = dict(
+        m_strOrderSysID="sys-1",
+        m_strRemark="tag-1",
+        m_strInstrumentID="601398",
+        m_strExchangeID="SH",
+        m_nOffsetFlag=48,
+        m_nVolumeTotalOriginal=100,
+        m_nVolumeTraded=0,
+        m_nOrderStatus=57,  # 废单
+        m_dLimitPrice=7.66,
+        m_strStrategyName="s1",
+    )
+    base.update(overrides)
+    return Row(**base)
+
+
+class StatusMessageExtractionTest(unittest.TestCase):
+    def test_reads_the_cancel_reason(self):
+        self.assertEqual(
+            _status_message(_order_row(m_strCancelInfo=COUNTER_MSG)), COUNTER_MSG)
+
+    def test_cancel_reason_wins_over_the_generic_status(self):
+        """废单原因 is the specific one; 状态信息 is often just a status word."""
+        row = _order_row(m_strCancelInfo=COUNTER_MSG, m_strErrorMsg="失败")
+        self.assertEqual(_status_message(row), COUNTER_MSG)
+
+    def test_falls_back_to_the_status_field(self):
+        self.assertEqual(_status_message(_order_row(m_strErrorMsg="废单")), "废单")
+
+    def test_blank_fields_are_skipped(self):
+        """An empty 废单原因 must not shadow a populated 状态信息."""
+        row = _order_row(m_strCancelInfo="   ", m_strErrorMsg=COUNTER_MSG)
+        self.assertEqual(_status_message(row), COUNTER_MSG)
+
+    def test_no_message_yields_empty_string(self):
+        self.assertEqual(_status_message(_order_row()), "")
+
+
+class OrderSnapshotStatusMsgTest(unittest.TestCase):
+    def test_defaults_keep_positional_callers_working(self):
+        self.assertEqual(
+            OrderSnapshot("sys", "tag", "601398.SH", "BUY", 100, 0, "50").status_msg, "")
+
+    def test_query_orders_carries_the_reason(self):
+        rows = [_order_row(m_strCancelInfo=COUNTER_MSG)]
+        gateway = BigQmtOrderGateway(
+            context_info=None,
+            passorder_func=None,
+            cancel_func=None,
+            get_trade_detail_data_func=lambda a, t, d, s="": rows if d == "ORDER" else [],
+        )
+
+        self.assertEqual(gateway.query_orders("acct", "")[0].status_msg, COUNTER_MSG)
+
+
+class OrderEventStatusMsgTest(unittest.TestCase):
+    def test_order_event_carries_the_reason(self):
+        event = normalize_order_event(_order_row(m_strCancelInfo=COUNTER_MSG), "acct")
+        self.assertEqual(event["status_msg"], COUNTER_MSG)
+
+    def test_order_error_event_reads_the_cancel_reason(self):
+        """The counter's text is in m_strCancelInfo; reading only m_strErrorMsg
+        is why error_msg was empty."""
+        event = normalize_order_error_event(
+            Row(m_strOrderSysID="sys-1", m_strInstrumentID="601398.SH",
+                m_nErrorID=-1, m_strCancelInfo=COUNTER_MSG), "acct")
+
+        self.assertEqual(event["error_msg"], COUNTER_MSG)
+
+    def test_order_error_event_still_reads_the_plain_error_field(self):
+        event = normalize_order_error_event(
+            Row(m_strOrderSysID="sys-1", m_nErrorID=-1, m_strErrorMsg="rejected"), "acct")
+
+        self.assertEqual(event["error_msg"], "rejected")
+
+
+class ClientStatusMsgTest(unittest.TestCase):
+    """The reported symptom: XtOrder.status_msg is empty."""
+
+    def _orders(self, payload):
+        trader = BigQmtXtTrader(account_id="acct")
+        trader.client.call = lambda method, params=None, account_id=None, **kw: payload
+        return trader.query_stock_orders(StockAccount("acct"))
+
+    def test_status_msg_is_exposed(self):
+        orders = self._orders([{
+            "stock_code": "601398.SH", "action": "BUY", "order_sys_id": "sys-1",
+            "volume": 100, "status": 57, "status_msg": COUNTER_MSG,
+        }])
+
+        self.assertEqual(orders[0].status_msg, COUNTER_MSG)
+
+    def test_missing_status_msg_defaults_to_empty(self):
+        """A server predating this field must not raise AttributeError."""
+        orders = self._orders([{
+            "stock_code": "601398.SH", "action": "BUY", "order_sys_id": "sys-1",
+            "volume": 100,
+        }])
+
+        self.assertEqual(orders[0].status_msg, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
关联 issue #58、#60。437 个测试通过。

## #58 get_full_tick 的 key 被全大写

你在 issue 里定位的根因完全正确——[market_bigqmt.py](src/bigqmt_signal_trader/adapters/market_bigqmt.py) 的 `get_ticks()` 把代码 upper() 后传给 QMT，返回时没映射回去。期货交易所的合约代码是小写（`rb2708`、`a2609`、`nr2612`），于是 `code in result` 对每一个都失败。

**但只还原大小写，不还原归一化。** 我第一版改过头了：把整个原始输入当 key 退回去，结果 `600000` → `600000.SH` 的后缀补全也被撤销，现有测试当场变红。补全后缀是有用的、调用方依赖的行为。

所以现在只有**纯大小写差异**的代码才映射回去——正好就是期货这一类。

QMT 主动返回、但我们没请求过的 key 原样透传而不是丢弃：**丢一条行情比多一个 key 更糟**。

## #60 柜台拒单原因没传出

两处独立的缺口：

1. `OrderSnapshot` **根本没有 status_msg 字段**，所以 `query_stock_orders` 无从携带
2. `normalize_order_error_event` **只读 `m_strErrorMsg`**

而柜台的文本在 **`m_strCancelInfo`** 里。这次字段名不用猜——PR #59 刚合并的官方字段表（`docs/BIGQMT_INNER_PYTHON_API_REFERENCE.md`）明确标注：

```
| m_strCancelInfo | str | 废单原因 |
...
57 废单（原因见 m_strCancelInfo）
```

所以这次没有用「多候选名 + 字段自曝」那套兜底，直接按文档写。

`status_msg` 已贯通 `OrderSnapshot` → `order_bigqmt` → 委托事件 → `_order_from_dict`；`order_error` 事件改为**优先读 `m_strCancelInfo`**。空白的废单原因不会遮蔽有内容的状态信息。

## 验证

两处修复各自还原后，对应测试变红：

| 还原 | 变红的测试 |
|---|---|
| 大小写还原 | `test_get_ticks_keys_keep_the_caller_case_for_futures`、`test_get_ticks_passes_through_an_unrequested_key` |
| `m_strCancelInfo` 优先 | `test_order_error_event_reads_the_cancel_reason` |

另有测试保证不回归：`test_get_ticks_still_completes_the_suffix`（后缀补全仍在）、`test_missing_status_msg_defaults_to_empty`（旧服务端不抛 AttributeError）。

## 未验证

`m_strCancelInfo` 的实际内容需要一笔真实废单才能确认（比如资金不足）。字段名有官方文档背书，但**没有实盘样本**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)