### PR TITLE
fix(bigqmt): parse POSITION futures codes correctly; support BIGQMT_ACCOUNT_TYPE

### DIFF
--- a/src/bigqmt_signal_trader/adapters/position_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/position_bigqmt.py
@@ -61,14 +61,54 @@ def _report_missing_field(label, row, candidates):
     )
 
 
+# Big QMT reports an instrument's market as the 迅投简称 (XunTou short) token on
+# POSITION/ORDER/DEAL rows. The same token is appended as the ContextInfo code
+# suffix (a2609.DF, rb2401.SF, 000001.SZ, 00700.HGT).
+# Stock/mutual-fund/HK-Connect markets: case-insensitive, unified via normalize.
+_STOCK_EXCHANGE_TOKENS = frozenset({"SH", "SZ", "BJ", "HK", "HGT", "SGT"})
+# Futures XunTou-short exchange tokens: only concatenate the suffix. The symbol
+# must follow each exchange's canonical naming and is case-sensitive
+# (AP401.ZF upper-case / rb2401.SF lower-case, not interchangeable), so never
+# rewrite its case.
+_FUTURES_EXCHANGE_TOKENS = frozenset({"IF", "SF", "DF", "ZF", "INE", "GF"})
+# Counter-style (display) futures exchange IDs also seen on POSITION rows.
+# Their symbol carries no suffix; return the raw code as a stable key.
+_FUTURES_EXCHANGES = frozenset({
+    "SHFE", "DCE", "CZCE", "ZCE", "CFFEX", "INE", "GFEX", "GZFE",
+})
+
+
 def _full_code(instrument_id, exchange_id):
-    code = str(instrument_id or "").strip().upper()
+    if instrument_id is None:
+        return ""
+    raw = str(instrument_id).strip()
+    if not raw:
+        return ""
     market = str(exchange_id or "").strip().upper()
-    if "." in code:
-        return normalize_stock_code(code)
-    if market in ("SH", "SZ"):
-        return normalize_stock_code("%s.%s" % (code, market))
-    return normalize_stock_code(code)
+    if "." in raw:
+        return normalize_stock_code(raw)
+    # Futures: decide purely from the exchange field (no code-shape guessing).
+    # Symbol is case-sensitive and preserved as-is; XunTou-short tokens get the
+    # suffix appended, counter display IDs return the raw bare key.
+    if market in _FUTURES_EXCHANGE_TOKENS:
+        return "%s.%s" % (raw, market)
+    if market in _FUTURES_EXCHANGES:
+        # Unexpected path: POSITION rows normally carry the XunTou-short token
+        # (DF/SF/...), so a display ID here signals a structure/vendor mismatch.
+        # Surface it so the caller can tell the difference from a genuine
+        # futures row that carries the XunTou-short token.
+        raise ValueError(
+            f"[bigqmt_code] futures exchange reported a display ID "
+            f"'{market}' for instrument '{raw}'; expected the XunTou-short "
+            f"token (e.g. 'DF' for DCE), not the counter-style ID"
+        )
+    # Stock/mutual-fund/HK-Connect: normalize into standard upper-case with suffix.
+    if market in _STOCK_EXCHANGE_TOKENS:
+        return normalize_stock_code("%s.%s" % (raw, market))
+    # Unknown/empty exchange: an instrument is never a futures contract without
+    # an exchange, so hand it to the normalizer and let an unrecognizable code
+    # raise -- a bare code here means the row itself is malformed.
+    return normalize_stock_code(raw)
 
 
 class BigQmtPositionProvider:

--- a/src/bigqmt_signal_trader/code_utils.py
+++ b/src/bigqmt_signal_trader/code_utils.py
@@ -15,6 +15,7 @@ def normalize_stock_code(code):
     # these are native ContextInfo codes that need no normalization.
     _QMT_SUFFIXES = (
         ".SH", ".SZ", ".BJ", ".HK",           # Stock markets
+        ".HGT", ".SGT",                        # 港股通（沪/深）
         ".SHO", ".SZO",                        # Options markets (8-digit codes)
         ".SF", ".DF", ".IF", ".ZF", ".INE", ".GF",    # Futures markets
     )

--- a/src/bigqmt_signal_trader_local_config.example.py
+++ b/src/bigqmt_signal_trader_local_config.example.py
@@ -10,6 +10,8 @@ Do not commit the real file. It may contain account ids and Redis credentials.
 
 BIGQMT_ACCOUNT_ID = "YOUR_ACCOUNT_ID"
 
+BIGQMT_ACCOUNT_TYPE = "STOCK"
+
 BIGQMT_REDIS_CONFIG = {
     "host": "127.0.0.1",
     "port": 6379,

--- a/src/bigqmt_signal_trader_redis_rpc_runtime.py
+++ b/src/bigqmt_signal_trader_redis_rpc_runtime.py
@@ -60,6 +60,9 @@ else:
 
 
 ACCOUNT_ID = ""
+# 账号类型：STOCK(股票) / CREDIT(信用/两融) / FUTURE(期货) / OPTION(期权)
+# 对应 xtconstant 枚举：SECURITY_ACCOUNT=2 / CREDIT_ACCOUNT=3 / FUTURE_ACCOUNT=1
+ACCOUNT_TYPE = "STOCK"
 REDIS_HOST = "127.0.0.1"
 REDIS_PORT = 6379
 REDIS_DB = 5
@@ -115,12 +118,21 @@ EXEC_EVENTS_ENABLED = True
 EXEC_EVENTS_DEBUG_RAW_FIELDS = False
 
 try:
+    # Keep optional account-type config backward compatible: an old local
+    # config without BIGQMT_ACCOUNT_TYPE must not discard the account ID or
+    # Redis settings that are present in that same module.
     from bigqmt_signal_trader_local_config import BIGQMT_ACCOUNT_ID, BIGQMT_REDIS_CONFIG
 except Exception:
     BIGQMT_ACCOUNT_ID = ""
     BIGQMT_REDIS_CONFIG = {}
+try:
+    from bigqmt_signal_trader_local_config import BIGQMT_ACCOUNT_TYPE
+except Exception:
+    BIGQMT_ACCOUNT_TYPE = "STOCK"
 
 ACCOUNT_ID = str(BIGQMT_ACCOUNT_ID or ACCOUNT_ID or "")
+# 账号类型：只从独立变量 BIGQMT_ACCOUNT_TYPE 读取，默认 STOCK
+ACCOUNT_TYPE = str(BIGQMT_ACCOUNT_TYPE or ACCOUNT_TYPE or "STOCK").strip().upper()
 REDIS_HOST = BIGQMT_REDIS_CONFIG.get("host", REDIS_HOST)
 REDIS_PORT = int(BIGQMT_REDIS_CONFIG.get("port", REDIS_PORT))
 REDIS_DB = int(BIGQMT_REDIS_CONFIG.get("db", REDIS_DB))
@@ -172,6 +184,7 @@ def _apply_config(account_id):
     configure(
         mode="bigqmt",
         account_id=account_id,
+        account_type=ACCOUNT_TYPE,
         position_sync_type="redis" if RPC_TRANSPORT in ("redis", "", "default") else "",
         enable_rpc=True,
         schedule_adjust=SCHEDULE_ADJUST_ENABLED,

--- a/tests/bigqmt_signal_trader/test_bigqmt_adapters.py
+++ b/tests/bigqmt_signal_trader/test_bigqmt_adapters.py
@@ -11,6 +11,7 @@ from bigqmt_signal_trader.adapter_factory import build_app
 from bigqmt_signal_trader.adapters.market_bigqmt import BigQmtMarketDataProvider
 from bigqmt_signal_trader.adapters.order_bigqmt import BigQmtOrderGateway
 from bigqmt_signal_trader.adapters.position_bigqmt import BigQmtPositionProvider
+from bigqmt_signal_trader.adapters.position_bigqmt import _full_code
 from bigqmt_signal_trader.models import OrderRef, OrderRequest
 
 
@@ -75,6 +76,36 @@ class FakeMarketDataFallbackContext(FakeContext):
 
 
 class BigQmtAdaptersTest(unittest.TestCase):
+
+    def test_position_code_keeps_future_contract_code(self):
+        # A futures row always carries the XunTou-short exchange token, so a
+        # bare contract with an empty exchange is not futures -- normalize it
+        # and let an unrecognizable code raise as malformed.
+        with self.assertRaises(ValueError):
+            _full_code("EG2609", "")
+        with self.assertRaises(ValueError):
+            _full_code("IF2609", "")
+        self.assertEqual(_full_code("600000", "SH"), "600000.SH")
+
+    def test_futures_exchange_short_token_appends_suffix_and_preserves_case(self):
+        """Futures are classified by the exchange field (XunTou-short token),
+        which is appended as the suffix. The symbol keeps the exchange's exact
+        case (e.g. rb2401.SF lower, AP401.ZF upper) and must not be rewritten."""
+        self.assertEqual(_full_code("rb2401", "SF"), "rb2401.SF")   # SHFE lower-case
+        self.assertEqual(_full_code("AP401", "ZF"), "AP401.ZF")     # CZCE upper-case
+        self.assertEqual(_full_code("a2609", "DF"), "a2609.DF")     # DCE lower-case
+        self.assertEqual(_full_code("sc2401", "INE"), "sc2401.INE") # INE lower-case
+        self.assertEqual(_full_code("IF2609", "IF"), "IF2609.IF")   # CFFEX
+        self.assertEqual(_full_code("GF2609", "GF"), "GF2609.GF")   # GFEX
+
+    def test_futures_display_exchange_id_raises(self):
+        """A counter display ID (DCE/CFFEX/...) is an unexpected path: POSITION
+        rows normally carry the XunTou-short token (DF/SF/...), so this signals
+        a structure/vendor mismatch and must surface rather than degrade."""
+        for exchange in ("DCE", "CFFEX"):
+            with self.assertRaises(ValueError):
+                _full_code("EG2609", exchange)
+
     def test_market_provider_normalizes_codes_before_context_call(self):
         context = FakeContext()
         provider = BigQmtMarketDataProvider(context)


### PR DESCRIPTION
Positions / codes:
- bare futures contracts (exchange_id is the XunTou-short token DF/SF/ZF) were misrouted into the stock normalizer and raised invalid stock code; now classify by the exchange field instead:
  * futures XunTou-short tokens (IF/SF/DF/ZF/INE/GF) get the suffix appended with the symbol's exact case preserved (rb2401.SF / AP401.ZF)
  * futures display IDs (SHFE/DCE/CFFEX/...) are an unexpected structure and now raise, surfacing a genuine vendor/format mismatch
  * stock / HK-Connect markets normalize with suffix appended
- add/refresh unit tests: short-token suffix with case preserved; display ID and empty-exchange bare codes asserted to raise

Config:
- add an independent BIGQMT_ACCOUNT_TYPE variable in local_config (parallel to account_id, default STOCK)
- redis_rpc_runtime imports it backward-compatibly, normalizes it to an upper-case string, and passes account_type=... into configure() so the account type becomes configurable and reliably arrives as a string