### PR TITLE
一行无法解析的数据不应搞垮整个查询（跟进 #68）

### DIFF
--- a/src/bigqmt_signal_trader/adapters/order_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/order_bigqmt.py
@@ -8,7 +8,7 @@ import hashlib
 from ..code_utils import normalize_stock_code
 from ..exec_events import date_time_seconds
 from ..models import CancelResult, OrderSnapshot, OrderSubmitResult, SignalAction, TradeSnapshot
-from .position_bigqmt import _attr, _full_code
+from .position_bigqmt import _attr, _full_code, skip_unparsable_row
 
 
 PRICE_TYPE_ALIASES = {
@@ -211,14 +211,19 @@ class BigQmtOrderGateway:
         rows = query(account_id, self.account_type, "ORDER", strategy_name) or []
         result = []
         for row in rows:
+            try:
+                stock_code = _full_code(
+                    _attr(row, ("m_strInstrumentID", "instrument_id", "stock_code")),
+                    _attr(row, ("m_strExchangeID", "exchange_id", "market")),
+                )
+            except Exception as exc:
+                skip_unparsable_row("ORDER", row, exc)
+                continue
             result.append(
                 OrderSnapshot(
                     order_sys_id=str(_attr(row, ("m_strOrderSysID", "order_sys_id"), "") or ""),
                     user_order_id=str(_attr(row, ("m_strRemark", "user_order_id", "remark"), "") or ""),
-                    stock_code=_full_code(
-                        _attr(row, ("m_strInstrumentID", "instrument_id", "stock_code")),
-                        _attr(row, ("m_strExchangeID", "exchange_id", "market")),
-                    ),
+                    stock_code=stock_code,
                     action=_action_from_offset_flag(_attr(row, ("m_nOffsetFlag", "offset_flag"), 0)),
                     volume=int(_attr(row, ("m_nVolumeTotalOriginal", "volume"), 0) or 0),
                     traded_volume=int(_attr(row, ("m_nVolumeTraded", "traded_volume"), 0) or 0),
@@ -257,14 +262,19 @@ class BigQmtOrderGateway:
         result = []
         for row in rows:
             traded_at_raw = _attr(row, ("m_strTradeTime", "trade_time", "traded_at"), "")
+            try:
+                stock_code = _full_code(
+                    _attr(row, ("m_strInstrumentID", "instrument_id", "stock_code")),
+                    _attr(row, ("m_strExchangeID", "exchange_id", "market")),
+                )
+            except Exception as exc:
+                skip_unparsable_row("DEAL", row, exc)
+                continue
             result.append(
                 TradeSnapshot(
                     trade_id=str(_attr(row, ("m_strTradeID", "trade_id"), "") or ""),
                     order_sys_id=str(_attr(row, ("m_strOrderSysID", "order_sys_id"), "") or ""),
-                    stock_code=_full_code(
-                        _attr(row, ("m_strInstrumentID", "instrument_id", "stock_code")),
-                        _attr(row, ("m_strExchangeID", "exchange_id", "market")),
-                    ),
+                    stock_code=stock_code,
                     action=_action_from_offset_flag(_attr(row, ("m_nOffsetFlag", "offset_flag"), 0)),
                     volume=int(_attr(row, ("m_nVolume", "volume"), 0) or 0),
                     price=float(_attr(row, ("m_dPrice", "m_dTradePrice", "price"), 0.0) or 0.0),

--- a/src/bigqmt_signal_trader/adapters/position_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/position_bigqmt.py
@@ -111,6 +111,34 @@ def _full_code(instrument_id, exchange_id):
     return normalize_stock_code(raw)
 
 
+# One unparsable row must not cost the whole query. _full_code raises on a
+# structure it does not recognise (a counter-style futures exchange ID, a
+# malformed bare code), and every caller loops over rows without per-row
+# protection -- so without this, a single odd row turns "one position missing"
+# into "no positions at all", which for a trading system is far worse.
+#
+# Reported once per (kind, exchange) so a persistently odd row does not flood
+# the QMT panel, while still naming what to look at.
+_unparsable_rows_reported = set()
+
+
+def skip_unparsable_row(kind, row, exc):
+    """Log an unparsable row once and let the caller skip it."""
+    exchange = ""
+    instrument = ""
+    try:
+        exchange = str(_attr(row, ("m_strExchangeID", "exchange_id", "market"), "") or "")
+        instrument = str(_attr(row, ("m_strInstrumentID", "instrument_id", "stock_code"), "") or "")
+    except Exception:
+        pass
+    key = (kind, exchange)
+    if key in _unparsable_rows_reported:
+        return
+    _unparsable_rows_reported.add(key)
+    print("[bigqmt_code] skipping unparsable %s row (instrument=%r exchange=%r): %s"
+          % (kind, instrument, exchange, exc))
+
+
 class BigQmtPositionProvider:
     def __init__(self, get_trade_detail_data_func, account_type="STOCK"):
         self.get_trade_detail_data = get_trade_detail_data_func
@@ -131,10 +159,14 @@ class BigQmtPositionProvider:
             return {}
         positions = {}
         for row in rows:
-            code = _full_code(
-                _attr(row, ("m_strInstrumentID", "instrument_id", "stock_code")),
-                _attr(row, ("m_strExchangeID", "exchange_id", "market")),
-            )
+            try:
+                code = _full_code(
+                    _attr(row, ("m_strInstrumentID", "instrument_id", "stock_code")),
+                    _attr(row, ("m_strExchangeID", "exchange_id", "market")),
+                )
+            except Exception as exc:
+                skip_unparsable_row("POSITION", row, exc)
+                continue
             positions[code] = PositionSnapshot(
                 stock_code=code,
                 volume=int(_attr(row, ("m_nVolume", "volume"), 0) or 0),

--- a/tests/bigqmt_signal_trader/test_bigqmt_adapters.py
+++ b/tests/bigqmt_signal_trader/test_bigqmt_adapters.py
@@ -425,3 +425,91 @@ class FinancialFieldTranslateTest(unittest.TestCase):
         self.assertEqual(calls[0][0], ["CustomTable"])
 
 
+
+
+class UnparsableRowIsolationTest(unittest.TestCase):
+    """A row _full_code cannot parse must cost that row, not the query.
+
+    PR #68 made _full_code raise on a counter-style futures exchange ID, which
+    is the right signal -- but every caller loops without per-row protection, so
+    one odd row turned "one position missing" into "no positions at all". For a
+    trading system that is the more dangerous failure.
+    """
+
+    class _Row(object):
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    def _rows(self):
+        return [
+            self._Row(m_strInstrumentID="600000", m_strExchangeID="SH",
+                      m_nVolume=100, m_nCanUseVolume=100,
+                      m_nVolumeTotalOriginal=100, m_nVolumeTraded=0,
+                      m_strTradeID="t1", m_nVolume_deal=1),
+            # Counter-style display ID -- _full_code raises on this one.
+            self._Row(m_strInstrumentID="rb2401", m_strExchangeID="SHFE",
+                      m_nVolume=1, m_nCanUseVolume=1,
+                      m_nVolumeTotalOriginal=1, m_nVolumeTraded=0,
+                      m_strTradeID="t2"),
+            self._Row(m_strInstrumentID="000001", m_strExchangeID="SZ",
+                      m_nVolume=200, m_nCanUseVolume=200,
+                      m_nVolumeTotalOriginal=200, m_nVolumeTraded=0,
+                      m_strTradeID="t3"),
+        ]
+
+    def setUp(self):
+        from bigqmt_signal_trader.adapters import position_bigqmt
+
+        position_bigqmt._unparsable_rows_reported.clear()
+
+    def test_positions_survive_one_unparsable_row(self):
+        from bigqmt_signal_trader.adapters.position_bigqmt import BigQmtPositionProvider
+
+        rows = self._rows()
+        provider = BigQmtPositionProvider(lambda a, t, d: rows if d == "POSITION" else [])
+
+        positions = provider.get_positions("acct")
+
+        self.assertEqual(sorted(positions), ["000001.SZ", "600000.SH"])
+
+    def test_orders_survive_one_unparsable_row(self):
+        from bigqmt_signal_trader.adapters.order_bigqmt import BigQmtOrderGateway
+
+        rows = self._rows()
+        gateway = BigQmtOrderGateway(
+            context_info=None, passorder_func=None, cancel_func=None,
+            get_trade_detail_data_func=lambda a, t, d, s="": rows if d == "ORDER" else [])
+
+        orders = gateway.query_orders("acct", "")
+
+        self.assertEqual(sorted(o.stock_code for o in orders), ["000001.SZ", "600000.SH"])
+
+    def test_trades_survive_one_unparsable_row(self):
+        from bigqmt_signal_trader.adapters.order_bigqmt import BigQmtOrderGateway
+
+        rows = self._rows()
+        gateway = BigQmtOrderGateway(
+            context_info=None, passorder_func=None, cancel_func=None,
+            get_trade_detail_data_func=lambda a, t, d, s="": rows if d == "DEAL" else [])
+
+        trades = gateway.query_trades("acct", "")
+
+        self.assertEqual(sorted(t.stock_code for t in trades), ["000001.SZ", "600000.SH"])
+
+    def test_the_skipped_row_is_reported_once(self):
+        import contextlib
+        import io as _io
+
+        from bigqmt_signal_trader.adapters.position_bigqmt import BigQmtPositionProvider
+
+        rows = self._rows()
+        provider = BigQmtPositionProvider(lambda a, t, d: rows if d == "POSITION" else [])
+        buffer = _io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            provider.get_positions("acct")
+            provider.get_positions("acct")
+        output = buffer.getvalue()
+
+        self.assertEqual(output.count("skipping unparsable"), 1)
+        self.assertIn("rb2401", output)
+        self.assertIn("SHFE", output)


### PR DESCRIPTION
PR #68 的跟进补丁。455 个测试通过。

## #68 引入的问题

`_full_code` 现在遇到无法识别的结构会 `raise`——柜台式期货交易所 ID、或畸形的裸代码。**这个信号本身是对的**：厂商上报 `SHFE` 而非迅投简称 `SF`，确实值得暴露。

但三个调用方的 `for row in rows` 循环**都没有逐行保护**，异常会一路抛出 `get_positions` / `query_orders` / `query_trades`：

| 调用点 | 后果 |
|---|---|
| `position_bigqmt.py` | 一行异常 → **整个持仓查询失败**，不是少一行 |
| `order_bigqmt.py` ORDER | `query_orders` 外层 `except` 返回 `[]` → **丢掉全部委托** |
| `order_bigqmt.py` DEAL | 同上 |

对交易系统来说，「持仓完全查不到」比「一行代码格式怪」严重得多。

而且它和这个模块自己的既定风格矛盾——POSITION 查询外面那个 try/except 的注释写着 *"degrade to empty like get_asset does"*。

## 修复

每个循环跳过解析不了的那一行，其余照常返回。跳过按 `(kind, exchange)` **只记一次日志**，这样持续异常的行会自报家门，又不会刷屏 QMT 面板。

## 验证

4 个新测试，**逐一确认去掉保护就会失败**：

```
test_positions_survive_one_unparsable_row      3 行中 1 行坏 -> 仍返回 2 个持仓
test_orders_survive_one_unparsable_row         同上
test_trades_survive_one_unparsable_row         同上
test_the_skipped_row_is_reported_once          两次查询只打一条日志, 且含 rb2401/SHFE
```

#68 本身的功能不受影响，期货代码解析实测正确：

```
rb2401  SF   -> rb2401.SF     小写保留
AP401   ZF   -> AP401.ZF      大写保留
00700   HGT  -> 00700.HGT     港股通
600000  SH   -> 600000.SH     股票不受影响
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)