### PR TITLE
修复 xtquant / xtquant_compat 循环导入（跟进 #73）

### DIFF
--- a/src/xtquant/__init__.py
+++ b/src/xtquant/__init__.py
@@ -4,6 +4,34 @@ Put this package before the real xtquant package on PYTHONPATH only when the
 caller intentionally wants Big QMT RPC compatibility.
 """
 
-from . import xtconstant, xtdata, xttrader, xttype
+# xtconstant / xttype are pure definitions and safe to import eagerly.
+#
+# xtdata and xttrader are NOT: both reach back into
+# bigqmt_signal_trader.xtquant_compat, which itself does
+# ``from xtquant.xtconstant import *``. Importing them here closes the loop --
+# ``import bigqmt_signal_trader`` then fails with "partially initialized
+# module", and only in that direction, so whether it breaks depends on which
+# package the caller happens to import first.
+#
+# Resolved lazily through __getattr__ (PEP 562): ``xtquant.xtdata`` and
+# ``from xtquant import xttrader`` both still work, but the import runs after
+# xtquant_compat has finished initialising rather than in the middle of it.
+from . import xtconstant, xttype
 
 __all__ = ["xtconstant", "xtdata", "xttrader", "xttype"]
+
+_LAZY_SUBMODULES = ("xtdata", "xttrader")
+
+
+def __getattr__(name):
+    if name in _LAZY_SUBMODULES:
+        import importlib
+
+        module = importlib.import_module("." + name, __name__)
+        globals()[name] = module      # resolve once, then it is a plain attribute
+        return module
+    raise AttributeError("module %r has no attribute %r" % (__name__, name))
+
+
+def __dir__():
+    return sorted(set(list(globals()) + list(_LAZY_SUBMODULES)))

--- a/tests/test_xtquant_shim_import.py
+++ b/tests/test_xtquant_shim_import.py
@@ -1,0 +1,138 @@
+"""The xtquant shim must not form an import cycle with xtquant_compat.
+
+xtquant_compat does ``from xtquant.xtconstant import *``, so anything
+xtquant/__init__ imports eagerly runs while xtquant_compat is still half
+initialised. xtdata and xttrader both reach back into it, which closes the loop.
+
+The failure is direction-dependent -- ``import xtquant`` first works, ``import
+bigqmt_signal_trader`` first raises -- so it survives casual testing and shows
+up only in whichever process happens to import the other package first. These
+tests run each direction in a clean interpreter.
+"""
+
+import os
+import subprocess
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SRC = os.path.join(ROOT, "src")
+
+
+def _run(code):
+    """Execute in a fresh interpreter: import order is the whole point here."""
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True, text=True, cwd=ROOT,
+        env=dict(os.environ, PYTHONPATH=SRC),
+    )
+
+
+class ImportCycleTest(unittest.TestCase):
+    def test_importing_the_package_first_works(self):
+        """The direction that broke: bigqmt_signal_trader before xtquant."""
+        result = _run("import bigqmt_signal_trader; print('ok')")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("ok", result.stdout)
+
+    def test_importing_xtquant_first_works(self):
+        result = _run("import xtquant; import bigqmt_signal_trader; print('ok')")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_compat_import_alone_works(self):
+        result = _run(
+            "from bigqmt_signal_trader.xtquant_compat import BigQmtXtTrader; print('ok')")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_init_does_not_eagerly_import_the_shims(self):
+        """Eager import of either shim re-creates the cycle. Assert on
+        sys.modules rather than on the source, so the guarantee holds however
+        __init__ is written."""
+        result = _run(
+            "import xtquant, sys;"
+            "print('xtdata' if 'xtquant.xtdata' in sys.modules else 'lazy');"
+            "print('xttrader' if 'xtquant.xttrader' in sys.modules else 'lazy')")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.split(), ["lazy", "lazy"])
+
+
+class ShimSurfaceTest(unittest.TestCase):
+    """Laziness must not change how callers reach the shims -- the whole point
+    of this package is that unmodified ``from xtquant import xtdata`` code
+    keeps working."""
+
+    def test_attribute_access(self):
+        result = _run("import xtquant; print(xtquant.xtdata.__name__)")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("xtquant.xtdata", result.stdout)
+
+    def test_from_import(self):
+        result = _run(
+            "from xtquant import xtdata, xttrader, xtconstant, xttype;"
+            "print(callable(xtdata.get_full_tick), hasattr(xttype, 'XtAsset'),"
+            "      xtconstant.STOCK_BUY)")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("True True 23", result.stdout)
+
+    def test_submodule_import(self):
+        result = _run("import xtquant.xttrader; print('ok')")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_dir_lists_the_lazy_submodules(self):
+        result = _run(
+            "import xtquant;"
+            "print(all(n in dir(xtquant) for n in "
+            "('xtconstant', 'xtdata', 'xttrader', 'xttype')))")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("True", result.stdout)
+
+    def test_unknown_attribute_still_raises(self):
+        result = _run(
+            "import xtquant\n"
+            "try:\n"
+            "    xtquant.nope\n"
+            "except AttributeError:\n"
+            "    print('raised')\n")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("raised", result.stdout)
+
+
+class ConstantValueTest(unittest.TestCase):
+    """The port added 443 constants; the 90 that already existed must keep
+    their values. A silently changed STOCK_BUY would misroute live orders."""
+
+    KNOWN = {
+        "STOCK_BUY": 23, "STOCK_SELL": 24,
+        "ORDER_UNREPORTED": 48, "ORDER_SUCCEEDED": 56, "ORDER_JUNK": 57,
+        "FIX_PRICE": 11,
+        "SECURITY_ACCOUNT": 2, "CREDIT_ACCOUNT": 3, "FUTURE_ACCOUNT": 1,
+    }
+
+    def test_known_values_are_unchanged(self):
+        from xtquant import xtconstant
+
+        for name, expected in self.KNOWN.items():
+            self.assertEqual(getattr(xtconstant, name), expected, name)
+
+    def test_compat_reexports_the_same_values(self):
+        from bigqmt_signal_trader import xtquant_compat
+        from xtquant import xtconstant
+
+        for name, expected in self.KNOWN.items():
+            self.assertEqual(getattr(xtquant_compat, name), expected, name)
+            self.assertEqual(getattr(xtquant_compat, name),
+                             getattr(xtconstant, name), name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
PR #73 的必要跟进。**合并 #73 后 main 上 `import bigqmt_signal_trader` 会直接失败**，本 PR 修复它。471 个测试通过。

## 问题

#73 把常量依赖反转（`xtquant_compat` 改为 `from xtquant.xtconstant import *`）——**方向是对的**，常量本就该在 shim 侧。但 `xtquant/__init__` 会急切加载 `xtdata` 和 `xttrader`，而这两个 shim 都反过来引用 `xtquant_compat`：

```
xtquant_compat.py:17    from xtquant.xtconstant import *
  └→ xtquant/__init__.py  from . import xtconstant, xtdata, xttrader, xttype
       └→ xttrader.py:1    from bigqmt_signal_trader.xtquant_compat import BigQmtXtTrader
            └→ ImportError: partially initialized module
```

后果：`import bigqmt_signal_trader` 直接抛错，**27 个测试模块无法收集**。

它还**依赖导入顺序**——先 `import xtquant` 能过，先 `import bigqmt_signal_trader` 就炸。哪个进程会坏取决于谁先被导入，这类 bug 平时测不出来。

## 修复

`xtconstant` / `xttype` 是纯定义，保持急切导入。两个 shim 改为通过模块级 `__getattr__`（PEP 562）惰性解析——它们在 `xtquant_compat` 初始化**完成之后**才加载，而非途中。

调用方用法完全不变，逐项验证过：

```
xtquant.xtdata              OK
from xtquant import xttrader OK
import xtquant.xtdata        OK
dir(xtquant)                 含全部四个
xtquant.nope                 仍正确抛 AttributeError
```

让未经修改的第三方代码能直接 `from xtquant import xtdata` 正是这个包存在的意义，所以这一面不能有任何变化。

## 常量部分我核对过，是干净的

对着 QMT 自带原生 SDK 逐个比对：

| 检查 | 结果 |
|---|---|
| 原生 90 个常量的值 | **0 个被改动** |
| 缺失的原生常量 | **0 个** |
| 从 compat 迁出的 90 个 | **0 个值变化** |
| 新增 | 443 个（券商扩展枚举） |

抽查 `STOCK_BUY=23` / `STOCK_SELL=24` / `ORDER_JUNK=57` / `FIX_PRICE=11` 均正确。

## 测试

新增 11 个：

- **4 个钉住循环** —— 在**全新解释器**里分别测两种导入顺序（同进程测不出来，模块已被缓存）
- **5 个钉住调用面** —— 属性访问 / from-import / 子模块导入 / dir() / 未知属性仍报错
- **2 个钉住常量值** —— 防止以后再动 xtconstant 时悄悄改值

其中 3 个循环测试**已确认「改回急切导入就会变红」**。

```
本 PR 单独   27 个收集错误
main 基线     460 通过
修复后        471 通过
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)