### PR TITLE
adjust 每个 tick 都在新建 Redis 客户端

### DIFF
--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -874,14 +874,20 @@ def _pump_download_jobs(context_info, config):
     account_id = str(job_config.get("account_id") or config.get("account_id") or _account_id or "")
     if not account_id:
         return None
-    redis_client = getattr(_rpc_service, "redis", None)
+    # Reuse one client. This runs on every adjust tick, so building a client
+    # here leaked one connection pool per tick -- at a 100ms interval that is
+    # ten per second. The symptom is easy to miss: the pools are garbage
+    # collected, and redis-py's __del__ then raises
+    # "AttributeError: 'Redis' object has no attribute 'connection'", which
+    # Python swallows as "Exception ignored in". It never reaches a log the
+    # package writes; it only shows up in the QMT panel.
+    #
+    # _exec_event_redis already learned this lesson and caches; this path was
+    # missed. Both only build a client when _rpc_service has none, which is the
+    # zmq-transport case.
+    redis_client = _exec_event_redis(config)
     if redis_client is None:
-        redis_config = dict(config.get("redis") or {})
-        if not redis_config:
-            return None
-        from bigqmt_signal_trader.adapters.redis_common import build_redis_client
-
-        redis_client = build_redis_client(redis_config)
+        return None
     market_data = getattr(getattr(_rpc_service, "handlers", None), "market_data", None)
     if market_data is None:
         from bigqmt_signal_trader.adapters.market_bigqmt import BigQmtMarketDataProvider

--- a/tests/bigqmt_signal_trader/test_adjust_redis_reuse.py
+++ b/tests/bigqmt_signal_trader/test_adjust_redis_reuse.py
@@ -1,0 +1,131 @@
+"""Adjust-phase helpers must reuse one Redis client, not build one per tick.
+
+Found in a live QMT panel log: 31 occurrences in one session of
+
+    Exception ignored in: <object repr() failed>
+      File "...redis/client.py", line 899, in __del__     self.close()
+      File "...redis/client.py", line 902, in close       conn = self.connection
+    AttributeError: 'Redis' object has no attribute 'connection'
+
+That AttributeError is the symptom, not the cause: redis-py's __del__ runs on a
+client whose construction never finished, so `connection` was never assigned.
+The cause is a fresh client per adjust tick -- at a 100ms interval, ten per
+second, each with its own connection pool.
+
+It is easy to miss because Python swallows the traceback ("Exception ignored
+in") and it never reaches a log this package writes. Only the QMT panel shows
+it, which is also why it survived so long.
+
+_exec_event_redis already caches for exactly this reason. _pump_download_jobs
+was missed. These tests pin both, and would catch a third helper repeating it.
+"""
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+import bigqmt_signal_trader_strategy as strategy
+from bigqmt_signal_trader.adapters import redis_common
+
+
+class _FakeRedis(object):
+    """Answers anything; these tests count constructions, not calls."""
+
+    def __getattr__(self, name):
+        return lambda *args, **kwargs: None
+
+
+class RedisClientReuseTest(unittest.TestCase):
+    def setUp(self):
+        self._real_build = redis_common.build_redis_client
+        self.built = []
+
+        def spy(config=None):
+            self.built.append(dict(config or {}))
+            return _FakeRedis()
+
+        redis_common.build_redis_client = spy
+        # No RPC service -> the zmq-transport case, where these helpers have to
+        # build their own client. With redis transport they borrow the service's.
+        self._real_service = strategy._rpc_service
+        strategy._rpc_service = None
+        strategy._exec_event_redis_client = None
+
+    def tearDown(self):
+        redis_common.build_redis_client = self._real_build
+        strategy._rpc_service = self._real_service
+        strategy._exec_event_redis_client = None
+
+    def _config(self):
+        return {
+            "account_id": "acct",
+            "redis": {"host": "127.0.0.1", "port": 6379, "db": 5},
+            "download_jobs": {"enabled": True},
+        }
+
+    def test_download_pump_builds_one_client_across_many_ticks(self):
+        config = self._config()
+        for _ in range(20):
+            try:
+                strategy._pump_download_jobs(None, config)
+            except Exception:
+                pass  # the job pump itself may fail; only construction count matters
+
+        self.assertEqual(len(self.built), 1,
+                         "built %d clients over 20 ticks" % len(self.built))
+
+    def test_exec_event_helper_still_caches(self):
+        config = self._config()
+        for _ in range(20):
+            strategy._exec_event_redis(config)
+
+        self.assertEqual(len(self.built), 1)
+
+    def test_both_helpers_share_the_same_client(self):
+        """Two cached clients would still be one pool too many."""
+        config = self._config()
+        strategy._pump_download_jobs(None, config)
+        strategy._exec_event_redis(config)
+
+        self.assertEqual(len(self.built), 1)
+
+    def test_the_client_uses_the_configured_redis_block(self):
+        config = self._config()
+        config["redis"] = {"host": "10.0.0.5", "port": 6380, "db": 7}
+        strategy._pump_download_jobs(None, config)
+
+        self.assertEqual(self.built[0]["host"], "10.0.0.5")
+        self.assertEqual(self.built[0]["port"], 6380)
+
+    def test_missing_redis_config_skips_without_building(self):
+        result = strategy._pump_download_jobs(
+            None, {"account_id": "acct", "download_jobs": {"enabled": True}})
+
+        self.assertIsNone(result)
+        self.assertEqual(self.built, [])
+
+    def test_service_client_is_preferred_over_building_one(self):
+        """With the redis transport the service already holds a client."""
+        class _Service(object):
+            redis = _FakeRedis()
+            handlers = None
+
+        strategy._rpc_service = _Service()
+        try:
+            for _ in range(5):
+                try:
+                    strategy._pump_download_jobs(None, self._config())
+                except Exception:
+                    pass
+        finally:
+            strategy._rpc_service = None
+
+        self.assertEqual(self.built, [], "built a client while the service had one")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
从**实盘 QMT 面板日志**里发现的，今天一个交易时段出现 31 次：

```
Exception ignored in: <object repr() failed>
Traceback (most recent call last):
  File "...redis/client.py", line 899, in __del__     self.close()
  File "...redis/client.py", line 902, in close       conn = self.connection
AttributeError: 'Redis' object has no attribute 'connection'
```

## 这个 AttributeError 是症状，不是根因

redis-py 的 `__del__` 跑在一个**构造未完成**的客户端上，所以 `connection` 从未被赋值。

真正的原因是 `_pump_download_jobs` **每次运行都新建一个 Redis 客户端**——而它是 `adjust` 的三个阶段之一，**每个 tick 都跑**。按当前 100ms 的间隔，就是**每秒 10 个客户端**，每个带一套连接池。

## 它藏得很好

Python 把这个异常吞成 `Exception ignored in`，所以它**从没进过 `bigqmt.log`**，只在 QMT 面板里出现过。我是查 issue #78 时顺手翻本地日志才撞见的。

## 同一个 bug 的第二次出现

`_exec_event_redis` 早就修过这个问题，注释写得明明白白：

> *building a new client per trade callback leaks*

它加了 `_exec_event_redis_client` 缓存，但 `_pump_download_jobs` 被漏掉了。

两处都只在 `_rpc_service` 没有 redis 时才自建客户端——也就是 **zmq 传输**的场景。所以用 redis 传输的部署从没遇到过。

## 修复

复用已有的缓存 helper，而不是再加一个缓存——两个缓存客户端仍然比需要的多一个连接池。有测试钉住「两个 helper 共用同一个客户端」。

## 复现与验证

```
修复前: 调用 20 次 -> 新建 20 个客户端
修复后: 调用 20 次 -> 新建  1 个
对照 _exec_event_redis (早已修复): 20 次 -> 1 个
```

新增 6 个测试，其中 2 个**确认还原修复就会变红**。另外钉住了：配置语义一致（都读 `config["redis"]`）、缺 redis 配置时安全跳过、有 `_rpc_service.redis` 时优先复用而不自建。

477 个测试通过。

## 可能相关

Issue #76 报的「zmq 模式没有回调推送」可能和这条有关联——如果 Redis 客户端构造失败，`_publish_exec_event` 会直接 `return`，事件静默丢弃。本 PR 不直接修 #76（那是设计上 exec 事件只走 Redis 通道），但减少了客户端反复构造，值得让报告人升级后复测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)