### PR TITLE
zmq 部署也能收到回调推送 (#76)

### DIFF
--- a/src/bigqmt_signal_trader/exec_events.py
+++ b/src/bigqmt_signal_trader/exec_events.py
@@ -475,6 +475,46 @@ def normalize_trade_event(trade, account_id=""):
     }
 
 
+# Push-channel topics, used when exec events travel over the quote push channel
+# instead of Redis pub/sub. They mirror the Redis channel names minus the
+# account (a zmq PUB socket is already per-account).
+EXEC_TOPICS = {
+    EVENT_ORDER: "exec:order",
+    EVENT_TRADE: "exec:trade",
+    "order_error": "exec:order_error",
+    "cancel_error": "exec:cancel_error",
+}
+
+
+def exec_topic(event_type):
+    return EXEC_TOPICS.get(str(event_type or ""), "exec:order")
+
+
+def publish_exec_event(sink, account_id, event):
+    """Publish one exec event through whichever sink the deployment has.
+
+    ``sink`` is either a Redis client or a QuotePushChannel. Redis stays on the
+    original per-account channels (streams + pub/sub, so short replay keeps
+    working); a push channel gets one topic per event type.
+
+    Exec events used to be Redis-only, which meant a zmq deployment silently
+    received no order/trade callbacks at all (issue #76) -- the publish path
+    just returned when no Redis client could be built.
+    """
+    event_type = str((event or {}).get("event_type") or EVENT_ORDER)
+    if hasattr(sink, "publish") and not hasattr(sink, "xadd"):
+        # QuotePushChannel: publish(topic, data).
+        sink.publish(exec_topic(event_type), event)
+        return event
+    if event_type == EVENT_TRADE:
+        return publish_trade_event(sink, account_id, event)
+    if event_type == "order_error":
+        return publish_order_error_event(sink, account_id, event)
+    if event_type == "cancel_error":
+        return publish_cancel_error_event(sink, account_id, event)
+    return publish_order_event(sink, account_id, event)
+
+
 def _publish(redis_client, channel, event, maxlen=2000):
     raw = json.dumps(event, ensure_ascii=False, default=str)
     try:

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -1818,7 +1818,56 @@ class BigQmtXtTrader:
         except Exception:
             log.exception("user callback failed: on_account_status")
 
+    def _event_loop_push_channel(self):
+        """zmq: exec events arrive on the same PUB socket as whole-quote data.
+
+        Reuses _build_quote_push_channel so the address derivation stays in one
+        place. The subscriber runs its own thread, so this loop only keeps the
+        channel alive and rebuilds it if the account changes or it dies.
+        """
+        from .exec_events import EXEC_TOPICS
+
+        topics = sorted(set(EXEC_TOPICS.values()))
+        while self._event_running:
+            channel = None
+            account_id = str(self.client.account_id or "")
+            try:
+                channel = self._build_quote_push_channel()
+                channel.start_subscriber(topics, self._on_push_exec_event)
+                while self._event_running:
+                    if str(self.client.account_id or "") != account_id:
+                        break      # account changed -> rebuild against the new address
+                    time.sleep(0.5)
+            except Exception:
+                time.sleep(1.0)
+            finally:
+                if channel is not None:
+                    try:
+                        channel.stop()
+                    except Exception:
+                        pass
+
+    def _on_push_exec_event(self, topic, data):
+        """Push-channel callback. The payload is already a decoded dict, unlike
+        the Redis path which hands over raw bytes."""
+        try:
+            self._dispatch_event(data)
+        except Exception:
+            pass
+
     def _event_loop(self):
+        """Receive exec events. Redis deployments subscribe to the per-account
+        channels; zmq deployments ride the quote push channel.
+
+        Exec events used to be Redis-only, so a zmq deployment received no
+        order/trade callbacks at all -- silently, since the loop just failed to
+        connect and retried forever (issue #76).
+        """
+        transport = str(getattr(self.client, "transport_name", "redis") or "redis").lower()
+        if transport == "zmq":
+            self._event_loop_push_channel()
+            return
+
         from .exec_events import (
             order_channel,
             trade_channel,
@@ -1854,14 +1903,22 @@ class BigQmtXtTrader:
                     pass
 
     def _dispatch_event(self, raw):
+        """Accepts raw bytes/str (Redis pub/sub) or an already-decoded dict.
+
+        The push channel decodes msgpack/json itself, so it hands over a dict --
+        str(dict) is not valid JSON and would be silently dropped here.
+        """
         callback = self.callback
         if callback is None:
             return
-        try:
-            text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else str(raw)
-            event = json.loads(text)
-        except Exception:
-            return
+        if isinstance(raw, dict):
+            event = raw
+        else:
+            try:
+                text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else str(raw)
+                event = json.loads(text)
+            except Exception:
+                return
         if not isinstance(event, dict):
             return
         # 放行超时的屏障, 再决定这条事件是直通还是暂存 (issue #51)。

--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -972,6 +972,28 @@ def handlebar(ContextInfo):
     return adjust(ContextInfo, _source="handlebar")
 
 
+def _exec_event_sink(config):
+    """Where exec events go: a Redis client, or the quote push channel.
+
+    Exec events were Redis-only, so a zmq deployment with no Redis configured
+    silently delivered no order/trade callbacks at all -- _publish_exec_event
+    simply returned (issue #76). zmq deployments already run a push channel for
+    whole-quote data, so reuse it rather than opening a second socket.
+
+    Redis stays first when available: its channels carry streams for short
+    replay, which the push channel has no equivalent of.
+    """
+    redis_client = _exec_event_redis(config)
+    if redis_client is not None:
+        return redis_client
+    if _quote_subscription_service is not None:
+        try:
+            return _quote_subscription_service[1]      # (manager, channel)
+        except Exception:
+            pass
+    return None
+
+
 def _exec_event_redis(config):
     """Return a redis client for exec-event publishing, reusing one instance.
 
@@ -1026,8 +1048,8 @@ def _publish_exec_event(kind, obj):
     account_id = str(event_config.get("account_id") or config.get("account_id") or _account_id or "")
     if not account_id:
         return
-    redis_client = _exec_event_redis(config)
-    if redis_client is None:
+    sink = _exec_event_sink(config)
+    if sink is None:
         return
     try:
         from bigqmt_signal_trader import exec_events
@@ -1036,13 +1058,19 @@ def _publish_exec_event(kind, obj):
             event = exec_events.normalize_trade_event(obj, account_id)
             if raw_fields:
                 event["raw_fields"] = raw_fields
-            exec_events.publish_trade_event(redis_client, account_id, event)
+            exec_events.publish_exec_event(sink, account_id, event)
         else:
             event = exec_events.normalize_order_event(obj, account_id)
-            event = exec_events.enrich_order_identity(redis_client, account_id, event)
+            # Identity enrichment reads the remark->identity map that
+            # remember_order_identity wrote, which only exists in Redis. On a
+            # push channel the event goes out un-enriched rather than not at
+            # all; order_sys_id and remark are already on it.
+            redis_client = _exec_event_redis(config)
+            if redis_client is not None:
+                event = exec_events.enrich_order_identity(redis_client, account_id, event)
             if raw_fields:
                 event["raw_fields"] = raw_fields
-            exec_events.publish_order_event(redis_client, account_id, event)
+            exec_events.publish_exec_event(sink, account_id, event)
             # 废单 (status=57 ENTRUST_STATUS_JUNK) 推送 order_error，让客户端
             # on_order_error 能感知下单被拒。
             try:
@@ -1053,7 +1081,7 @@ def _publish_exec_event(kind, obj):
                 err_event = exec_events.normalize_order_error_event(obj, account_id)
                 if raw_fields:
                     err_event["raw_fields"] = raw_fields
-                exec_events.publish_order_error_event(redis_client, account_id, err_event)
+                exec_events.publish_exec_event(sink, account_id, err_event)
     except Exception as exc:
         _log_err("exec_events", "publish %s failed: %s" % (kind, exc))
 

--- a/tests/bigqmt_signal_trader/test_zmq_exec_events.py
+++ b/tests/bigqmt_signal_trader/test_zmq_exec_events.py
@@ -1,0 +1,198 @@
+"""Exec events must reach a zmq deployment, not just a Redis one (issue #76).
+
+They used to be Redis-only on both ends: the server's publish path returned
+early when it could not build a Redis client, and the client's listener only
+ever subscribed to Redis channels. A zmq deployment therefore received no
+on_stock_order / on_stock_trade / on_order_error at all -- silently, since the
+listener just failed to connect and retried forever.
+
+zmq deployments already run a push channel for whole-quote data, so exec events
+ride that rather than opening a second socket.
+"""
+
+import os
+import sys
+import threading
+import time
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader import exec_events
+from bigqmt_signal_trader.xtquant_compat import BigQmtXtTrader, XtQuantTraderCallback
+
+
+class _Recorder(XtQuantTraderCallback):
+    def __init__(self):
+        self.seen = []
+        self.lock = threading.Lock()
+
+    def _add(self, *item):
+        with self.lock:
+            self.seen.append(item)
+
+    def on_stock_order(self, order):
+        self._add("order", order.stock_code)
+
+    def on_stock_trade(self, trade):
+        self._add("trade", trade.stock_code)
+
+    def on_order_error(self, err):
+        self._add("error", err.stock_code)
+
+    def names(self):
+        with self.lock:
+            return [item[0] for item in self.seen]
+
+
+class _FakeChannel(object):
+    """Stands in for a QuotePushChannel: records publish(topic, data)."""
+
+    def __init__(self):
+        self.published = []
+
+    def publish(self, topic, data):
+        self.published.append((topic, data))
+
+
+class _FakeRedis(object):
+    """Stands in for a Redis client: exposes xadd, which is how the sink
+    distinguishes the two."""
+
+    def __init__(self):
+        self.published = []
+
+    def xadd(self, key, fields, maxlen=None, approximate=None):
+        self.published.append(("xadd", key))
+        return b"1-0"
+
+    def publish(self, key, value):
+        self.published.append(("publish", key))
+        return 1
+
+
+def _order_row(**overrides):
+    attrs = dict(
+        m_strInstrumentID="601398", m_strExchangeID="SH", m_nOffsetFlag=48,
+        m_nVolumeTotalOriginal=100, m_nVolumeTraded=0, m_strOrderSysID="sys-1",
+        m_strRemark="TAG-1", m_nOrderStatus=50, m_strTradeID="t-1",
+        m_nVolume=100, m_dPrice=7.5,
+    )
+    attrs.update(overrides)
+    return type("Row", (), attrs)()
+
+
+class SinkRoutingTest(unittest.TestCase):
+    """publish_exec_event picks the path from what the sink can do."""
+
+    def test_push_channel_gets_a_topic_per_event_type(self):
+        channel = _FakeChannel()
+        for event in (exec_events.normalize_order_event(_order_row(), "acct"),
+                      exec_events.normalize_trade_event(_order_row(), "acct"),
+                      exec_events.normalize_order_error_event(_order_row(), "acct")):
+            exec_events.publish_exec_event(channel, "acct", event)
+
+        self.assertEqual([topic for topic, _ in channel.published],
+                         ["exec:order", "exec:trade", "exec:order_error"])
+
+    def test_redis_still_uses_the_per_account_channels(self):
+        """Redis keeps streams for short replay; the push channel has none, so
+        the Redis path must not be rerouted."""
+        redis = _FakeRedis()
+        exec_events.publish_exec_event(
+            redis, "acct", exec_events.normalize_order_event(_order_row(), "acct"))
+
+        self.assertIn(("xadd", exec_events.order_channel("acct")), redis.published)
+        self.assertIn(("publish", exec_events.order_channel("acct")), redis.published)
+
+    def test_every_event_type_has_a_topic(self):
+        for event_type in ("order", "trade", "order_error", "cancel_error"):
+            self.assertTrue(exec_events.exec_topic(event_type).startswith("exec:"))
+
+    def test_unknown_event_type_falls_back_rather_than_dropping(self):
+        self.assertEqual(exec_events.exec_topic("something-new"), "exec:order")
+
+
+class DispatchInputTest(unittest.TestCase):
+    """The push channel decodes msgpack/json itself and hands over a dict; the
+    Redis path hands over raw bytes. Both must dispatch."""
+
+    def _trader(self):
+        trader = BigQmtXtTrader(account_id="acct")
+        recorder = _Recorder()
+        trader.register_callback(recorder)
+        return trader, recorder
+
+    def test_decoded_dict_is_dispatched(self):
+        trader, rec = self._trader()
+        trader._dispatch_event(
+            {"event_type": "order", "account_id": "acct", "stock_code": "601398.SH",
+             "action": "BUY", "order_sys_id": "sys-1"})
+
+        self.assertEqual(rec.names(), ["order"])
+
+    def test_raw_bytes_still_dispatched(self):
+        import json
+
+        trader, rec = self._trader()
+        trader._dispatch_event(json.dumps(
+            {"event_type": "trade", "account_id": "acct", "stock_code": "601398.SH",
+             "action": "BUY", "trade_id": "t-1"}).encode("utf-8"))
+
+        self.assertEqual(rec.names(), ["trade"])
+
+    def test_push_callback_signature_matches_the_channel(self):
+        """The channel calls on_msg(topic, data)."""
+        trader, rec = self._trader()
+        trader._on_push_exec_event(
+            "exec:order",
+            {"event_type": "order", "account_id": "acct", "stock_code": "601398.SH",
+             "action": "BUY", "order_sys_id": "sys-1"})
+
+        self.assertEqual(rec.names(), ["order"])
+
+
+class ZmqRoundTripTest(unittest.TestCase):
+    """A real PUB/SUB pair, since the point is that these actually travel."""
+
+    ADDRESS = "tcp://127.0.0.1:15997"
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import zmq  # noqa: F401
+        except ImportError:
+            raise unittest.SkipTest("pyzmq not installed")
+
+    def test_all_three_event_types_reach_the_callback(self):
+        from bigqmt_signal_trader.quote_push_channel import ZmqQuotePushChannel
+
+        server = ZmqQuotePushChannel(bind_address=self.ADDRESS)
+        server.start_publisher()
+        trader = BigQmtXtTrader(account_id="acct")
+        recorder = _Recorder()
+        trader.register_callback(recorder)
+        client = ZmqQuotePushChannel(connect_address=self.ADDRESS)
+        client.start_subscriber(sorted(set(exec_events.EXEC_TOPICS.values())),
+                                trader._on_push_exec_event)
+        try:
+            time.sleep(0.6)          # PUB/SUB needs a moment to connect
+            for event in (exec_events.normalize_order_event(_order_row(), "acct"),
+                          exec_events.normalize_trade_event(_order_row(), "acct"),
+                          exec_events.normalize_order_error_event(_order_row(), "acct")):
+                exec_events.publish_exec_event(server, "acct", event)
+
+            deadline = time.time() + 5.0
+            while time.time() < deadline and len(recorder.names()) < 3:
+                time.sleep(0.05)
+
+            self.assertEqual(sorted(recorder.names()), ["error", "order", "trade"])
+        finally:
+            client.stop()
+            server.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
关联 issue #76。485 个测试通过（新增 8 个）。

## 报告人是对的

order/trade 回调**两端都硬绑 Redis**：

- **服务端** `_publish_exec_event` → 建不出 Redis 客户端就直接 `return`
- **客户端** `_event_loop` → 只订阅 Redis 频道

所以纯 zmq 部署**完全收不到** `on_stock_order` / `on_stock_trade` / `on_order_error`。而且是**静默的**：客户端只是连不上然后无限重试，服务端把「没有 Redis 客户端」当成正常跳过、一条日志都不打。

他读代码就把这个推出来了，比生产上踩到早。

## 复用已有通道，不新开 socket

zmq 部署本来就为全推行情跑着一条 push channel，exec 事件搭同一条。两端的传输选型逻辑也已存在（客户端 `_build_quote_push_channel`、服务端 `build_quote_subscription_service`），直接复用而不是再写一套。

**Redis 优先**：它的频道带 stream 可做短重放，push channel 没有等价物。只有在没有 Redis 客户端时才回落到 push channel。

## 往返测试暴露的两个细节

**1. push channel 递来的是已解码的 dict**，而 Redis 路径递来的是原始 bytes。`_dispatch_event` 只接受后者——`str(dict)` 喂给 `json.loads` 会失败，**事件被静默丢弃、连日志都没有**。这个只有真跑一遍才会发现。

**2. 身份增强依赖 Redis**。`enrich_order_identity` 读的是 `remember_order_identity` 写的 remark→identity 映射，只存在于 Redis。走 push channel 时事件**不增强照常发出**，而不是不发——`order_sys_id` 和 `remark` 本来就在事件里。

## 验证

真实 PUB/SUB 往返，三类事件全部送达客户端回调：

```
order  601398.SH    sys-1
trade  601398.SH    t-1
error  601398       [COUNTER] 资金不足
```

8 个新测试，**其中 4 个确认还原修复就变红**。其中一个是真实 PUB/SUB 往返——重点是这些事件**真的能传到**，而不是路由函数返回了正确的字符串。

## 说明

本 PR 只解决「zmq 收不到事件」。Redis 部署行为完全不变（有测试钉住它仍走原频道 + stream）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)