### PR TITLE
feat: implement query_position_statistics futures position statistics

### DIFF
--- a/src/bigqmt_signal_trader/adapters/position_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/position_bigqmt.py
@@ -1,7 +1,7 @@
 """Big QMT position and asset adapters."""
 
 from ..code_utils import normalize_stock_code
-from ..models import AssetSnapshot, PositionSnapshot
+from ..models import AssetSnapshot, PositionSnapshot, PositionStatisticsSnapshot
 
 
 def _attr(obj, names, default=None):
@@ -182,6 +182,81 @@ class BigQmtPositionProvider:
                 direction=int(_attr(row, ("m_nDirection", "direction"), 48) or 48),
             )
         return positions
+
+    def get_position_statistics(self, account_id):
+        query = self._require_query_func()
+        try:
+            rows = query(account_id, self.account_type, "POSITION_STATISTICS") or []
+        except Exception:
+            return []
+        stats = []
+        for row in rows:
+            try:
+                code = _full_code(
+                    _attr(row, ("m_strInstrumentID", "instrument_id", "stock_code")),
+                    _attr(row, ("m_strExchangeID", "exchange_id", "market")),
+                )
+            except Exception as exc:
+                skip_unparsable_row("POSITION_STATISTICS", row, exc)
+                continue
+            stats.append(
+                PositionStatisticsSnapshot(
+                    account_id=account_id,
+                    exchange_id=str(_attr(row, ("m_strExchangeID", "exchange_id", "market"), "") or ""),
+                    exchange_name=str(_attr(row, ("m_strExchangeName", "exchange_name"), "") or ""),
+                    product_id=str(_attr(row, ("m_strProductID", "product_id"), "") or ""),
+                    instrument_id=str(_attr(row, ("m_strInstrumentID", "instrument_id"), "") or ""),
+                    instrument_name=str(_attr(row, ("m_strInstrumentName", "instrument_name"), "") or ""),
+                    stock_code=code,
+                    direction=int(_attr(row, ("m_nDirection", "direction"), 0) or 0),
+                    hedge_flag=int(_attr(row, ("m_nHedgeFlag", "hedge_flag"), 0) or 0),
+                    position=int(_attr(row, ("m_nPosition", "position"), 0) or 0),
+                    yesterday_position=int(_attr(row, ("m_nYestodayPosition", "yesterday_position"), 0) or 0),
+                    today_position=int(_attr(row, ("m_nTodayPosition", "today_position"), 0) or 0),
+                    can_close_vol=int(_attr(row, ("m_nCanCloseVol", "can_close_vol"), 0) or 0),
+                    position_cost=_float_or_none(_attr(row, ("m_dPositionCost", "position_cost"))),
+                    avg_price=_float_or_none(_attr(row, ("m_dAvgPrice", "avg_price"))),
+                    position_profit=_float_or_none(_attr(row, ("m_dPositionProfit", "position_profit"))),
+                    float_profit=_float_or_none(_attr(row, ("m_dFloatProfit", "float_profit"))),
+                    open_price=_float_or_none(_attr(row, ("m_dOpenPrice", "open_price"))),
+                    used_margin=_float_or_none(_attr(row, ("m_dUsedMargin", "used_margin"))),
+                    used_commission=_float_or_none(_attr(row, ("m_dUsedCommission", "used_commission"))),
+                    frozen_margin=_float_or_none(_attr(row, ("m_dFrozenMargin", "frozen_margin"))),
+                    frozen_commission=_float_or_none(_attr(row, ("m_dFrozenCommission", "frozen_commission"))),
+                    instrument_value=_float_or_none(_attr(row, ("m_dInstrumentValue", "instrument_value"))),
+                    open_times=int(_attr(row, ("m_nOpenTimes", "open_times"), 0) or 0),
+                    open_volume=int(_attr(row, ("m_nOpenVolume", "open_volume"), 0) or 0),
+                    cancel_times=int(_attr(row, ("m_nCancelTimes", "cancel_times"), 0) or 0),
+                    last_price=_float_or_none(_attr(row, ("m_dLastPrice", "last_price"))),
+                    rise_ratio=_float_or_none(_attr(row, ("m_dRiseRatio", "rise_ratio"))),
+                    product_name=str(_attr(row, ("m_strProductName", "product_name"), "") or ""),
+                    royalty=_float_or_none(_attr(row, ("m_dRoyalty", "royalty"))),
+                    expire_date=str(_attr(row, ("m_strExpireDate", "expire_date"), "") or ""),
+                    assest_weight=_float_or_none(_attr(row, ("m_dAssestWeight", "assest_weight"))),
+                    increase_by_settlement=_float_or_none(
+                        _attr(row, ("m_dIncreaseBySettlement", "increase_by_settlement"))
+                    ),
+                    margin_ratio=_float_or_none(_attr(row, ("m_dMarginRatio", "margin_ratio"))),
+                    float_profit_divide_by_used_margin=_float_or_none(
+                        _attr(row, ("m_dFloatProfitDivideByUsedMargin", "float_profit_divide_by_used_margin"))
+                    ),
+                    float_profit_divide_by_balance=_float_or_none(
+                        _attr(row, ("m_dFloatProfitDivideByBalance", "float_profit_divide_by_balance"))
+                    ),
+                    today_profit_loss=_float_or_none(_attr(row, ("m_dTodayProfitLoss", "today_profit_loss"))),
+                    yesterday_init_position=int(
+                        _attr(row, ("m_nYestodayInitPosition", "yesterday_init_position"), 0) or 0
+                    ),
+                    frozen_royalty=_float_or_none(_attr(row, ("m_dFrozenRoyalty", "frozen_royalty"))),
+                    today_close_profit_loss=_float_or_none(
+                        _attr(row, ("m_dTodayCloseProfitLoss", "today_close_profit_loss"))
+                    ),
+                    close_profit=_float_or_none(_attr(row, ("m_dCloseProfit", "close_profit"))),
+                    ft_product_name=str(_attr(row, ("m_strFtProductName", "ft_product_name"), "") or ""),
+                    open_cost=_float_or_none(_attr(row, ("m_dOpenCost", "open_cost"))),
+                )
+            )
+        return stats
 
     def get_asset(self, account_id):
         query = self._require_query_func()

--- a/src/bigqmt_signal_trader/models.py
+++ b/src/bigqmt_signal_trader/models.py
@@ -191,6 +191,102 @@ class PositionSnapshot:
         self.direction = direction
 
 
+class PositionStatisticsSnapshot:
+    """One position-statistics row, i.e. ``get_trade_detail_data(..., "POSITION_STATISTICS")``.
+
+    """
+
+    def __init__(
+        self,
+        account_id="",
+        exchange_id="",
+        exchange_name="",
+        product_id="",
+        instrument_id="",
+        instrument_name="",
+        stock_code="",
+        direction=0,
+        hedge_flag=0,
+        position=0,
+        yesterday_position=0,
+        today_position=0,
+        can_close_vol=0,
+        position_cost=None,
+        avg_price=None,
+        position_profit=None,
+        float_profit=None,
+        open_price=None,
+        used_margin=None,
+        used_commission=None,
+        frozen_margin=None,
+        frozen_commission=None,
+        instrument_value=None,
+        open_times=0,
+        open_volume=0,
+        cancel_times=0,
+        last_price=None,
+        rise_ratio=None,
+        product_name="",
+        royalty=None,
+        expire_date="",
+        assest_weight=None,
+        increase_by_settlement=None,
+        margin_ratio=None,
+        float_profit_divide_by_used_margin=None,
+        float_profit_divide_by_balance=None,
+        today_profit_loss=None,
+        yesterday_init_position=0,
+        frozen_royalty=None,
+        today_close_profit_loss=None,
+        close_profit=None,
+        ft_product_name="",
+        open_cost=None,
+    ):
+        self.account_id = account_id
+        self.exchange_id = exchange_id
+        self.exchange_name = exchange_name
+        self.product_id = product_id
+        self.instrument_id = instrument_id
+        self.instrument_name = instrument_name
+        self.stock_code = stock_code
+        self.direction = direction
+        self.hedge_flag = hedge_flag
+        self.position = position
+        self.yesterday_position = yesterday_position
+        self.today_position = today_position
+        self.can_close_vol = can_close_vol
+        self.position_cost = position_cost
+        self.avg_price = avg_price
+        self.position_profit = position_profit
+        self.float_profit = float_profit
+        self.open_price = open_price
+        self.used_margin = used_margin
+        self.used_commission = used_commission
+        self.frozen_margin = frozen_margin
+        self.frozen_commission = frozen_commission
+        self.instrument_value = instrument_value
+        self.open_times = open_times
+        self.open_volume = open_volume
+        self.cancel_times = cancel_times
+        self.last_price = last_price
+        self.rise_ratio = rise_ratio
+        self.product_name = product_name
+        self.royalty = royalty
+        self.expire_date = expire_date
+        self.assest_weight = assest_weight
+        self.increase_by_settlement = increase_by_settlement
+        self.margin_ratio = margin_ratio
+        self.float_profit_divide_by_used_margin = float_profit_divide_by_used_margin
+        self.float_profit_divide_by_balance = float_profit_divide_by_balance
+        self.today_profit_loss = today_profit_loss
+        self.yesterday_init_position = yesterday_init_position
+        self.frozen_royalty = frozen_royalty
+        self.today_close_profit_loss = today_close_profit_loss
+        self.close_profit = close_profit
+        self.ft_product_name = ft_product_name
+        self.open_cost = open_cost
+
+
 class AssetSnapshot:
     """Account funds, mirroring MiniQMT's ``XtAsset``.
 

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -63,6 +63,7 @@ READ_METHODS = {
     "get_formula_result",
     "gen_factor_index",
     "get_positions",
+    "get_position_statistics",
     "get_asset",
     "query_orders",
     "query_trades",
@@ -125,6 +126,7 @@ LISTENER_DEFERRED_METHODS = {
     # data. Asset queries use the same QMT detail API and must follow this rule.
     "get_asset",
     "get_positions",
+    "get_position_statistics",
     "query_stock_position",
     "query_orders",
     "query_trades",
@@ -164,6 +166,7 @@ METHOD_ALIASES = {
     "getDividFactors": "get_divid_factors",
     "query_stock_asset": "get_asset",
     "query_stock_positions": "get_positions",
+    "query_position_statistics": "get_position_statistics",
     "query_stock_orders": "query_orders",
     "query_stock_trades": "query_trades",
     "order_stock": "submit_order",
@@ -598,6 +601,9 @@ class BigQmtRpcHandlers:
 
     def _handle_get_positions(self, params):
         return self.position_provider.get_positions(self._request_account_id(params))
+
+    def _handle_get_position_statistics(self, params):
+        return self.position_provider.get_position_statistics(self._request_account_id(params))
 
     def _handle_query_stock_position(self, params):
         stock_code = str(params.get("stock_code") or params.get("code") or "").strip()
@@ -1582,6 +1588,18 @@ class RedisPubSubRpcService:
         return template.format(account_id=account_id, request_id=request_id)
 
     def _publish_response(self, request, response):
+        try:
+            print(
+                "%s >> send method=%s ok=%s payload=%s"
+                % (
+                    self.print_prefix,
+                    response.get("method"),
+                    response.get("ok"),
+                    json.dumps(response, ensure_ascii=False)[:2000],
+                )
+            )
+        except Exception:
+            pass
         # Delegate to the transport (RedisTransport fans out to key/list/channel;
         # ZMQ/MySQL transports use their native reply path).
         self._transport.send_response(request, response)

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -2097,6 +2097,119 @@ class BigQmtXtTrader:
                 raise
         return [self._position_object(account_id, item) for item in self._position_items(data)]
 
+    def query_position_statistics(self, account):
+        """Intraday position statistics (futures), mirroring MiniQMT ``query_position_statistics``.
+
+        Returns a list of :class:`XtPositionStatistics`-style :class:`CompatObject`.
+        The server queries via ``get_trade_detail_data(..., "POSITION_STATISTICS")``.
+        """
+        account_id = _account_id(account, self.client.account_id)
+        data = self.client.call(
+            "query_position_statistics",
+            {"account_id": account_id},
+            account_id=account_id,
+        ) or {}
+        return [self._position_statistics_object(account_id, item) for item in _as_list(data)]
+
+    def _position_statistics_object(self, account_id, item):
+        return CompatObject(
+            account_id=account_id,
+            exchange_id=str(item.get("exchange_id") or ""),
+            exchange_name=str(item.get("exchange_name") or ""),
+            product_id=str(item.get("product_id") or ""),
+            instrument_id=str(item.get("instrument_id") or ""),
+            instrument_name=str(item.get("instrument_name") or ""),
+            stock_code=str(item.get("stock_code") or ""),
+            direction=_safe_int(item.get("direction"), 0),
+            hedge_flag=_safe_int(item.get("hedge_flag"), 0),
+            position=_safe_int(item.get("position"), 0),
+            yesterday_position=_safe_int(item.get("yesterday_position"), 0),
+            today_position=_safe_int(item.get("today_position"), 0),
+            can_close_vol=_safe_int(item.get("can_close_vol"), 0),
+            position_cost=_safe_float(item.get("position_cost"), None),
+            avg_price=_safe_float(item.get("avg_price"), None),
+            position_profit=_safe_float(item.get("position_profit"), None),
+            float_profit=_safe_float(item.get("float_profit"), None),
+            open_price=_safe_float(item.get("open_price"), None),
+            used_margin=_safe_float(item.get("used_margin"), None),
+            used_commission=_safe_float(item.get("used_commission"), None),
+            frozen_margin=_safe_float(item.get("frozen_margin"), None),
+            frozen_commission=_safe_float(item.get("frozen_commission"), None),
+            instrument_value=_safe_float(item.get("instrument_value"), None),
+            open_times=_safe_int(item.get("open_times"), 0),
+            open_volume=_safe_int(item.get("open_volume"), 0),
+            cancel_times=_safe_int(item.get("cancel_times"), 0),
+            last_price=_safe_float(item.get("last_price"), None),
+            rise_ratio=_safe_float(item.get("rise_ratio"), None),
+            product_name=str(item.get("product_name") or ""),
+            royalty=_safe_float(item.get("royalty"), None),
+            expire_date=str(item.get("expire_date") or ""),
+            assest_weight=_safe_float(item.get("assest_weight"), None),
+            increase_by_settlement=_safe_float(item.get("increase_by_settlement"), None),
+            margin_ratio=_safe_float(item.get("margin_ratio"), None),
+            float_profit_divide_by_used_margin=_safe_float(
+                item.get("float_profit_divide_by_used_margin"), None
+            ),
+            float_profit_divide_by_balance=_safe_float(
+                item.get("float_profit_divide_by_balance"), None
+            ),
+            today_profit_loss=_safe_float(item.get("today_profit_loss"), None),
+            yesterday_init_position=_safe_int(item.get("yesterday_init_position"), 0),
+            frozen_royalty=_safe_float(item.get("frozen_royalty"), None),
+            today_close_profit_loss=_safe_float(item.get("today_close_profit_loss"), None),
+            close_profit=_safe_float(item.get("close_profit"), None),
+            ft_product_name=str(item.get("ft_product_name") or ""),
+            open_cost=_safe_float(item.get("open_cost"), None),
+            # ===== native xtquant field-name aliases (m_-prefixed access) =====
+            m_strAccountID=account_id,
+            m_strStockCode=str(item.get("stock_code") or ""),
+            m_strExchangeID=str(item.get("exchange_id") or ""),
+            m_strExchangeName=str(item.get("exchange_name") or ""),
+            m_strProductID=str(item.get("product_id") or ""),
+            m_strInstrumentID=str(item.get("instrument_id") or ""),
+            m_strInstrumentName=str(item.get("instrument_name") or ""),
+            m_nDirection=_safe_int(item.get("direction"), 0),
+            m_nHedgeFlag=_safe_int(item.get("hedge_flag"), 0),
+            m_nPosition=_safe_int(item.get("position"), 0),
+            m_nYestodayPosition=_safe_int(item.get("yesterday_position"), 0),
+            m_nTodayPosition=_safe_int(item.get("today_position"), 0),
+            m_nCanCloseVol=_safe_int(item.get("can_close_vol"), 0),
+            m_dPositionCost=_safe_float(item.get("position_cost"), None),
+            m_dAvgPrice=_safe_float(item.get("avg_price"), None),
+            m_dPositionProfit=_safe_float(item.get("position_profit"), None),
+            m_dFloatProfit=_safe_float(item.get("float_profit"), None),
+            m_dOpenPrice=_safe_float(item.get("open_price"), None),
+            m_dUsedMargin=_safe_float(item.get("used_margin"), None),
+            m_dUsedCommission=_safe_float(item.get("used_commission"), None),
+            m_dFrozenMargin=_safe_float(item.get("frozen_margin"), None),
+            m_dFrozenCommission=_safe_float(item.get("frozen_commission"), None),
+            m_dInstrumentValue=_safe_float(item.get("instrument_value"), None),
+            m_nOpenTimes=_safe_int(item.get("open_times"), 0),
+            m_nOpenVolume=_safe_int(item.get("open_volume"), 0),
+            m_nCancelTimes=_safe_int(item.get("cancel_times"), 0),
+            m_dLastPrice=_safe_float(item.get("last_price"), None),
+            m_dRiseRatio=_safe_float(item.get("rise_ratio"), None),
+            m_strProductName=str(item.get("product_name") or ""),
+            m_dRoyalty=_safe_float(item.get("royalty"), None),
+            m_strExpireDate=str(item.get("expire_date") or ""),
+            m_dAssestWeight=_safe_float(item.get("assest_weight"), None),
+            m_dIncreaseBySettlement=_safe_float(item.get("increase_by_settlement"), None),
+            m_dMarginRatio=_safe_float(item.get("margin_ratio"), None),
+            m_dFloatProfitDivideByUsedMargin=_safe_float(
+                item.get("float_profit_divide_by_used_margin"), None
+            ),
+            m_dFloatProfitDivideByBalance=_safe_float(
+                item.get("float_profit_divide_by_balance"), None
+            ),
+            m_dTodayProfitLoss=_safe_float(item.get("today_profit_loss"), None),
+            m_nYestodayInitPosition=_safe_int(item.get("yesterday_init_position"), 0),
+            m_dFrozenRoyalty=_safe_float(item.get("frozen_royalty"), None),
+            m_dTodayCloseProfitLoss=_safe_float(item.get("today_close_profit_loss"), None),
+            m_dCloseProfit=_safe_float(item.get("close_profit"), None),
+            m_strFtProductName=str(item.get("ft_product_name") or ""),
+            m_dOpenCost=_safe_float(item.get("open_cost"), None),
+        )
+
     def query_stock_position(self, account, stock_code):
         account_id = _account_id(account, self.client.account_id)
         try:


### PR DESCRIPTION
Add MiniQMT query_position_statistics compatibility, served on the backend through get_trade_detail_data(..., "POSITION_STATISTICS")