### PR TITLE
修复单文件 QMT 沙箱部署的两个加载失败 (#76)

### DIFF
--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -14,7 +14,16 @@ import threading
 import importlib
 import datetime as _dt
 from typing import Any, Dict, Iterable, List, Optional
-from xtquant.xtconstant import *
+# Only these three are used below, but every public constant is re-exported
+# further down: docs/XTQUANT_COMPAT_REPLACEMENT.md tells callers to do
+# ``from bigqmt_signal_trader import xtquant_compat as xtconstant`` and read
+# e.g. ``xtconstant.ORDER_SUCCEEDED`` off this module.
+#
+# This is deliberately not ``from xtquant.xtconstant import *``. That form is a
+# SyntaxError ("import * only allowed at module level") in the single-file QMT
+# builds, which exec each module inside a function body (issue #76).
+from xtquant import xtconstant as _xtconstant
+from xtquant.xtconstant import ORDER_UNKNOWN, STOCK_BUY, STOCK_SELL
 from xtquant.xttype import StockAccount
 
 from .full_tick_cache import request_full_tick_cache, wait_full_tick_cache
@@ -23,6 +32,21 @@ from .redis_rpc import call_redis_rpc
 from .logging_setup import get_logger
 
 log = get_logger("xtquant_compat")
+
+
+# Re-export every public xtconstant name on this module, replacing what
+# ``import *`` used to do implicitly. Before #73 these 110-odd constants were
+# defined here outright, and the documented "approach 1" migration path binds
+# this module as ``xtconstant``, so dropping them would break callers that read
+# e.g. ``xtquant_compat.FIX_PRICE``.
+#
+# Written as an explicit loop rather than ``import *`` (a SyntaxError inside the
+# single-file builds' function-scope exec, issue #76) and rather than a
+# module-level ``__getattr__`` (PEP 562, Python 3.7+, while QMT ships 3.6).
+for _const_name in dir(_xtconstant):
+    if not _const_name.startswith("_"):
+        globals().setdefault(_const_name, getattr(_xtconstant, _const_name))
+del _const_name
 
 
 # Default OHLCV fields pulled + cached by get_local_data fallback_rpc.

--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -11,6 +11,7 @@ import importlib as _importlib
 import sys
 import threading
 import time
+import traceback as _traceback
 
 # The DRYRUN entry reloads strategy/runtime/redis_rpc/redis_common but NOT the
 # other package submodules. Without this, the "from adapter_factory import build_app"
@@ -54,6 +55,59 @@ else:
         tick_app,
     )
     from bigqmt_signal_trader.runtime_bigqmt import BigQmtRuntimeAdapter
+
+
+# exec_events is loaded here, at module load, and never from inside the
+# order/deal callback. QMT runs those callbacks on a C++ thread entered via
+# PyGILState_Ensure; the first exec of a not-yet-imported module on such a
+# thread fails down in the C layer WITHOUT setting a Python exception, which
+# surfaces as SystemError "error return without exception set" (issue #76,
+# live repro 2026-08-27). Modules already in sys.modules resolve fine there --
+# which is why this only bites deployments where the init-time reload could not
+# preload it, i.e. the single-file QMT sandbox build.
+def _import_exec_events():
+    # In the QMT sandbox a package-level "from bigqmt_signal_trader import x"
+    # goes through the C-level __import__ and fails the same way; the local
+    # loader that already serves the adapter modules does not.
+    if _load_bridge_module is not None:
+        return _load_bridge_module("bigqmt_signal_trader.exec_events")
+    from bigqmt_signal_trader import exec_events
+
+    return exec_events
+
+
+def _load_exec_events():
+    try:
+        return _import_exec_events()
+    except Exception:
+        direct_error = _traceback.format_exc()
+    # Only reached when the direct load failed. A plain threading.Thread always
+    # has a full Python thread state, so the exec that just failed succeeds
+    # there; the import lock makes handing the result back safe.
+    holder = {}
+
+    def _target():
+        try:
+            holder["module"] = _import_exec_events()
+        except Exception:
+            pass
+
+    try:
+        worker = threading.Thread(target=_target)
+        worker.start()
+        worker.join()
+    except Exception:
+        pass
+    if holder.get("module") is not None:
+        return holder["module"]
+    print(
+        "[bigqmt_signal_trader] exec_events load failed; exec-event push is "
+        "disabled for this run:\n%s" % direct_error
+    )
+    return None
+
+
+_exec_events = _load_exec_events()
 
 
 _app_factory = None
@@ -1035,10 +1089,12 @@ def _publish_exec_event(kind, obj):
     # enabled/account_id early returns), because the point is to observe the
     # object exactly as QMT handed it over — even when publishing is off.
     raw_fields = None
+    exec_events = _exec_events
+    if exec_events is None:
+        # Already reported once at module load; a per-callback log would flood.
+        return
     if _config_bool(event_config.get("debug_raw_fields"), False):
         try:
-            from bigqmt_signal_trader import exec_events
-
             print(exec_events.format_raw_snapshot(kind, obj))
             raw_fields = exec_events.raw_field_snapshot(obj)
         except Exception as exc:
@@ -1052,8 +1108,6 @@ def _publish_exec_event(kind, obj):
     if sink is None:
         return
     try:
-        from bigqmt_signal_trader import exec_events
-
         if kind == "trade":
             event = exec_events.normalize_trade_event(obj, account_id)
             if raw_fields:
@@ -1083,7 +1137,14 @@ def _publish_exec_event(kind, obj):
                     err_event["raw_fields"] = raw_fields
                 exec_events.publish_exec_event(sink, account_id, err_event)
     except Exception as exc:
-        _log_err("exec_events", "publish %s failed: %s" % (kind, exc))
+        # str(exc) alone reads "error return without exception set" with no hint
+        # of where it came from -- that is what made issue #76 take a day to
+        # pin down. Carry the exception class and the traceback.
+        _log_err(
+            "exec_events",
+            "publish %s failed: %s (%s)\n%s"
+            % (kind, exc, exc.__class__.__name__, _traceback.format_exc()),
+        )
 
 
 def order_callback(ContextInfo, orderInfo):

--- a/tests/bigqmt_signal_trader/test_qmt_sandbox_loading.py
+++ b/tests/bigqmt_signal_trader/test_qmt_sandbox_loading.py
@@ -1,0 +1,202 @@
+"""Two failures that only appear in the single-file QMT sandbox build (#76).
+
+Both were reported by heimo88 against a deployed v0.2.10 with a live repro on
+2026-08-27, and neither is visible in a normal package deployment -- which is
+exactly why the whole existing suite stayed green through both.
+
+1. ``from xtquant.xtconstant import *`` (introduced by #73) is a SyntaxError in
+   the single-file builds, which exec each module inside a function body.
+   Nothing in a normal install compiles that way, so nothing caught it.
+
+2. exec_events was imported from inside the order/deal callback. QMT runs those
+   on a C++ thread entered through PyGILState_Ensure, where the first exec of a
+   not-yet-imported module fails in the C layer without setting a Python
+   exception -- SystemError "error return without exception set". A normal
+   deployment preloads the module during init, so the lazy import hits the
+   sys.modules cache and never execs anything on that thread.
+"""
+
+import io
+import os
+import sys
+import textwrap
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+SRC = os.path.join(ROOT, "src")
+sys.path.insert(0, SRC)
+
+
+def _module_source(relative_path):
+    with io.open(os.path.join(SRC, relative_path), encoding="utf-8") as handle:
+        return handle.read()
+
+
+class FunctionScopeCompileTest(unittest.TestCase):
+    """A single-file build execs each module inside a function body."""
+
+    def _compile_in_function(self, relative_path):
+        source = _module_source(relative_path)
+        wrapped = "def _single_file_module():\n" + textwrap.indent(source, "    ")
+        compile(wrapped, "<single-file-build:%s>" % relative_path, "exec")
+
+    def test_xtquant_compat_compiles_inside_a_function_body(self):
+        # Before the fix this raised: "import * only allowed at module level".
+        self._compile_in_function("bigqmt_signal_trader/xtquant_compat.py")
+
+    def test_no_star_import_anywhere_in_the_bundled_package(self):
+        """One star import is all it takes to break the build again."""
+        offenders = []
+        for directory, _dirs, files in os.walk(SRC):
+            for name in files:
+                if not name.endswith(".py"):
+                    continue
+                path = os.path.join(directory, name)
+                with io.open(path, encoding="utf-8") as handle:
+                    for lineno, line in enumerate(handle, 1):
+                        if line.lstrip().startswith("from ") and line.rstrip().endswith(
+                            "import *"
+                        ):
+                            offenders.append(
+                                "%s:%d" % (os.path.relpath(path, SRC), lineno)
+                            )
+        self.assertEqual(offenders, [], "star imports break single-file builds")
+
+
+class ConstantReExportTest(unittest.TestCase):
+    """``import *`` was also the only thing keeping these names on the module.
+
+    docs/XTQUANT_COMPAT_REPLACEMENT.md documents
+    ``from bigqmt_signal_trader import xtquant_compat as xtconstant``, so the
+    obvious fix -- importing just the three names the module uses -- would have
+    silently dropped 536 constants out from under that documented path.
+    """
+
+    def _both(self):
+        from xtquant import xtconstant
+        from bigqmt_signal_trader import xtquant_compat
+
+        return xtconstant, xtquant_compat
+
+    def test_every_public_constant_is_still_reachable(self):
+        xtconstant, xtquant_compat = self._both()
+        exported = [n for n in dir(xtconstant) if not n.startswith("_")]
+        missing = [n for n in exported if not hasattr(xtquant_compat, n)]
+
+        self.assertEqual(missing, [])
+        self.assertGreater(len(exported), 500)
+
+    def test_values_match_the_source_of_truth(self):
+        xtconstant, xtquant_compat = self._both()
+        for name in dir(xtconstant):
+            if name.startswith("_"):
+                continue
+            self.assertIs(
+                getattr(xtquant_compat, name),
+                getattr(xtconstant, name),
+                "%s diverged from xtquant.xtconstant" % name,
+            )
+
+    def test_mixed_case_constants_survive(self):
+        """A .isupper() filter would look right and drop these four."""
+        _, xtquant_compat = self._both()
+        for name in (
+            "EESO_ActiveFirst",
+            "EESO_ActiveFirstFull",
+            "EESO_ConcurrentlyOrder",
+            # sic -- the native SDK spells it "ClOSE"; we mirror it verbatim.
+            "OFFSET_FLAG_ClOSEYESTERDAY",
+        ):
+            self.assertTrue(hasattr(xtquant_compat, name), name)
+
+    def test_the_documented_migration_path_still_reads_constants(self):
+        from bigqmt_signal_trader import xtquant_compat as xtconstant
+
+        self.assertEqual(xtconstant.STOCK_BUY, 23)
+        self.assertEqual(xtconstant.STOCK_SELL, 24)
+        self.assertEqual(xtconstant.FIX_PRICE, 11)
+        self.assertEqual(xtconstant.ORDER_SUCCEEDED, 56)
+
+    def test_backfill_does_not_shadow_the_module_s_own_names(self):
+        """setdefault, not update: xtquant_compat's own definitions win."""
+        from bigqmt_signal_trader import xtquant_compat
+
+        self.assertEqual(xtquant_compat.DEFAULT_MARKET_DATA_CHUNK, 100)
+        self.assertTrue(hasattr(xtquant_compat, "BigQmtXtTrader"))
+
+
+class ExecEventsPreloadTest(unittest.TestCase):
+    """The callback path must not be where exec_events first gets exec'd."""
+
+    def test_module_is_loaded_at_import_time(self):
+        import bigqmt_signal_trader_strategy as strategy
+
+        self.assertIsNotNone(
+            strategy._exec_events,
+            "exec_events must be resolved at module load, not in the callback",
+        )
+        self.assertTrue(hasattr(strategy._exec_events, "normalize_order_event"))
+
+    def test_publish_path_contains_no_import_statement(self):
+        """An import here runs on QMT's PyGILState_Ensure callback thread."""
+        source = _module_source("bigqmt_signal_trader_strategy.py")
+        start = source.index("def _publish_exec_event(")
+        end = source.index("\ndef ", start + 1)
+        body = source[start:end]
+
+        self.assertNotIn("import exec_events", body)
+        self.assertNotIn("import_module", body)
+
+    def test_publish_is_a_no_op_when_the_module_failed_to_load(self):
+        """Load failure disables pushing; it must not raise into the callback.
+
+        A raise here would reach QMT's callback and stop the strategy.
+        """
+        import bigqmt_signal_trader_strategy as strategy
+
+        saved = strategy._exec_events
+        strategy._exec_events = None
+        try:
+            self.assertIsNone(strategy._publish_exec_event("order", object()))
+        finally:
+            strategy._exec_events = saved
+
+    def test_publish_failures_log_the_exception_type_and_traceback(self):
+        """str(exc) alone reads "error return without exception set" and stops
+        there -- that is what made this take a day to diagnose."""
+        import bigqmt_signal_trader_strategy as strategy
+
+        logged = []
+
+        class _Boom(object):
+            def __getattr__(self, name):
+                raise SystemError("error return without exception set")
+
+        class _Events(object):
+            def normalize_order_event(self, obj, account_id):
+                raise SystemError("error return without exception set")
+
+        saved = {
+            name: getattr(strategy, name)
+            for name in ("_log_err", "_exec_event_sink", "_exec_events", "_build_config")
+        }
+        strategy._log_err = lambda name, msg: logged.append(msg)
+        strategy._exec_event_sink = lambda config: object()
+        strategy._exec_events = _Events()
+        strategy._build_config = lambda: {"account_id": "acct", "exec_events": {"enabled": True}}
+        try:
+            strategy._publish_exec_event("order", _Boom())
+        finally:
+            for name, value in saved.items():
+                setattr(strategy, name, value)
+
+        self.assertEqual(len(logged), 1, logged)
+        message = logged[0]
+        self.assertIn("SystemError", message)
+        self.assertIn("error return without exception set", message)
+        self.assertIn("Traceback", message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
两个都由 @heimo88 在部署 v0.2.10 后报出，均有 2026-08-27 实测。两个都**只在单文件 / QMT 沙箱部署里暴露**，普通包部署不触发——这也是整个测试套件一路全绿的原因。

## 1. `from xtquant.xtconstant import *` 是语法错误

```
SyntaxError: import * only allowed at module level (<string>, line 10219)
```

单文件构建把每个模块塞进函数体 exec，而 `import *` 只允许在模块级。这是 #73 引入的——它删掉 `xtquant_compat` 里 110 个硬编码常量，改用 `import *` 兜住。

**只导入实际用到的 3 个名字会修好语法、同时弄坏别的东西**：`import *` 拉进 534 个名字，模块自己只用 `ORDER_UNKNOWN` / `STOCK_BUY` / `STOCK_SELL` 三个，但 `docs/XTQUANT_COMPAT_REPLACEMENT.md` 写明的「接入方式一」是

```python
from bigqmt_signal_trader import xtquant_compat as xtconstant
```

也就是调用方会从这个模块读常量。所以改成显式循环回填，**539/539 全部保留**，逐个与来源比对通过。

没有用模块级 `__getattr__`：PEP 562 是 Python 3.7+，而 QMT 是 **3.6**（`bin.x64/python36.dll`）。4 个混合大小写常量（含原生 SDK 拼错的 `OFFSET_FLAG_ClOSEYESTERDAY`）也说明不能按 `.isupper()` 过滤。

## 2. `exec_events: publish order failed: error return without exception set`

`exec_events` 之前是**在 order/deal 回调内部**导入的。QMT 的这些回调跑在经 `PyGILState_Ensure` 进入的 C++ 线程上，在那条线程上首次 exec 一个尚未导入的模块会在 C 层失败**且不设置 Python 异常**，表现为 `SystemError: error return without exception set`。

普通部署不炸，是因为 init 时的 reload 循环已经把它预热进 `sys.modules`，惰性导入直接命中缓存；沙箱构建里那个 `import_module` 会失败并被 `except` 吞掉，于是真的在回调线程上首载。

改为模块加载时导入，走的是已经在给适配器模块服务的同一个本地 loader，并对这个实测到的 C 层失败模式保留一个 `threading.Thread` 重试。

**另外**：原来的 handler 只记 `str(exc)`，读出来就是 `error return without exception set` 然后没了——这正是它花了一天才定位的原因。现在带上异常类和完整堆栈。

## 测试

新增 11 个，其中 **6 个在修复前的代码上会红**。另外 5 个守的是常量再导出——照抄那版只导 3 个名字的补丁会让它们变红。

`497 passed`，42/42 测试文件全部收集。

## 这里验证不了的部分

报告人的单文件构建脚本依赖两个从未附上的模块（见 #56），所以**我没法跑那个构建**。第 1 项是通过「把模块源码放进函数体编译」钉住的——已确认这条检查在旧代码上复现了他报的那条 SyntaxError。第 2 项的真实回调投递需要实际下单才触发。

两项都建议 @heimo88 在他的部署上复测。
