### PR TITLE
fix(bigqmt): pass account type to compact queries

### DIFF
--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -702,6 +702,11 @@ class BigQmtRpcHandlers:
         except Exception:
             return []
 
+    def _configured_account_type(self):
+        return str(
+            getattr(self.order_gateway, "account_type", "CREDIT") or "CREDIT"
+        ).strip().upper()
+
     def _query_trade_detail(self, params, detail_type, strategy_name=""):
         """get_trade_detail_data with one of the 6 official detail types.
 
@@ -733,7 +738,11 @@ class BigQmtRpcHandlers:
 
     def _handle_query_stk_compacts(self, params):
         # 未平仓合约（负债）— 官方 get_unclosed_compacts
-        return self._call_qmt_global("get_unclosed_compacts", self._request_account_id(params))
+        return self._call_qmt_global(
+            "get_unclosed_compacts",
+            self._request_account_id(params),
+            self._configured_account_type(),
+        )
 
     def _handle_query_credit_subjects(self, params):
         # 融资标的（担保品）— 官方 get_assure_contract
@@ -796,10 +805,18 @@ class BigQmtRpcHandlers:
         return self._call_qmt_global("get_enable_short_contract", self._request_account_id(params))
 
     def _handle_get_unclosed_compacts(self, params):
-        return self._call_qmt_global("get_unclosed_compacts", self._request_account_id(params))
+        return self._call_qmt_global(
+            "get_unclosed_compacts",
+            self._request_account_id(params),
+            self._configured_account_type(),
+        )
 
     def _handle_get_closed_compacts(self, params):
-        return self._call_qmt_global("get_closed_compacts", self._request_account_id(params))
+        return self._call_qmt_global(
+            "get_closed_compacts",
+            self._request_account_id(params),
+            self._configured_account_type(),
+        )
 
     def _handle_get_debt_contract(self, params):
         return self._call_qmt_global("get_debt_contract", self._request_account_id(params))

--- a/tests/bigqmt_signal_trader/test_redis_rpc.py
+++ b/tests/bigqmt_signal_trader/test_redis_rpc.py
@@ -66,6 +66,41 @@ class FakePositionProvider:
         return AssetSnapshot(account_id=account_id, cash=100.0, total_asset=1000.0)
 
 
+class CreditCompactQueryTest(unittest.TestCase):
+    def test_compact_queries_pass_configured_account_type(self):
+        calls = []
+
+        def query(*args):
+            calls.append(args)
+            return []
+
+        gateway = DryRunOrderGateway()
+        gateway.account_type = "credit"
+        handlers = BigQmtRpcHandlers(
+            account_id="acct",
+            market_data=FakeMarketData(),
+            position_provider=FakePositionProvider(),
+            order_gateway=gateway,
+            qmt_api={
+                "get_unclosed_compacts": query,
+                "get_closed_compacts": query,
+            },
+        )
+
+        handlers._handle_query_stk_compacts({})
+        handlers._handle_get_unclosed_compacts({})
+        handlers._handle_get_closed_compacts({})
+
+        self.assertEqual(
+            calls,
+            [
+                ("acct", "CREDIT"),
+                ("acct", "CREDIT"),
+                ("acct", "CREDIT"),
+            ],
+        )
+
+
 def _service(allow_order_methods=False, process_in_listener=False):
     return _service_with_listener_methods(
         allow_order_methods=allow_order_methods,


### PR DESCRIPTION
## Summary

Credit compact RPC queries no longer fail on QMT runtimes that enforce the documented two-argument signature. Both unclosed and closed compact handlers now pass the configured account type while preserving the existing empty-list fallback behavior for unavailable QMT functions.

## Test plan

- `python -m pytest tests/bigqmt_signal_trader/test_redis_rpc.py -q` — 41 passed

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)
