### PR TITLE
fix(bigqmt): preserve credit order operation types

### DIFF
--- a/src/bigqmt_signal_trader/adapters/order_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/order_bigqmt.py
@@ -20,6 +20,16 @@ PRICE_TYPE_ALIASES = {
     "MARKET_SZ_CONVERT_5_CANCEL": 47,
 }
 
+ORDER_TYPE_ACTIONS = {
+    23: "BUY",
+    24: "SELL",
+    27: "BUY",
+    31: "SELL",
+    32: "REPAY",
+    33: "BUY",
+    34: "SELL",
+}
+
 
 def _action_from_offset_flag(offset_flag):
     return SignalAction.BUY.value if int(offset_flag or 0) == 48 else SignalAction.SELL.value
@@ -166,7 +176,12 @@ class BigQmtOrderGateway:
     def submit(self, request):
         passorder = self._require_passorder()
         action = str(request.action).upper()
-        if action == SignalAction.BUY.value:
+        explicit_order_type = getattr(request, "order_type", None)
+        if explicit_order_type is not None:
+            op_type = int(explicit_order_type)
+            if ORDER_TYPE_ACTIONS.get(op_type) != action:
+                raise ValueError("unsupported order_type or action mismatch: %s/%s" % (op_type, action))
+        elif action == SignalAction.BUY.value:
             op_type = 23
         elif action == SignalAction.SELL.value:
             op_type = 24
@@ -216,6 +231,15 @@ class BigQmtOrderGateway:
                     _attr(row, ("m_strInstrumentID", "instrument_id", "stock_code")),
                     _attr(row, ("m_strExchangeID", "exchange_id", "market")),
                 )
+                order_type = int(
+                    _attr(row, ("m_nOpType", "op_type", "order_type"), 0) or 0
+                )
+                action = ORDER_TYPE_ACTIONS.get(
+                    order_type,
+                    _action_from_offset_flag(
+                        _attr(row, ("m_nOffsetFlag", "offset_flag"), 0)
+                    ),
+                )
             except Exception as exc:
                 skip_unparsable_row("ORDER", row, exc)
                 continue
@@ -224,7 +248,7 @@ class BigQmtOrderGateway:
                     order_sys_id=str(_attr(row, ("m_strOrderSysID", "order_sys_id"), "") or ""),
                     user_order_id=str(_attr(row, ("m_strRemark", "user_order_id", "remark"), "") or ""),
                     stock_code=stock_code,
-                    action=_action_from_offset_flag(_attr(row, ("m_nOffsetFlag", "offset_flag"), 0)),
+                    action=action,
                     volume=int(_attr(row, ("m_nVolumeTotalOriginal", "volume"), 0) or 0),
                     traded_volume=int(_attr(row, ("m_nVolumeTraded", "traded_volume"), 0) or 0),
                     status=str(_attr(row, ("m_nOrderStatus", "status"), "") or ""),
@@ -236,6 +260,7 @@ class BigQmtOrderGateway:
                     traded_price=float(
                         _attr(row, ("m_dTradedPrice", "traded_price", "avg_traded_price"), 0.0) or 0.0
                     ),
+                    order_type=order_type or None,
                 )
             )
         return result

--- a/src/bigqmt_signal_trader/models.py
+++ b/src/bigqmt_signal_trader/models.py
@@ -329,6 +329,7 @@ class OrderRequest:
         price_type,
         strategy_name,
         remark="",
+        order_type=None,
     ):
         self.signal_id = signal_id
         self.account_id = account_id
@@ -339,6 +340,7 @@ class OrderRequest:
         self.price_type = price_type
         self.strategy_name = strategy_name
         self.remark = remark
+        self.order_type = order_type
 
 
 class OrderSubmitResult:
@@ -365,6 +367,7 @@ class OrderSnapshot:
         order_time=0,
         status_msg="",
         traded_price=0.0,
+        order_type=None,
     ):
         self.order_sys_id = order_sys_id
         self.user_order_id = user_order_id
@@ -375,6 +378,7 @@ class OrderSnapshot:
         self.status = status
         self.price = price
         self.traded_price = traded_price
+        self.order_type = order_type
         self.strategy_name = strategy_name
         self.remark = remark
         # 报单时间, Unix 秒 -- MiniQMT XtOrder.order_time 的语义。0 = 未上报。

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -176,8 +176,17 @@ METHOD_ALIASES = {
     "cancel_order_stock_sysid": "cancel_order",
 }
 
-BUY_ORDER_TYPES = {"23", "STOCK_BUY", "BUY", "B"}
-SELL_ORDER_TYPES = {"24", "STOCK_SELL", "SELL", "S"}
+ORDER_TYPE_ACTIONS = {
+    "23": "BUY",
+    "24": "SELL",
+    "27": "BUY",
+    "31": "SELL",
+    "32": "REPAY",
+    "33": "BUY",
+    "34": "SELL",
+}
+BUY_ORDER_TYPES = {"23", "27", "33", "STOCK_BUY", "BUY", "B"}
+SELL_ORDER_TYPES = {"24", "31", "34", "STOCK_SELL", "SELL", "S"}
 CANCELABLE_ORDER_STATUSES = {"50", "55"}
 SAFE_B64_PREFIX = "b64s:"
 SAFE_B64_DIGIT_ENCODE = str.maketrans("0123456789", "!#$%&()*~?")
@@ -886,14 +895,30 @@ class BigQmtRpcHandlers:
 
     def _order_action_from_params(self, params):
         action = str(params.get("action") or "").upper()
-        if action:
-            return action
         order_type = str(params.get("order_type") or "").upper()
+        if action:
+            expected_action = ORDER_TYPE_ACTIONS.get(order_type)
+            if expected_action is not None and expected_action != action:
+                raise ValueError("order_type does not match action")
+            return action
         if order_type in BUY_ORDER_TYPES:
             return "BUY"
         if order_type in SELL_ORDER_TYPES:
             return "SELL"
+        if order_type == "32":
+            return "REPAY"
         raise ValueError("action or order_type is required")
+
+    def _explicit_order_type_from_params(self, params):
+        value = params.get("order_type")
+        if value is None or value == "":
+            return None
+        text = str(value).strip().upper()
+        if text in ("STOCK_BUY", "BUY", "B", "STOCK_SELL", "SELL", "S"):
+            return None
+        if text not in ORDER_TYPE_ACTIONS:
+            raise ValueError("unsupported order_type: %s" % value)
+        return int(text)
 
     def _handle_submit_order(self, params):
         if self.order_gateway is None:
@@ -913,9 +938,10 @@ class BigQmtRpcHandlers:
             price_type=params.get("price_type") or "LIMIT",
             strategy_name=str(params.get("strategy_name") or "bigqmt_rpc"),
             remark=order_tag,
+            order_type=self._explicit_order_type_from_params(params),
         )
-        if request.action not in ("BUY", "SELL"):
-            raise ValueError("action must be BUY or SELL")
+        if request.action not in ("BUY", "SELL", "REPAY"):
+            raise ValueError("action must be BUY, SELL or REPAY")
         if not request.stock_code:
             raise ValueError("stock_code is required")
         if request.volume <= 0:

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -2947,7 +2947,7 @@ class BigQmtXtTrader:
 
     def _order_from_dict(self, account_id, item):
         action = item.get("action")
-        order_type = _action_to_order_type(action)
+        order_type = _safe_int(item.get("order_type"), _action_to_order_type(action))
         order_sysid = str(item.get("order_sys_id") or item.get("order_sysid") or item.get("order_id") or "")
         return CompatObject(
             account_id=account_id,

--- a/tests/bigqmt_signal_trader/test_bigqmt_adapters.py
+++ b/tests/bigqmt_signal_trader/test_bigqmt_adapters.py
@@ -252,6 +252,37 @@ class BigQmtAdaptersTest(unittest.TestCase):
         self.assertEqual(calls[0][9], result.user_order_id)
         self.assertIs(calls[0][10], context)
 
+    def test_order_gateway_submit_preserves_credit_operation_types(self):
+        cases = (
+            (27, "BUY"),
+            (31, "SELL"),
+            (32, "REPAY"),
+            (33, "BUY"),
+            (34, "SELL"),
+        )
+        for order_type, action in cases:
+            with self.subTest(order_type=order_type):
+                calls = []
+                gateway = BigQmtOrderGateway(
+                    context_info=object(),
+                    passorder_func=lambda *args: calls.append(args),
+                )
+                request = OrderRequest(
+                    signal_id="sig-%s" % order_type,
+                    account_id="acct",
+                    action=action,
+                    stock_code="600000.SH",
+                    volume=100,
+                    price=10.0,
+                    price_type=11,
+                    strategy_name="credit-strategy",
+                    order_type=order_type,
+                )
+
+                gateway.submit(request)
+
+                self.assertEqual(calls[0][0], order_type)
+
     def test_order_gateway_cancel_and_query_orders(self):
         cancel_calls = []
 
@@ -267,7 +298,8 @@ class BigQmtAdaptersTest(unittest.TestCase):
                     m_strRemark="remark1",
                     m_strInstrumentID="000001",
                     m_strExchangeID="SZ",
-                    m_nOffsetFlag=49,
+                    m_nOffsetFlag=48,
+                    m_nOpType=31,
                     m_nVolumeTotalOriginal=1000,
                     m_nVolumeTraded=200,
                     m_nOrderStatus=50,
@@ -291,6 +323,7 @@ class BigQmtAdaptersTest(unittest.TestCase):
         self.assertEqual(cancel_calls, [("ord1", "acct", "STOCK", context)])
         self.assertEqual(orders[0].stock_code, "000001.SZ")
         self.assertEqual(orders[0].action, "SELL")
+        self.assertEqual(orders[0].order_type, 31)
         self.assertEqual(orders[0].traded_volume, 200)
         self.assertEqual(orders[0].price, 10.12)
         self.assertEqual(orders[0].traded_price, 10.05)

--- a/tests/bigqmt_signal_trader/test_redis_rpc.py
+++ b/tests/bigqmt_signal_trader/test_redis_rpc.py
@@ -66,6 +66,33 @@ class FakePositionProvider:
         return AssetSnapshot(account_id=account_id, cash=100.0, total_asset=1000.0)
 
 
+class CreditOrderTypeRpcTest(unittest.TestCase):
+    def test_submit_order_forwards_explicit_credit_operation_type(self):
+        gateway = DryRunOrderGateway()
+        handlers = BigQmtRpcHandlers(
+            account_id="acct",
+            market_data=FakeMarketData(),
+            position_provider=FakePositionProvider(),
+            order_gateway=gateway,
+            allow_order_methods=True,
+        )
+
+        handlers._handle_submit_order(
+            {
+                "stock_code": "600000.SH",
+                "order_type": 31,
+                "order_volume": 100,
+                "price": 10.0,
+                "price_type": 11,
+                "signal_id": "credit-sell-repay",
+                "wait_settlement": False,
+            }
+        )
+
+        self.assertEqual(gateway.submitted[0].action, "SELL")
+        self.assertEqual(gateway.submitted[0].order_type, 31)
+
+
 def _service(allow_order_methods=False, process_in_listener=False):
     return _service_with_listener_methods(
         allow_order_methods=allow_order_methods,

--- a/tests/bigqmt_signal_trader/test_xtquant_compat_contract.py
+++ b/tests/bigqmt_signal_trader/test_xtquant_compat_contract.py
@@ -348,12 +348,14 @@ class QueryPathSerializationContractTest(unittest.TestCase):
             remark="rmk-9",
             order_time=1755655200,
             traded_price=10.05,
+            order_type=31,
         )
         item = to_jsonable(snapshot)
         order = self._trader()._order_from_dict("acct", item)
         self.assertEqual(order.order_id, "sys-9")
         self.assertEqual(order.order_time, 1755655200)
         self.assertEqual(order.traded_price, 10.05)
+        self.assertEqual(order.order_type, 31)
         self.assertEqual(order.strategy_name, "strat-a")
         self.assertEqual(order.order_remark, "rmk-9")
 


### PR DESCRIPTION
## Summary

Credit orders no longer collapse to plain stock buy/sell operations before reaching `passorder`. RPC requests can carry financing, repayment, and collateral operation types 27/31/32/33/34 end to end, with action/type mismatches rejected before submission.

Order queries now preserve QMT's `m_nOpType` through the RPC snapshot and XtQuant-compatible order object, while retaining the existing per-row isolation, rejection message, and traded-price fields. This was validated without enabling or sending live orders.

## Test plan

- `python -m pytest tests/bigqmt_signal_trader/test_bigqmt_adapters.py tests/bigqmt_signal_trader/test_redis_rpc.py tests/bigqmt_signal_trader/test_xtquant_compat_contract.py -q` — 85 passed, 5 subtests passed

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)
