### PR TITLE
account_id 缺失时说清楚找过哪里 (#90)，补 QMT Python 组件前置说明 (#85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,8 @@ print(xtdata.get_full_tick(["000001.SZ"]))
 
 ### B. 服务端（QMT 内 Python 3.6）
 
+> **前置：先在 QMT 界面里下载 Python 组件。** 全新安装的终端 `bin.x64\` 下**没有 `Lib\` 目录**，也没有 `python.exe`——那是 Python 组件带来的，不是终端自带的，**不要自己手动创建 `Lib\`**。在 QMT 客户端里下载安装该组件后，`bin.x64\Lib\site-packages\` 才会出现，下面的路径才成立。具体入口见迅投官方文档。
+
 QMT 自带 Python 3.6（`bin.x64/python.exe`），**只需按你选的传输装对应依赖**：
 
 | 传输 | 服务端需要的包 | 客户端需要的包 |

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -193,6 +193,45 @@ def _quote_push_zmq_address(client):
     return "tcp://%s:%d" % (host, base_port + 1)
 
 
+def _missing_account_id_message():
+    """Say what was searched and what to do, not just that something is missing.
+
+    "Big QMT account_id is required" told the reader nothing about where the
+    config was looked for, so a config file placed one sys.path away from the
+    running interpreter looked identical to no config at all (issue #90).
+    """
+    searched = list(DEFAULT_CLIENT_CONFIG_MODULES)
+    selected = os.environ.get(CLIENT_CONFIG_MODULE_ENV)
+    if selected and selected not in searched:
+        searched.insert(0, selected)
+    found = None
+    try:
+        config = load_client_config()
+        found = (config or {}).get("module")
+    except Exception:
+        pass
+
+    if found:
+        detail = ("imported %s, but it defines no BIGQMT_ACCOUNT_ID"
+                  % found)
+    else:
+        detail = ("none of these modules could be imported: %s"
+                  % ", ".join(searched))
+    lines = [
+        "Big QMT account_id is required -- %s." % detail,
+        "Fix it in any one of these ways:",
+        "  1. put bigqmt_signal_trader_client_config.py somewhere on sys.path"
+        " (the current working directory counts), with BIGQMT_ACCOUNT_ID set;",
+        "  2. set the BIGQMT_ACCOUNT_ID environment variable;",
+        "  3. call bigqmt_signal_trader.xtquant_compat.configure(account_id=...)"
+        " before use;",
+        "  or run `bigqmt-init`, which writes both config files for you.",
+        "configure() also runs at import time, so a config put in place after"
+        " importing this module needs configure() called again.",
+    ]
+    return "\n".join(lines)
+
+
 def load_client_config(module_name=None):
     """Load local private client config without requiring environment variables."""
     candidates = []
@@ -648,7 +687,7 @@ class BigQmtRpcClient:
     def call(self, method, params=None, account_id=None, timeout_seconds=None):
         target_account = str(account_id or self.account_id or "")
         if not target_account:
-            raise ValueError("Big QMT account_id is required")
+            raise ValueError(_missing_account_id_message())
         wait_seconds = self.timeout_seconds if timeout_seconds is None else timeout_seconds
         # Fast path: reference/history reads answered straight by QMT's
         # FormulaServer, bypassing the strategy process and its GIL. Anything it

--- a/tests/bigqmt_signal_trader/test_missing_account_id_message.py
+++ b/tests/bigqmt_signal_trader/test_missing_account_id_message.py
@@ -1,0 +1,103 @@
+"""The missing-account_id error has to say what was searched (issue #90).
+
+"Big QMT account_id is required" was the whole message. It did not say which
+modules were looked for, so a config file sitting one sys.path away from the
+running interpreter produced exactly the same text as no config at all -- and
+the reporter had in fact placed the file, just where their interpreter could
+not import it.
+"""
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader import xtquant_compat
+
+
+class MissingAccountIdMessageTest(unittest.TestCase):
+    def setUp(self):
+        self._saved = {name: os.environ.get(name)
+                       for name in ("BIGQMT_ACCOUNT_ID",
+                                    xtquant_compat.CLIENT_CONFIG_MODULE_ENV)}
+        for name in self._saved:
+            os.environ.pop(name, None)
+
+    def tearDown(self):
+        for name, value in self._saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+    def test_it_names_the_modules_it_looked_for(self):
+        message = xtquant_compat._missing_account_id_message()
+        for module_name in xtquant_compat.DEFAULT_CLIENT_CONFIG_MODULES:
+            self.assertIn(module_name, message)
+
+    def test_it_offers_every_working_remedy(self):
+        """All three are verified paths; the message must not omit one."""
+        message = xtquant_compat._missing_account_id_message()
+
+        self.assertIn("sys.path", message)
+        self.assertIn("BIGQMT_ACCOUNT_ID", message)
+        self.assertIn("configure(account_id=", message)
+        self.assertIn("bigqmt-init", message)
+
+    def test_it_mentions_the_import_time_timing_trap(self):
+        """configure() runs at import, so a config placed afterwards is
+        silently ignored until configure() is called again."""
+        message = xtquant_compat._missing_account_id_message()
+        self.assertIn("import time", message)
+
+    def test_a_selected_module_from_the_environment_is_listed_first(self):
+        os.environ[xtquant_compat.CLIENT_CONFIG_MODULE_ENV] = "my_own_config"
+        message = xtquant_compat._missing_account_id_message()
+
+        self.assertIn("my_own_config", message)
+        self.assertLess(message.index("my_own_config"),
+                        message.index("bigqmt_signal_trader_client_config"))
+
+    def test_the_call_path_actually_raises_it(self):
+        client = xtquant_compat.BigQmtRpcClient(account_id="")
+        with self.assertRaises(ValueError) as caught:
+            client.call("ping", {})
+
+        message = str(caught.exception)
+        self.assertIn("Big QMT account_id is required", message)
+        self.assertIn("bigqmt_signal_trader_client_config", message)
+
+    def test_a_config_that_imports_but_lacks_the_key_says_so(self):
+        """Different cause, different message: the file was found, the key was
+        not -- telling the reader to check sys.path would send them the wrong
+        way."""
+        module = type(sys)("fake_client_config")
+        module.BIGQMT_REDIS_CONFIG = {"host": "127.0.0.1"}
+        sys.modules["fake_client_config"] = module
+        os.environ[xtquant_compat.CLIENT_CONFIG_MODULE_ENV] = "fake_client_config"
+        try:
+            message = xtquant_compat._missing_account_id_message()
+        finally:
+            sys.modules.pop("fake_client_config", None)
+
+        self.assertIn("fake_client_config", message)
+        self.assertIn("defines no BIGQMT_ACCOUNT_ID", message)
+
+    def test_it_never_raises_while_building_the_message(self):
+        """This runs on an error path; an exception here would replace a bad
+        error message with a worse one."""
+        saved = xtquant_compat.load_client_config
+        xtquant_compat.load_client_config = lambda *a, **k: 1 / 0
+        try:
+            message = xtquant_compat._missing_account_id_message()
+        finally:
+            xtquant_compat.load_client_config = saved
+
+        self.assertIn("Big QMT account_id is required", message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## #90：`account_id is required` 说不清问题在哪

原来整条消息就一句 `Big QMT account_id is required`。它**不说自己找过哪些模块**，所以「配置文件放错了解释器能看到的位置」和「压根没建配置文件」产生的报错**一模一样**。

报告人其实已经建了那个文件——只是放在了一个他运行的解释器并不 import 的 site-packages 里。

### 实测四种情况

```
(a) 没有配置模块
    config module found : None
    account_id resolved : ''
    -> ValueError: Big QMT account_id is required     <- 复现

(b) 配置模块在 sys.path 上
    config module found : bigqmt_signal_trader_client_config
    account_id resolved : '8886800503'

(c) 只设 BIGQMT_ACCOUNT_ID 环境变量
    config module found : None
    account_id resolved : '8886800503'

(d) 显式 configure(account_id=...)
    after configure()   : '8886800503'
```

### 改成

```
Big QMT account_id is required -- none of these modules could be imported:
bigqmt_signal_trader_client_config, bigqmt_signal_trader_local_config.
Fix it in any one of these ways:
  1. put bigqmt_signal_trader_client_config.py somewhere on sys.path
     (the current working directory counts), with BIGQMT_ACCOUNT_ID set;
  2. set the BIGQMT_ACCOUNT_ID environment variable;
  3. call bigqmt_signal_trader.xtquant_compat.configure(account_id=...) before use;
  or run `bigqmt-init`, which writes both config files for you.
configure() also runs at import time, so a config put in place after importing
this module needs configure() called again.
```

两种成因分开说：**没有可导入的模块** vs **模块导入了但没定义 `BIGQMT_ACCOUNT_ID`**。后者去查 `sys.path` 是南辕北辙。

顺带点出那个时序陷阱：`configure()` 在模块导入时就跑了一次，之后才放好的配置不会自动生效。

构造这条消息本身**不会抛异常**——它跑在错误路径上，在这里抛异常等于用一个更糟的报错替换一个不好的报错。已有测试钉住。

## #85：`bin.x64\` 下没有 `Lib\`

README 补了前置说明：全新安装的终端 `bin.x64\` 下**没有** `Lib\`，也没有 `python.exe`——那是 Python 组件带来的，**不要手动创建 `Lib\`**。在 QMT 客户端里装好该组件后目录才会出现，README 后面那些路径才成立。

## 测试

新增 7 个。`543 passed`，45/45 测试文件全部收集。
