### PR TITLE
account_type 的三个配置位置，两个静默失效 (#92)

### DIFF
--- a/src/bigqmt_signal_trader_local_config.example.py
+++ b/src/bigqmt_signal_trader_local_config.example.py
@@ -10,6 +10,11 @@ Do not commit the real file. It may contain account ids and Redis credentials.
 
 BIGQMT_ACCOUNT_ID = "YOUR_ACCOUNT_ID"
 
+# STOCK(股票) / CREDIT(信用两融) / FUTURE(期货) / STOCK_OPTION(股票期权) ...
+# 信用账户务必设为 CREDIT：按 STOCK 查询不会报错，get_trade_detail_data 会返回
+# 一行全 0 的资产，表现为「信用账户资产全是 0」而日志里毫无线索（issue #92）。
+# 也可以写在下面 BIGQMT_REDIS_CONFIG 的 "account_type" 里，两处都认；解析结果
+# 会在启动时打印，冲突也会指出来。
 BIGQMT_ACCOUNT_TYPE = "STOCK"
 
 BIGQMT_REDIS_CONFIG = {

--- a/src/bigqmt_signal_trader_redis_rpc_runtime.py
+++ b/src/bigqmt_signal_trader_redis_rpc_runtime.py
@@ -128,11 +128,53 @@ except Exception:
 try:
     from bigqmt_signal_trader_local_config import BIGQMT_ACCOUNT_TYPE
 except Exception:
-    BIGQMT_ACCOUNT_TYPE = "STOCK"
+    BIGQMT_ACCOUNT_TYPE = ""
 
 ACCOUNT_ID = str(BIGQMT_ACCOUNT_ID or ACCOUNT_ID or "")
-# 账号类型：只从独立变量 BIGQMT_ACCOUNT_TYPE 读取，默认 STOCK
-ACCOUNT_TYPE = str(BIGQMT_ACCOUNT_TYPE or ACCOUNT_TYPE or "STOCK").strip().upper()
+
+# Account type. A credit account read as STOCK returns an all-zero asset row
+# rather than an error, so getting this wrong is silent (issue #92).
+#
+# Three places look plausible and only one used to work:
+#   - BIGQMT_ACCOUNT_TYPE in the local config          -- worked
+#   - account_type inside BIGQMT_REDIS_CONFIG          -- was ignored
+#   - editing ACCOUNT_TYPE in this file                -- silently overwritten
+#     below, because the shipped example config sets BIGQMT_ACCOUNT_TYPE.
+# Both of the others are now honoured, and the resolved value is printed at
+# startup so a setting that did not take effect is visible instead of showing
+# up later as zero assets.
+# The constant above ships as "STOCK", so it only counts as something the user
+# chose once it has been edited away from that; otherwise every credit setup
+# would report a phantom conflict with it.
+_ACCOUNT_TYPE_EDITED_HERE = ACCOUNT_TYPE if ACCOUNT_TYPE != "STOCK" else ""
+_account_type_sources = [
+    ("BIGQMT_ACCOUNT_TYPE", BIGQMT_ACCOUNT_TYPE),
+    ("BIGQMT_REDIS_CONFIG['account_type']", BIGQMT_REDIS_CONFIG.get("account_type")),
+    ("ACCOUNT_TYPE in bigqmt_signal_trader_redis_rpc_runtime.py",
+     _ACCOUNT_TYPE_EDITED_HERE),
+]
+ACCOUNT_TYPE_SOURCE = "default"
+ACCOUNT_TYPE = "STOCK"
+for _source_name, _source_value in _account_type_sources:
+    if _source_value:
+        ACCOUNT_TYPE = str(_source_value).strip().upper()
+        ACCOUNT_TYPE_SOURCE = _source_name
+        break
+
+
+def _report_account_type():
+    """Say which account type won and where it came from."""
+    print("[bigqmt_shell] account_type=%s (from %s)" % (ACCOUNT_TYPE, ACCOUNT_TYPE_SOURCE))
+    conflicting = [
+        name for name, value in _account_type_sources
+        if value and str(value).strip().upper() != ACCOUNT_TYPE
+    ]
+    if conflicting:
+        print("[bigqmt_shell] ignored conflicting account_type from: %s"
+              % ", ".join(conflicting))
+
+
+_report_account_type()
 REDIS_HOST = BIGQMT_REDIS_CONFIG.get("host", REDIS_HOST)
 REDIS_PORT = int(BIGQMT_REDIS_CONFIG.get("port", REDIS_PORT))
 REDIS_DB = int(BIGQMT_REDIS_CONFIG.get("db", REDIS_DB))

--- a/tests/bigqmt_signal_trader/test_account_type_resolution.py
+++ b/tests/bigqmt_signal_trader/test_account_type_resolution.py
@@ -1,0 +1,180 @@
+"""account_type has to be discoverable, and visible once resolved (issue #92).
+
+A credit account queried as STOCK does not error -- `get_trade_detail_data`
+returns an all-zero asset row. So getting this setting wrong shows up as
+"credit assets are all 0" with nothing in the logs pointing at the cause.
+
+Three places looked plausible and only one worked:
+
+  BIGQMT_ACCOUNT_TYPE in the local config      worked
+  account_type inside BIGQMT_REDIS_CONFIG      silently ignored
+  ACCOUNT_TYPE in the runtime module           silently overwritten, because
+                                               the shipped example config sets
+                                               BIGQMT_ACCOUNT_TYPE = "STOCK"
+
+All three are honoured now, and the resolved value is printed with its source.
+"""
+
+import io
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SRC = os.path.join(ROOT, "src")
+sys.path.insert(0, SRC)
+
+
+PROBE = (
+    "import sys\n"
+    "sys.path.insert(0, %r)\n"
+    "import bigqmt_signal_trader_redis_rpc_runtime as rt\n"
+    "print('RESOLVED|%%s|%%s' %% (rt.ACCOUNT_TYPE, rt.ACCOUNT_TYPE_SOURCE))\n"
+) % SRC
+
+
+def resolve(config_source):
+    """Import the runtime in a fresh interpreter against a generated config."""
+    workdir = tempfile.mkdtemp()
+    with io.open(os.path.join(workdir, "bigqmt_signal_trader_local_config.py"),
+                 "w", encoding="utf-8") as handle:
+        handle.write(config_source)
+    script = os.path.join(workdir, "probe.py")
+    with io.open(script, "w", encoding="utf-8") as handle:
+        handle.write(PROBE)
+    completed = subprocess.run(
+        [sys.executable, script], cwd=workdir,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    output = completed.stdout.decode("utf-8", "replace")
+    if completed.returncode != 0:
+        raise AssertionError("probe failed:\n%s" % output)
+    line = [row for row in output.splitlines() if row.startswith("RESOLVED|")]
+    if not line:
+        raise AssertionError("probe printed nothing usable:\n%s" % output)
+    _tag, account_type, source = line[0].split("|", 2)
+    return account_type, source, output
+
+
+BASE = 'BIGQMT_ACCOUNT_ID = "acct"\n'
+
+
+class AccountTypeSourcesTest(unittest.TestCase):
+    def test_documented_variable_wins(self):
+        account_type, source, _ = resolve(
+            BASE + 'BIGQMT_ACCOUNT_TYPE = "CREDIT"\n'
+                   'BIGQMT_REDIS_CONFIG = {"host": "127.0.0.1"}\n')
+
+        self.assertEqual(account_type, "CREDIT")
+        self.assertEqual(source, "BIGQMT_ACCOUNT_TYPE")
+
+    def test_redis_config_key_is_honoured(self):
+        """Where the reporter put it. It used to be read by nothing."""
+        account_type, source, _ = resolve(
+            BASE + 'BIGQMT_REDIS_CONFIG = {"host": "1", "account_type": "CREDIT"}\n')
+
+        self.assertEqual(account_type, "CREDIT")
+        self.assertIn("BIGQMT_REDIS_CONFIG", source)
+
+    def test_nothing_set_falls_back_to_stock(self):
+        account_type, source, _ = resolve(
+            BASE + 'BIGQMT_REDIS_CONFIG = {"host": "127.0.0.1"}\n')
+
+        self.assertEqual(account_type, "STOCK")
+        self.assertEqual(source, "default")
+
+    def test_value_is_normalised(self):
+        account_type, _source, _ = resolve(
+            BASE + 'BIGQMT_ACCOUNT_TYPE = "  credit  "\n'
+                   'BIGQMT_REDIS_CONFIG = {}\n')
+
+        self.assertEqual(account_type, "CREDIT")
+
+    def test_a_config_without_the_key_keeps_the_account_id(self):
+        """An older local config must not lose its account id just because it
+        predates BIGQMT_ACCOUNT_TYPE."""
+        _account_type, _source, output = resolve(
+            BASE + 'BIGQMT_REDIS_CONFIG = {"host": "10.0.0.5"}\n')
+
+        self.assertNotIn("Traceback", output)
+
+
+class ResolutionIsVisibleTest(unittest.TestCase):
+    """Silence is what turned a one-line setting into "assets are all 0"."""
+
+    def test_the_resolved_type_and_its_source_are_printed(self):
+        _account_type, _source, output = resolve(
+            BASE + 'BIGQMT_ACCOUNT_TYPE = "CREDIT"\n'
+                   'BIGQMT_REDIS_CONFIG = {}\n')
+
+        self.assertIn("account_type=CREDIT", output)
+        self.assertIn("BIGQMT_ACCOUNT_TYPE", output)
+
+    def test_conflicting_settings_are_called_out(self):
+        _account_type, _source, output = resolve(
+            BASE + 'BIGQMT_ACCOUNT_TYPE = "CREDIT"\n'
+                   'BIGQMT_REDIS_CONFIG = {"account_type": "STOCK"}\n')
+
+        self.assertIn("ignored conflicting", output)
+        self.assertIn("BIGQMT_REDIS_CONFIG", output)
+
+    def test_the_shipped_default_is_not_reported_as_a_conflict(self):
+        """ACCOUNT_TYPE ships as STOCK, so every credit setup would otherwise
+        report a phantom conflict with it."""
+        _account_type, _source, output = resolve(
+            BASE + 'BIGQMT_ACCOUNT_TYPE = "CREDIT"\n'
+                   'BIGQMT_REDIS_CONFIG = {}\n')
+
+        self.assertNotIn("ignored conflicting", output)
+
+
+class ReachesTheAssetQueryTest(unittest.TestCase):
+    """The setting only matters if it arrives at get_trade_detail_data."""
+
+    def test_configured_type_reaches_get_asset(self):
+        import bigqmt_signal_trader_strategy as strategy
+        from bigqmt_signal_trader.adapters.position_bigqmt import BigQmtPositionProvider
+
+        saved = dict(strategy._config)
+        try:
+            strategy.configure(mode="bigqmt", account_id="acct", account_type="CREDIT")
+            config = strategy._build_config()
+        finally:
+            strategy._config.clear()
+            strategy._config.update(saved)
+
+        self.assertEqual(config.get("account_type"), "CREDIT")
+
+        seen = []
+
+        def query(account, account_type, detail_type, *args):
+            seen.append((account_type, detail_type))
+            return []
+
+        provider = BigQmtPositionProvider(
+            get_trade_detail_data_func=query,
+            account_type=config.get("account_type", "STOCK"))
+        provider.get_asset("acct")
+
+        self.assertEqual(seen[0], ("CREDIT", "ACCOUNT"))
+
+    def test_positions_use_the_same_type(self):
+        from bigqmt_signal_trader.adapters.position_bigqmt import BigQmtPositionProvider
+
+        seen = []
+
+        def query(account, account_type, detail_type, *args):
+            seen.append((account_type, detail_type))
+            return []
+
+        provider = BigQmtPositionProvider(
+            get_trade_detail_data_func=query, account_type="CREDIT")
+        provider.get_positions("acct")
+
+        self.assertEqual(seen[0][0], "CREDIT")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 报告人的诊断，一半对

**对的一半**：`BIGQMT_REDIS_CONFIG` 里的 `account_type` 确实**没有任何地方读它**。

**不对的一半**：「不管怎么设定都按 stock 执行」不成立。文档写明的位置——local config 里的模块级 `BIGQMT_ACCOUNT_TYPE`——**是通的**，我端到端验过：

```
_build_config()['account_type'] = 'CREDIT'
get_asset -> get_trade_detail_data(account_type='CREDIT', detail='ACCOUNT')
```

## 真正的问题：三个看着都合理的位置，两个静默失效

| 位置 | 修复前 |
|---|---|
| local config 里的 `BIGQMT_ACCOUNT_TYPE` | 生效 |
| `BIGQMT_REDIS_CONFIG["account_type"]` | **无人读取** |
| 改 `redis_rpc_runtime.py` 里的 `ACCOUNT_TYPE` | **被静默覆盖** |

第三条尤其阴：`ACCOUNT_TYPE = str(BIGQMT_ACCOUNT_TYPE or ACCOUNT_TYPE or "STOCK")`，而随包发的 example 配置里写着 `BIGQMT_ACCOUNT_TYPE = "STOCK"`——它是**真值**，所以永远赢，改文件里那个常量等于白改。

报告人用的正是后两条。

## 为什么它彻底没有线索

信用账户按 STOCK 查**不报错**——`get_trade_detail_data` 返回一行全 0 的资产。而且解析出的 `account_type` **从不打印**：启动日志只列 `BIGQMT_REDIS_CONFIG` 的键。所以设错地方唯一的表现就是「资产全是 0」。

## 改动

后两条位置现在都认，按上表优先级；解析结果在启动时打印并说明来源：

```
1. BIGQMT_ACCOUNT_TYPE = 'CREDIT'
   [bigqmt_shell] account_type=CREDIT (from BIGQMT_ACCOUNT_TYPE)

2. account_type 放在 BIGQMT_REDIS_CONFIG 里   <- 报告人试的
   [bigqmt_shell] account_type=CREDIT (from BIGQMT_REDIS_CONFIG['account_type'])

3. 两处冲突
   [bigqmt_shell] account_type=CREDIT (from BIGQMT_ACCOUNT_TYPE)
   [bigqmt_shell] ignored conflicting account_type from: BIGQMT_REDIS_CONFIG['account_type']

4. 都不设
   [bigqmt_shell] account_type=STOCK (from default)
```

模块常量出厂就是 `"STOCK"`，所以**只有被改动过**才算用户的选择——否则每个信用部署都会报一条与它的假冲突。

## 测试

新增 10 个，**8 个在修复前会红**。通过的 2 个是资产查询链路——这是**对的**，因为那条链路本来就没坏，这个区分正是本 PR 想说清楚的事。

`553 passed`，46/46 测试文件全部收集。

`local_config.example.py` 也写上了这个症状，那是大家会去看的地方。

## 未验证

本机是股票账户，**没有信用账户可以实盘确认「资产不再全 0」**。本 PR 修的是配置发现与可见性，那部分完全由测试钉住；请 @jerry87n 在信用账户上复测——启动日志现在会直接打印 `account_type=`，一眼可辨。
