### PR TITLE
feat: 新增新股申购(打新)支持 - 每日自动申购沪深新股

### DIFF
--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -757,8 +757,11 @@ class BigQmtRpcHandlers:
         return self._call_qmt_global("get_assure_contract", self._request_account_id(params))
 
     def _handle_query_appointment_info(self, params):
-        # 新股数据 — 官方 get_ipo_data
-        return self._call_qmt_global("get_ipo_data", self._request_account_id(params))
+        # 新股数据 — 官方 get_ipo_data(type)
+        # 8-28 修复: 原实现把 account_id 当第一个参数传给 get_ipo_data (期望 type),
+        # 导致返回 [{}]. 改为透传 type 参数 ("STOCK"/"BOND"/缺省全部).
+        return self._call_qmt_global(
+            "get_ipo_data", str(params.get("type") or params.get("stock_type") or ""))
 
     def _handle_query_smt_secu_info(self, params):
         # 期权标的持仓 — 官方 get_option_subject_position
@@ -783,7 +786,9 @@ class BigQmtRpcHandlers:
         return self._call_qmt_global("get_last_order_id", self._request_account_id(params))
 
     def _handle_get_ipo_data(self, params):
-        return self._call_qmt_global("get_ipo_data", self._request_account_id(params))
+        # 8-28 修复: get_ipo_data(type) 期望 type 参数, 原错传 account_id -> [{}]
+        return self._call_qmt_global(
+            "get_ipo_data", str(params.get("type") or params.get("stock_type") or ""))
 
     def _handle_get_new_purchase_limit(self, params):
         return self._call_qmt_global("get_new_purchase_limit", self._request_account_id(params))

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -138,6 +138,7 @@ LISTENER_DEFERRED_METHODS = {
     "query_credit_slo_code",
     "query_credit_assure",
     "query_appointment_info",
+    "get_ipo_data",   # 8-28: 交易类查询, 需主线程上下文 (后台线程返回空)
     "query_smt_secu_info",
     "query_smt_secu_rate",
     "get_value_by_order_id",

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -2775,8 +2775,21 @@ class BigQmtXtTrader:
         except Exception:
             return []
 
-    def query_ipo_data(self, account=None):
-        return self._query_account_list(account, "query_appointment_info")
+    def query_ipo_data(self, account=None, stock_type=""):
+        """新股申购信息 (大 QMT get_ipo_data).
+        stock_type: "" 全部, "STOCK" 新股, "BOND" 新债.
+        8-28 修复: 直接调 get_ipo_data 带 type 参数 (原走 query_appointment_info
+        传 account_id 导致返回空)."""
+        account_id = _account_id(account, self.client.account_id)
+        try:
+            data = self.client.call(
+                "get_ipo_data",
+                {"type": stock_type},
+                account_id=account_id,
+            )
+            return data or []
+        except Exception:
+            return []
 
     def query_new_purchase_limit(self, account):
         """新股申购额度 (大 QMT get_new_purchase_limit).

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -2779,7 +2779,30 @@ class BigQmtXtTrader:
         return self._query_account_list(account, "query_appointment_info")
 
     def query_new_purchase_limit(self, account):
-        return {}
+        """新股申购额度 (大 QMT get_new_purchase_limit).
+        返回 {板块: 额度} 或 {} (失败/无权限)."""
+        account_id = _account_id(account, self.client.account_id)
+        try:
+            data = self.client.call(
+                "get_new_purchase_limit",
+                {"account_id": account_id},
+                account_id=account_id,
+            ) or {}
+            if isinstance(data, dict):
+                return data
+            return {}
+        except Exception:
+            return {}
+
+    def ipo_subscribe(self, account, stock_code, volume, price, strategy_name="ipo",
+                      order_remark="ipo_sub"):
+        """新股申购 (打新). 复用现有 order_stock RPC (passorder opType=23 指定价).
+        stock_code 应为 get_ipo_data 返回的申购代码 (带后缀), price=发行价.
+        返回 {order_sys_id} 或 {} (失败)."""
+        return self.order_stock_result(
+            account, stock_code, STOCK_BUY, int(volume),
+            FIX_PRICE, float(price), strategy_name, order_remark,
+        )
 
     # ------------------------------------------------------------------
     # async 变体：MiniQMT 的 *_async 方法返回 seq 后异步回调。

--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -1013,15 +1013,18 @@ def _run_daily_ipo(ContextInfo):
       - get_ipo_data("STOCK") 拿当日可申购新股 (已验证在 QMT 端返回正确数据)
       - 对每只 passorder(23, 1101, account, code, 11, 发行价, maxPurchaseNum)
     passorder 由 QMT 运行时注入全局; account 用 _account_id.
-    幂等: _ipo_done_date 记录当天已打新, 避免 adjust 每周期重复申购.
+    幂等: _ipo_done_date 在函数最开头就标记当天, 无论成功失败当天只执行一次
+    (8-28 教训: 原实现末尾才设置, 中间异常导致 adjust 重复触发 -> 重复申购,
+     第二条被拒 "委托重复申购").
     """
     global _ipo_done_date
     from datetime import datetime as _dt
 
+    today = _dt.now().strftime("%Y%m%d")
+    if _ipo_done_date == today:
+        return
+    _ipo_done_date = today   # 前置标记: 幂等 (当天只试一次)
     try:
-        today = _dt.now().strftime("%Y%m%d")
-        if _ipo_done_date == today:
-            return
         get_ipo_data = _resolve_runtime_name("get_ipo_data")
         if get_ipo_data is None:
             print("[ipo] get_ipo_data 未绑定 (QMT 未注入), 跳过打新")
@@ -1042,7 +1045,6 @@ def _run_daily_ipo(ContextInfo):
             return
         if not ipo:
             print("[ipo] 今日无新股可申购")
-            _ipo_done_date = today
             return
 
         print("[ipo] 今日可申购 %d 只新股:" % len(ipo))
@@ -1061,7 +1063,6 @@ def _run_daily_ipo(ContextInfo):
                     code, info.get("name", ""), max_num, price))
             except Exception as exc:
                 print("[ipo] %s 申购异常: %s" % (code, exc))
-        _ipo_done_date = today
         print("[ipo] 今日打新完成")
     except Exception as exc:
         print("[ipo] 打新流程异常: %s" % exc)

--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -133,6 +133,9 @@ _last_full_tick_market_refresh_at = 0.0
 # Observed adjust cadence, so a mis-scheduled run_time (e.g. clamped to bar
 # cadence) is visible in the logs instead of silently costing latency.
 _adjust_tick_stats = {"last_ts": 0.0, "count": 0, "window_start": 0.0, "sum": 0.0, "min": 0.0, "max": 0.0}
+# 打新 (8-28): 记录当天已打新的日期 (YYYYMMDD), 幂等避免每日重复申购
+_ipo_done_date = None
+_IPO_SUBSCRIBE_HHMM = 940   # 每天 09:40 触发打新 (HHMM)
 
 
 def set_app_factory(factory):
@@ -989,6 +992,81 @@ def _adjust_phase(name, fn, *args):
             print("[adjust_phase] %s %.0fms" % (name, ms))
 
 
+def _maybe_run_daily_ipo(ContextInfo):
+    """每天 09:40 后触发一次打新 (adjust 每周期调用, _ipo_done_date 幂等)."""
+    from datetime import datetime as _dt
+    try:
+        now = _dt.now()
+        if now.strftime("%H%M") < "0940":
+            return
+        if now.strftime("%H%M") > "1130":
+            return  # 申购窗口过后不再触发
+        _run_daily_ipo(ContextInfo)
+    except Exception:
+        pass
+
+
+def _run_daily_ipo(ContextInfo):
+    """每日新股申购 (8-28, 子项目内置, 不依赖 RPC 查询链路).
+
+    在 QMT 主线程 (adjust) 中直接调用原生 get_ipo_data + passorder:
+      - get_ipo_data("STOCK") 拿当日可申购新股 (已验证在 QMT 端返回正确数据)
+      - 对每只 passorder(23, 1101, account, code, 11, 发行价, maxPurchaseNum)
+    passorder 由 QMT 运行时注入全局; account 用 _account_id.
+    幂等: _ipo_done_date 记录当天已打新, 避免 adjust 每周期重复申购.
+    """
+    global _ipo_done_date
+    from datetime import datetime as _dt
+
+    try:
+        today = _dt.now().strftime("%Y%m%d")
+        if _ipo_done_date == today:
+            return
+        get_ipo_data = _resolve_runtime_name("get_ipo_data")
+        if get_ipo_data is None:
+            print("[ipo] get_ipo_data 未绑定 (QMT 未注入), 跳过打新")
+            return
+        passorder = _resolve_runtime_name("passorder")
+        if passorder is None:
+            print("[ipo] passorder 未绑定, 跳过打新")
+            return
+        account_id = _account_id or ""
+        if not account_id:
+            print("[ipo] account_id 未配置, 跳过打新")
+            return
+
+        try:
+            ipo = get_ipo_data("STOCK") or {}
+        except Exception as exc:
+            print("[ipo] get_ipo_data 调用异常: %s" % exc)
+            return
+        if not ipo:
+            print("[ipo] 今日无新股可申购")
+            _ipo_done_date = today
+            return
+
+        print("[ipo] 今日可申购 %d 只新股:" % len(ipo))
+        for code, info in ipo.items():
+            try:
+                price = float(info.get("issuePrice") or 0)
+                max_num = int(info.get("maxPurchaseNum") or 0)
+                if price <= 0 or max_num <= 0:
+                    print("[ipo] %s 发行价/数量非法, 跳过" % code)
+                    continue
+                # passorder(opType=23 买入/申购, orderType=1101 普通, account, code,
+                #          prType=11 指定价, price=发行价, volume=max, strategy, quick, remark)
+                passorder(23, 1101, account_id, code, 11, price, max_num,
+                          "ipo", 1, "ipo:%s:%s" % (code, today), ContextInfo)
+                print("[ipo] %s(%s) 申购 %d 股 @ %s" % (
+                    code, info.get("name", ""), max_num, price))
+            except Exception as exc:
+                print("[ipo] %s 申购异常: %s" % (code, exc))
+        _ipo_done_date = today
+        print("[ipo] 今日打新完成")
+    except Exception as exc:
+        print("[ipo] 打新流程异常: %s" % exc)
+
+
 def adjust(ContextInfo, _source="timer"):
     global _adjust_logged
     _record_adjust_tick()
@@ -1002,6 +1080,11 @@ def adjust(ContextInfo, _source="timer"):
             return None
     except Exception:
         pass
+    # 8-28: 每日打新 (QMT 主线程直接调 get_ipo_data + passorder)
+    try:
+        _maybe_run_daily_ipo(ContextInfo)
+    except Exception as exc:
+        print("[ipo] adjust 打新触发异常: %s" % exc)
     if not _adjust_logged:
         print("[bigqmt_signal_trader] adjust ok")
         _adjust_logged = True

--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -1048,8 +1048,15 @@ def _run_daily_ipo(ContextInfo):
             return
 
         print("[ipo] 今日可申购 %d 只新股:" % len(ipo))
+        skipped = 0
         for code, info in ipo.items():
             try:
+                # 只打沪深 (SH/SZ): 沪深打新是市值申购, 不冻结资金;
+                # 北交所 (BJ/920/8/4 开头) 需冻结资金, 排除.
+                if not _is_shsz_ipo_code(code):
+                    print("[ipo] %s 非沪深 (北交所/其他), 跳过" % code)
+                    skipped += 1
+                    continue
                 price = float(info.get("issuePrice") or 0)
                 max_num = int(info.get("maxPurchaseNum") or 0)
                 if price <= 0 or max_num <= 0:
@@ -1063,9 +1070,27 @@ def _run_daily_ipo(ContextInfo):
                     code, info.get("name", ""), max_num, price))
             except Exception as exc:
                 print("[ipo] %s 申购异常: %s" % (code, exc))
+        if skipped:
+            print("[ipo] 跳过北交所/非沪深 %d 只 (资金不冻结, 仅打沪深)" % skipped)
         print("[ipo] 今日打新完成")
     except Exception as exc:
         print("[ipo] 打新流程异常: %s" % exc)
+
+
+def _is_shsz_ipo_code(code):
+    """判断申购代码是否沪深 (SH/SZ). 北交所 920/8/4 开头或 .BJ 后缀 -> False."""
+    c = str(code or "")
+    up = c.upper()
+    if up.endswith(".BJ"):
+        return False
+    if up.endswith(".SH") or up.endswith(".SZ"):
+        return True
+    # 裸码: 920/8/4 开头北交所, 6/0/3 开头沪深
+    if up.startswith(("920", "8", "4")):
+        return False
+    if up[:1] in ("6", "0", "3"):
+        return True
+    return True  # 无法识别默认放行 (申购代码多为 7/0/3 开头)
 
 
 def adjust(ContextInfo, _source="timer"):


### PR DESCRIPTION
## 概要
为大 QMT 桥新增新股(IPO)申购能力。

### 包含内容
1. **服务端自动打新**（`bigqmt_signal_trader_strategy.py`）：在 `adjust` 回调中，
   每天 09:40-11:30 窗口触发一次——调 `get_ipo_data("STOCK")` 获取当日可申购新股，
   通过原生 `passorder(23, 1101, code, 11, 发行价, 最大量)` 逐只申购。
   当天幂等（函数入口即置当日标记，避免重复触发）。**只申购沪深(SH/SZ)股票**——
   沪深打新为市值申购、不冻结资金；北交所需冻结资金，已排除。

2. **RPC 客户端方法**（`xtquant_compat.py`）：
   - `query_ipo_data(stock_type=...)`：对接服务端 `get_ipo_data`，修正 `type` 参数。
   - `query_new_purchase_limit`：接通服务端 `get_new_purchase_limit`
     （原为空实现 `{}`）。
   - `ipo_subscribe(...)`：通过现有 `order_stock` RPC 提交打新委托。

3. **服务端 handler 修复**（`redis_rpc.py`）：
   - `get_ipo_data` / `query_appointment_info` 原先把 `account_id` 误当成
     `get_ipo_data(type)` 的第一个参数传入，导致永远返回 `[{}]`。现改为透传
     `type` 参数（"STOCK"/"BOND"/空=全部）。
   - `get_ipo_data` 加入 `LISTENER_DEFERRED_METHODS`：它是交易类查询，
     在 RPC 后台线程调用会返回空，需在主策略线程执行。

## 验证
- **实盘**：2026-08-28 成功申购 301689.SZ（最大 12000 股 @ 16.0），委托已受理
  （status=86）。一次重复尝试被券商拒绝（"委托重复申购"，已通过入口幂等标记修复）。
- **单元**：沪深/北交所代码过滤测试 7 例通过。
- 所有改动文件 `py_compile` 通过。

## 备注
- 打新支持因券商而异，请先确认你的券商接受 `passorder` 方式的新股申购。
- 幂等标记为进程内变量，盘中重启服务端可能重复尝试（券商会拒绝重复申购）。