### PR TITLE
期货合约符号不再被大写化 (#95)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,124 @@
+# CLAUDE.md
+
+Notes for working in this repo. Everything here cost real time to learn; none of
+it is obvious from the code.
+
+## What this is
+
+A Python RPC bridge exposing Big QMT (大 QMT) trading APIs to external programs,
+plus a MiniQMT-compatible client layer. `passorder` / `get_trade_detail_data`
+are globals injected into QMT's own Python process, which is why the bridge
+exists: MiniQMT's `XtQuantServer` channel returns `connect() == -1` here.
+
+Two sides, and it matters which one you are editing:
+
+- **Server** — runs *inside* QMT: `src/bigqmt_signal_trader_strategy.py`,
+  `src/bigqmt_signal_trader_redis_rpc_runtime.py`, `src/bigqmt_signal_trader/`
+- **Client** — runs in the user's own program: `src/bigqmt_signal_trader/xtquant_compat.py`,
+  `src/xtquant/` (a shim standing in for the real MiniQMT package)
+
+## Hard constraints
+
+**`get_trade_detail_data` returns EMPTY off the main strategy thread.** This is
+the single most important fact in the project. It kills any "background worker
+polls orders/positions" design. Order and query RPCs run on the adjust (main)
+thread — see `ORDER_METHODS` / `LISTENER_DEFERRED_METHODS` in `redis_rpc.py`.
+Never move them to a background thread, and never let `rpc_background_threads`
+default to True in any config or template.
+
+**QMT ships Python 3.6** (`bin.x64/python36.dll`). Server-side code must avoid
+3.7+ syntax. Notably, module-level `__getattr__` (PEP 562) is 3.7+ and does
+nothing there — f-strings are fine (3.6+), walrus and dataclasses are not.
+
+**No star imports anywhere in `src/`.** The single-file builds exec each module
+inside a `def _mod_N():` body, where `from X import *` is a SyntaxError. Pinned
+by `tests/bigqmt_signal_trader/test_qmt_sandbox_loading.py`, which is the only
+place in the suite that compiles a module inside a function.
+
+**QMT enforces an import whitelist.** `socket` has been rejected in the field,
+including indirectly (`logging_setup` → `logging.handlers` → `socket`). AST
+scanning for direct imports is not enough. Keep setup-time tooling
+(`init_config`, which imports `subprocess`/`getpass`) out of anything that runs
+in the sandbox.
+
+**QMT's order/deal callbacks run on a C++ thread** entered via
+`PyGILState_Ensure`. The first exec of a not-yet-imported module on that thread
+fails in the C layer *without setting a Python exception* — it surfaces as
+`SystemError: error return without exception set`. Import at module load, never
+inside a callback.
+
+## Testing
+
+```bash
+python -m pytest tests/ -q
+```
+
+Two habits worth keeping:
+
+- **Check collection count, not just pass count.** A merged PR once left 27 test
+  modules silently uncollectable; `-q` output looks identical.
+  ```bash
+  find tests -name "test_*.py" | wc -l
+  python -m pytest tests/ --collect-only -q | grep -oE "^tests[^:]*\.py" | sort -u | wc -l
+  ```
+- **Verify a new test fails against the pre-fix code** (`git stash`, run, pop).
+  Tests written from the same wrong premise as the code pass while the premise is
+  wrong — that is exactly how PR #88's mis-mapped order types stayed green.
+
+## Deploying to the live terminal
+
+Server-side code goes to `D:\国金证券QMT交易端_lemo\python\`. Sync the package
+directories **and the top-level modules** — `bigqmt_signal_trader_redis_rpc_runtime.py`
+is a top-level file and is easy to miss. Never overwrite
+`bigqmt_signal_trader_local_config.py` or `..._client_config.py`; they hold the
+account id and credentials.
+
+QMT keeps strategy modules in `sys.modules` across editor re-runs, so **a deploy
+does nothing until the user restarts the strategy**. Ask them to restart, then
+check `userdata/log/XtClient_FormulaOutput_YYYYMMDD.log` (not `userdata_mini/`,
+which is a stale MiniQMT subprocess) — the reqid suffix increments on a fresh
+instance.
+
+**When probing the deployed code, put your temp directory ahead of the QMT
+directory on `sys.path`.** The QMT directory contains a real
+`bigqmt_signal_trader_local_config.py`; getting the order wrong makes every
+probe silently read the live config instead of your fixture, which looks exactly
+like the fix not working.
+
+## Releasing
+
+Version in `pyproject.toml`, entry in `CHANGELOG.md`, then tag and push.
+
+**Write release notes to a file and use `--notes-file`.** Backticks in an inline
+`--body` are command substitution and get silently eaten — this has corrupted
+release notes and an issue comment. Same for `gh issue comment`.
+
+**`gh release create` uploads assets after creating the release, and deletes the
+release if an upload fails.** If it times out and moves to the background, do
+NOT upload manually — the duplicate returns HTTP 422, the background create
+rolls back, and the whole release disappears while the tag stays. Create the
+release with no assets, then `gh release upload` one file at a time. Verify
+afterwards that both artifacts are attached and that the notes still render.
+
+## Working with contributed PRs
+
+Several arrive AI-generated with passing tests. Two things have needed catching:
+
+- **Constants asserted as literals.** Check every value against
+  `src/xtquant/xtconstant.py` by name. PR #88 mapped `33`/`34` as special credit
+  financing; they are stock-option operations (`40`/`41` are the credit ones),
+  and its tests encoded the same mistake.
+- **Contributors' own live settings in templates.** One PR carried a real account
+  id plus `rpc_allow_order_methods=True`. Diff config blocks against
+  `src/bigqmt_signal_trader_local_config.example.py` before merging.
+
+Fork PRs cannot be pushed to. Merge, then land corrections as a follow-up PR
+from a branch in this repo.
+
+## Reporting
+
+Say what was verified and what was not. Several fixes here can only be confirmed
+by a reporter with a credit account, a restricted broker sandbox, or live fills.
+Record those as known limitations in the release notes rather than implying
+coverage — and when a limitation is later resolved by real evidence, say so
+explicitly in the next release.

--- a/src/bigqmt_signal_trader/code_utils.py
+++ b/src/bigqmt_signal_trader/code_utils.py
@@ -6,23 +6,39 @@ import re
 _DIGIT_CODE_RE = re.compile(r"^\d{6}$")
 
 
+# QMT ContextInfo uses market-specific suffixes for all instrument types.
+_QMT_SUFFIXES = (
+    ".SH", ".SZ", ".BJ", ".HK",            # Stock markets
+    ".HGT", ".SGT",                        # 港股通（沪/深）
+    ".SHO", ".SZO",                        # Options markets (8-digit codes)
+    ".SF", ".DF", ".IF", ".ZF", ".INE", ".GF",    # Futures markets
+)
+# Futures symbols are case-sensitive: each exchange has its own convention, and
+# the two are not interchangeable -- "rb2401.SF" (SHFE, lower) is a different
+# string to QMT than "RB2401.SF", while CZCE writes "AP401.ZF" upper. Uppercasing
+# a lowercase futures symbol therefore produces a code QMT does not recognise,
+# which surfaces as an empty quote rather than an error (issue #95).
+#
+# #68 fixed this for POSITION rows by bypassing this function; every other path
+# -- orders, quotes, the full-tick cache, the risk guard -- still came through
+# here and got uppercased.
+_CASE_SENSITIVE_SUFFIXES = frozenset({".SF", ".DF", ".IF", ".ZF", ".INE", ".GF"})
+
+
 def normalize_stock_code(code):
-    text = str(code or "").strip().upper()
-    if not text:
+    raw = str(code or "").strip()
+    if not raw:
         return ""
-    # QMT ContextInfo uses market-specific suffixes for all instrument types.
+    text = raw.upper()
     # If the code already has a recognized suffix, pass it through unchanged —
     # these are native ContextInfo codes that need no normalization.
-    _QMT_SUFFIXES = (
-        ".SH", ".SZ", ".BJ", ".HK",           # Stock markets
-        ".HGT", ".SGT",                        # 港股通（沪/深）
-        ".SHO", ".SZO",                        # Options markets (8-digit codes)
-        ".SF", ".DF", ".IF", ".ZF", ".INE", ".GF",    # Futures markets
-    )
     for suffix in _QMT_SUFFIXES:
         if text.endswith(suffix):
             prefix = text[:-len(suffix)]
             if prefix and (prefix.isdigit() or prefix[0].isalpha()):
+                if suffix in _CASE_SENSITIVE_SUFFIXES:
+                    # Normalise the suffix, keep the caller's symbol verbatim.
+                    return raw[:-len(suffix)] + suffix
                 return text
     # Original logic for 6-digit stock codes
     if text.startswith("SH") and _DIGIT_CODE_RE.match(text[2:]):

--- a/src/bigqmt_signal_trader/full_tick_cache.py
+++ b/src/bigqmt_signal_trader/full_tick_cache.py
@@ -27,12 +27,15 @@ def normalize_full_tick_codes(codes):
     normalized = []
     seen = set()
     for code in codes or []:
-        text = str(code or "").strip().upper()
+        text = str(code or "").strip()
         if not text:
             continue
-        if text in MARKET_CODES:
-            item = text
+        if text.upper() in MARKET_CODES:
+            item = text.upper()
         else:
+            # Pass the raw code through: futures symbol case is exchange
+            # convention and normalize_stock_code preserves it (issue #95).
+            # Uppercasing here would undo that before it ever gets the chance.
             item = normalize_stock_code(text)
         if item not in seen:
             seen.add(item)

--- a/tests/bigqmt_signal_trader/test_futures_code_case.py
+++ b/tests/bigqmt_signal_trader/test_futures_code_case.py
@@ -1,0 +1,144 @@
+"""Futures symbol case must survive normalisation (issue #95).
+
+Each exchange writes its contract symbols its own way and the two are not
+interchangeable: SHFE writes "rb2401", CZCE writes "AP401". To QMT those are
+different strings, so uppercasing a lowercase futures symbol yields a code it
+does not recognise -- and an unrecognised code comes back as an empty quote,
+not an error.
+
+normalize_stock_code opened with `.upper()`, so every caller got the uppercased
+form. #68 fixed this for POSITION rows by bypassing the function entirely; the
+order, quote, cache and risk-guard paths all still came through here.
+"""
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.code_utils import normalize_stock_code
+
+
+# (symbol as the exchange writes it, suffix)
+FUTURES = [
+    ("rb2401", ".SF"),    # SHFE  螺纹钢 -- lower
+    ("ag2412", ".SF"),    # SHFE  白银   -- lower
+    ("m2609", ".DF"),     # DCE   豆粕   -- lower
+    ("AP401", ".ZF"),     # CZCE  苹果   -- upper
+    ("CF405", ".ZF"),     # CZCE  棉花   -- upper
+    ("IC2609", ".IF"),    # CFFEX 中证500 -- upper
+    ("IF2609", ".IF"),    # CFFEX 沪深300 -- upper
+    ("sc2503", ".INE"),   # INE   原油   -- lower
+    ("si2504", ".GF"),    # GFEX  工业硅 -- lower
+]
+
+
+class FuturesCasePreservedTest(unittest.TestCase):
+    def test_symbol_case_is_returned_verbatim(self):
+        for symbol, suffix in FUTURES:
+            code = symbol + suffix
+            self.assertEqual(normalize_stock_code(code), code,
+                             "%s was rewritten" % code)
+
+    def test_lowercase_symbols_are_not_uppercased(self):
+        """The specific regression: rb2401.SF must not become RB2401.SF."""
+        self.assertEqual(normalize_stock_code("rb2401.SF"), "rb2401.SF")
+        self.assertEqual(normalize_stock_code("m2609.DF"), "m2609.DF")
+
+    def test_uppercase_symbols_are_not_lowercased_either(self):
+        self.assertEqual(normalize_stock_code("AP401.ZF"), "AP401.ZF")
+        self.assertEqual(normalize_stock_code("IC2609.IF"), "IC2609.IF")
+
+    def test_the_suffix_itself_is_normalised(self):
+        """Only the symbol is case-sensitive; the market suffix is not."""
+        self.assertEqual(normalize_stock_code("rb2401.sf"), "rb2401.SF")
+        self.assertEqual(normalize_stock_code("AP401.zf"), "AP401.ZF")
+        self.assertEqual(normalize_stock_code("sc2503.ine"), "sc2503.INE")
+
+    def test_normalisation_is_idempotent(self):
+        for symbol, suffix in FUTURES:
+            once = normalize_stock_code(symbol + suffix)
+            self.assertEqual(normalize_stock_code(once), once, once)
+
+    def test_two_spellings_stay_distinct(self):
+        """If both collapsed to one string the bug would be invisible."""
+        self.assertNotEqual(normalize_stock_code("rb2401.SF"),
+                            normalize_stock_code("RB2401.SF"))
+
+
+class StockCodesUnaffectedTest(unittest.TestCase):
+    """Stock symbols are digits, so this change must not move them."""
+
+    def test_plain_and_suffixed_stock_codes(self):
+        self.assertEqual(normalize_stock_code("600000"), "600000.SH")
+        self.assertEqual(normalize_stock_code("000001"), "000001.SZ")
+        self.assertEqual(normalize_stock_code("600000.SH"), "600000.SH")
+        self.assertEqual(normalize_stock_code("sh600000"), "600000.SH")
+        self.assertEqual(normalize_stock_code("SZ000001"), "000001.SZ")
+
+    def test_other_suffixed_markets(self):
+        self.assertEqual(normalize_stock_code("00700.HGT"), "00700.HGT")
+        self.assertEqual(normalize_stock_code("00700.hgt"), "00700.HGT")
+        self.assertEqual(normalize_stock_code("10004356.SHO"), "10004356.SHO")
+
+    def test_invalid_codes_still_raise(self):
+        for bad in ("", None):
+            self.assertEqual(normalize_stock_code(bad), "")
+        with self.assertRaises(ValueError):
+            normalize_stock_code("not-a-code")
+
+
+class CallerPathsTest(unittest.TestCase):
+    """The function is only interesting because of what calls it. These are the
+    paths that were sending an uppercased futures code to QMT."""
+
+    def test_order_submission_keeps_the_symbol(self):
+        from bigqmt_signal_trader.adapters.order_bigqmt import BigQmtOrderGateway
+        from bigqmt_signal_trader.models import OrderRequest
+
+        captured = {}
+
+        def passorder(op_type, order_type, account, code, price_type, price,
+                      volume, strategy, quick, remark, context=None, *a, **k):
+            captured["code"] = code
+
+        gateway = BigQmtOrderGateway(account_id="acct", passorder_func=passorder,
+                                     context_info=object())
+        gateway.submit(OrderRequest(
+            signal_id="s1", account_id="acct", stock_code="rb2401.SF",
+            action="BUY", volume=1, price=3500.0, price_type="LIMIT",
+            strategy_name="s"))
+
+        self.assertEqual(captured["code"], "rb2401.SF")
+
+    def test_full_tick_cache_keys_keep_the_symbol(self):
+        """This one uppercased the code BEFORE calling normalize_stock_code, so
+        it undid the fix on the very path issue #95 reported."""
+        from bigqmt_signal_trader.full_tick_cache import normalize_full_tick_codes
+
+        self.assertEqual(normalize_full_tick_codes(["rb2401.SF"]), ["rb2401.SF"])
+        self.assertEqual(normalize_full_tick_codes(["AP401.ZF"]), ["AP401.ZF"])
+
+    def test_full_tick_cache_still_recognises_whole_market_tokens(self):
+        from bigqmt_signal_trader.full_tick_cache import normalize_full_tick_codes
+
+        self.assertEqual(normalize_full_tick_codes(["sh", "SZ", "hk"]),
+                         ["HK", "SH", "SZ"])
+
+    def test_position_rows_and_this_function_now_agree(self):
+        """#68 worked around the uppercasing for POSITION rows. Both paths must
+        produce the same string, or a position and its order look unrelated."""
+        from bigqmt_signal_trader.adapters.position_bigqmt import _full_code
+
+        for symbol, suffix in FUTURES:
+            market = suffix.lstrip(".")
+            self.assertEqual(_full_code(symbol, market),
+                             normalize_stock_code(symbol + suffix),
+                             "%s%s" % (symbol, suffix))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 期货代码被大写化

各交易所的合约符号写法不同，而且**不可互换**：上期所写 `rb2401`，郑商所写 `AP401`。对 QMT 来说这是两个不同的字符串，所以把小写符号大写后得到的是它不认识的代码——而不认识的代码返回的是**空行情，不是报错**。

`normalize_stock_code` 第一行就是 `.upper()`：

```python
def normalize_stock_code(code):
    text = str(code or "").strip().upper()   # <-- 符号大小写在这里就没了
```

`#68` 当初是靠**绕开**这个函数解决持仓那条路径的；下单、行情、全推缓存、风控全都还从这里过。

而且 `full_tick_cache` 自己**还有一次** `.upper()`，发生在调用 `normalize_stock_code` **之前**——就在本 issue 报告的 `get_full_tick` 那条路径上。只修其中一处，那条路径不会有任何变化。

## 改动

符号原样返回，只归一化市场后缀：

```
rb2401.SF  ->  rb2401.SF      小写保留
AP401.ZF   ->  AP401.ZF       大写保留
rb2401.sf  ->  rb2401.SF      后缀归一化，符号不动
RB2401.SF  ->  RB2401.SF      与 rb2401.SF 保持为不同字符串
600000.SH  ->  600000.SH      股票是数字，不受影响
```

## 最值得看的一条测试

修复前，同一个期货合约的**持仓**（`rb2401.SF`，走 #68 那条路）和**委托**（`RB2401.SF`，走本函数）产生的是**两个不同的字符串**——看起来像两个不相干的品种。

新增 13 个测试，**7 个在修复前会红**，包括下单路径和上面这条一致性检查。

`566 passed`，47/47 测试文件全部收集。

## 未验证 —— 这条要说清楚

**本机终端根本没有期货行情数据**：

```
datadir/                      ->  SH  SZ  HK ...
IF SF DF ZF INE GF            ->  六个期货市场目录一个都没有
get_instrument_detail(期货)   ->  0 字段   (股票 33 字段)
期货板块                       ->  0 个合约
```

所以报告人那个空 `get_full_tick` 在我这里**复现不出是桥的问题**，本 PR 也**不能确认就解决了他的现象**——他报的 `IC2609.IF` 本身就是大写，不受本 bug 影响。

本 PR 修的是一个独立成立的真实缺陷（小写合约如 `rb2401.SF` / `m2609.DF` / `sc2503.INE` 此前必然被送成 QMT 不认识的代码）。报告人的具体问题需要他在自己终端上确认是否有期货数据。
