### PR TITLE
打新改为显式接口，不再自动下单 (#96 跟进)

### DIFF
--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -703,6 +703,27 @@ class BigQmtRpcHandlers:
         except Exception:
             return []
 
+    def _call_qmt_mapping(self, func_name, *args, **kwargs):
+        """Same as _call_qmt_global, for the QMT globals that answer with a
+        mapping rather than a row list -- get_ipo_data, get_new_purchase_limit.
+
+        The row normaliser would iterate such a dict by key and throw the values
+        away, so these keep their shape and only have their values made
+        JSON-safe.
+        """
+        func = self.qmt_api.get(func_name)
+        if func is None:
+            return {}
+        try:
+            data = func(*args, **kwargs)
+        except Exception:
+            return {}
+        if isinstance(data, dict):
+            return dict((str(key), _normalize_mapping_value(value))
+                        for key, value in data.items())
+        # Some brokers hand back rows even here; normalise rather than drop.
+        return _normalize_detail_rows(data)
+
     def _configured_account_type(self):
         return str(
             getattr(self.order_gateway, "account_type", "CREDIT") or "CREDIT"
@@ -787,12 +808,20 @@ class BigQmtRpcHandlers:
         return self._call_qmt_global("get_last_order_id", self._request_account_id(params))
 
     def _handle_get_ipo_data(self, params):
-        # 8-28 修复: get_ipo_data(type) 期望 type 参数, 原错传 account_id -> [{}]
-        return self._call_qmt_global(
+        # get_ipo_data answers with a dict KEYED BY SUBSCRIPTION CODE, not with
+        # detail rows. Sending it through _normalize_detail_rows iterates the
+        # dict, i.e. its keys, and attribute-scrapes each code string -- so
+        # {"730001": {...}, "001234": {...}} came out as [{}, {}]: codes, issue
+        # prices and quantities all gone. #96 fixed the `type` argument but the
+        # response was still being destroyed here.
+        return self._call_qmt_mapping(
             "get_ipo_data", str(params.get("type") or params.get("stock_type") or ""))
 
     def _handle_get_new_purchase_limit(self, params):
-        return self._call_qmt_global("get_new_purchase_limit", self._request_account_id(params))
+        # Documented as returning a dict of 板块 -> 额度, so it has the same
+        # shape problem get_ipo_data had (6.10 in the API reference).
+        return self._call_qmt_mapping(
+            "get_new_purchase_limit", self._request_account_id(params))
 
     def _handle_get_history_trade_detail_data(self, params):
         account_id = self._request_account_id(params)
@@ -1175,6 +1204,18 @@ def _bool_value(value, default=False):
     if isinstance(value, bool):
         return value
     return str(value).strip().lower() in ("1", "true", "yes", "y", "on")
+
+
+def _normalize_mapping_value(value):
+    """Make one mapping value JSON-safe without flattening its shape."""
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, dict):
+        return dict((str(k), _normalize_mapping_value(v)) for k, v in value.items())
+    if isinstance(value, (list, tuple)):
+        return [_normalize_mapping_value(v) for v in value]
+    rows = _normalize_detail_rows([value])
+    return rows[0] if rows else {}
 
 
 def _normalize_detail_rows(rows):

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -834,6 +834,36 @@ class BigQmtRpcClient:
                 pass
 
 
+# IPO subscription codes are their own numbering, distinct from the listed
+# share's code. Classification is FAIL-CLOSED: an unrecognised code returns None
+# and the caller skips it. The version this replaced ended in `return True`
+# ("默认放行"), i.e. it guessed in favour of placing an order -- on a path whose
+# whole job was to keep BJ subscriptions, which freeze cash, out.
+_IPO_SH_PREFIXES = ("730", "732", "780", "787", "789", "707")
+_IPO_SZ_PREFIXES = ("00", "30")
+_IPO_BJ_PREFIXES = ("920", "889", "8", "4")
+
+
+def ipo_market_of(code):
+    """Return "SH" / "SZ" / "BJ", or None when the code is not recognised."""
+    text = str(code or "").strip().upper()
+    if not text:
+        return None
+    for suffix, market in ((".SH", "SH"), (".SZ", "SZ"), (".BJ", "BJ")):
+        if text.endswith(suffix):
+            return market
+    if not text.isdigit():
+        return None
+    # Order matters: BJ 920/889 would otherwise be caught by a looser rule.
+    if text.startswith(_IPO_BJ_PREFIXES):
+        return "BJ"
+    if text.startswith(_IPO_SH_PREFIXES):
+        return "SH"
+    if text.startswith(_IPO_SZ_PREFIXES):
+        return "SZ"
+    return None
+
+
 class BigQmtXtData:
     def __init__(self, client):
         self.client = client
@@ -2787,9 +2817,12 @@ class BigQmtXtTrader:
                 {"type": stock_type},
                 account_id=account_id,
             )
-            return data or []
+            # get_ipo_data answers with a dict keyed by subscription code; an
+            # empty list here would break a caller doing .items() on the
+            # no-IPOs-today path, which is most days.
+            return data if isinstance(data, dict) else {}
         except Exception:
-            return []
+            return {}
 
     def query_new_purchase_limit(self, account):
         """新股申购额度 (大 QMT get_new_purchase_limit).
@@ -2806,6 +2839,61 @@ class BigQmtXtTrader:
             return {}
         except Exception:
             return {}
+
+    def ipo_subscribe_all(self, account=None, stock_type="STOCK",
+                          markets=("SH", "SZ"), dry_run=False,
+                          strategy_name="ipo"):
+        """Subscribe to today's IPOs. Nothing here runs on a timer.
+
+        This is deliberately a call you make, not a behaviour the bridge takes
+        on: it places real orders, so it must be something the operator asked
+        for on that day. It also goes through order_stock, which means it obeys
+        rpc_allow_order_methods and inherits the gateway's passorder settings
+        (orderType 1101, prType 11 指定价, quickTrade 2 -- 2 being the value the
+        API reference requires for a non-bar context).
+
+        markets: exchanges to subscribe on. SH/SZ subscriptions are backed by
+            market value and freeze no cash; BJ freezes cash, so it is excluded
+            by default. A code whose market cannot be identified is SKIPPED,
+            never subscribed on a guess.
+        dry_run: return the plan without placing anything.
+
+        Returns one dict per candidate: stock_code, name, price, volume,
+        action ("subscribed" / "skipped" / "failed") and reason.
+        """
+        allowed = set(str(m).upper() for m in (markets or ()))
+        results = []
+        for code, info in (self.query_ipo_data(account, stock_type=stock_type) or {}).items():
+            info = info or {}
+            entry = {
+                "stock_code": code,
+                "name": str(info.get("name") or ""),
+                "price": _safe_float(info.get("issuePrice"), 0.0),
+                "volume": _safe_int(info.get("maxPurchaseNum"), 0),
+                "action": "skipped",
+                "reason": "",
+            }
+            market = ipo_market_of(code)
+            if market is None:
+                entry["reason"] = "market not identified"
+            elif market not in allowed:
+                entry["reason"] = "%s not in %s" % (market, sorted(allowed))
+            elif entry["price"] <= 0 or entry["volume"] <= 0:
+                entry["reason"] = "issuePrice/maxPurchaseNum missing or non-positive"
+            elif dry_run:
+                entry["action"] = "planned"
+            else:
+                try:
+                    entry["result"] = self.ipo_subscribe(
+                        account, code, entry["volume"], entry["price"],
+                        strategy_name=strategy_name,
+                        order_remark="ipo:%s" % code)
+                    entry["action"] = "subscribed"
+                except Exception as exc:
+                    entry["action"] = "failed"
+                    entry["reason"] = "%s: %s" % (exc.__class__.__name__, exc)
+            results.append(entry)
+        return results
 
     def ipo_subscribe(self, account, stock_code, volume, price, strategy_name="ipo",
                       order_remark="ipo_sub"):

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -2817,10 +2817,21 @@ class BigQmtXtTrader:
                 {"type": stock_type},
                 account_id=account_id,
             )
-            # get_ipo_data answers with a dict keyed by subscription code; an
-            # empty list here would break a caller doing .items() on the
-            # no-IPOs-today path, which is most days.
-            return data if isinstance(data, dict) else {}
+            # get_ipo_data answers with a dict keyed by subscription code.
+            if isinstance(data, dict):
+                return data
+            if data:
+                # Non-empty and not a dict: an older server is still routing
+                # this through the detail-row normaliser, which iterates the
+                # dict by key and discards every value -- real IPOs arrive as
+                # [{}, {}]. Coercing that to {} silently reports "no IPOs
+                # today", so say so instead of swallowing it.
+                log.warning(
+                    "query_ipo_data: server returned %s, not a mapping -- the "
+                    "QMT-side bridge is too old to preserve get_ipo_data's "
+                    "shape and the rows are empty. Update the server side.",
+                    type(data).__name__)
+            return {}
         except Exception:
             return {}
 

--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -133,9 +133,6 @@ _last_full_tick_market_refresh_at = 0.0
 # Observed adjust cadence, so a mis-scheduled run_time (e.g. clamped to bar
 # cadence) is visible in the logs instead of silently costing latency.
 _adjust_tick_stats = {"last_ts": 0.0, "count": 0, "window_start": 0.0, "sum": 0.0, "min": 0.0, "max": 0.0}
-# 打新 (8-28): 记录当天已打新的日期 (YYYYMMDD), 幂等避免每日重复申购
-_ipo_done_date = None
-_IPO_SUBSCRIBE_HHMM = 940   # 每天 09:40 触发打新 (HHMM)
 
 
 def set_app_factory(factory):
@@ -992,107 +989,6 @@ def _adjust_phase(name, fn, *args):
             print("[adjust_phase] %s %.0fms" % (name, ms))
 
 
-def _maybe_run_daily_ipo(ContextInfo):
-    """每天 09:40 后触发一次打新 (adjust 每周期调用, _ipo_done_date 幂等)."""
-    from datetime import datetime as _dt
-    try:
-        now = _dt.now()
-        if now.strftime("%H%M") < "0940":
-            return
-        if now.strftime("%H%M") > "1130":
-            return  # 申购窗口过后不再触发
-        _run_daily_ipo(ContextInfo)
-    except Exception:
-        pass
-
-
-def _run_daily_ipo(ContextInfo):
-    """每日新股申购 (8-28, 子项目内置, 不依赖 RPC 查询链路).
-
-    在 QMT 主线程 (adjust) 中直接调用原生 get_ipo_data + passorder:
-      - get_ipo_data("STOCK") 拿当日可申购新股 (已验证在 QMT 端返回正确数据)
-      - 对每只 passorder(23, 1101, account, code, 11, 发行价, maxPurchaseNum)
-    passorder 由 QMT 运行时注入全局; account 用 _account_id.
-    幂等: _ipo_done_date 在函数最开头就标记当天, 无论成功失败当天只执行一次
-    (8-28 教训: 原实现末尾才设置, 中间异常导致 adjust 重复触发 -> 重复申购,
-     第二条被拒 "委托重复申购").
-    """
-    global _ipo_done_date
-    from datetime import datetime as _dt
-
-    today = _dt.now().strftime("%Y%m%d")
-    if _ipo_done_date == today:
-        return
-    _ipo_done_date = today   # 前置标记: 幂等 (当天只试一次)
-    try:
-        get_ipo_data = _resolve_runtime_name("get_ipo_data")
-        if get_ipo_data is None:
-            print("[ipo] get_ipo_data 未绑定 (QMT 未注入), 跳过打新")
-            return
-        passorder = _resolve_runtime_name("passorder")
-        if passorder is None:
-            print("[ipo] passorder 未绑定, 跳过打新")
-            return
-        account_id = _account_id or ""
-        if not account_id:
-            print("[ipo] account_id 未配置, 跳过打新")
-            return
-
-        try:
-            ipo = get_ipo_data("STOCK") or {}
-        except Exception as exc:
-            print("[ipo] get_ipo_data 调用异常: %s" % exc)
-            return
-        if not ipo:
-            print("[ipo] 今日无新股可申购")
-            return
-
-        print("[ipo] 今日可申购 %d 只新股:" % len(ipo))
-        skipped = 0
-        for code, info in ipo.items():
-            try:
-                # 只打沪深 (SH/SZ): 沪深打新是市值申购, 不冻结资金;
-                # 北交所 (BJ/920/8/4 开头) 需冻结资金, 排除.
-                if not _is_shsz_ipo_code(code):
-                    print("[ipo] %s 非沪深 (北交所/其他), 跳过" % code)
-                    skipped += 1
-                    continue
-                price = float(info.get("issuePrice") or 0)
-                max_num = int(info.get("maxPurchaseNum") or 0)
-                if price <= 0 or max_num <= 0:
-                    print("[ipo] %s 发行价/数量非法, 跳过" % code)
-                    continue
-                # passorder(opType=23 买入/申购, orderType=1101 普通, account, code,
-                #          prType=11 指定价, price=发行价, volume=max, strategy, quick, remark)
-                passorder(23, 1101, account_id, code, 11, price, max_num,
-                          "ipo", 1, "ipo:%s:%s" % (code, today), ContextInfo)
-                print("[ipo] %s(%s) 申购 %d 股 @ %s" % (
-                    code, info.get("name", ""), max_num, price))
-            except Exception as exc:
-                print("[ipo] %s 申购异常: %s" % (code, exc))
-        if skipped:
-            print("[ipo] 跳过北交所/非沪深 %d 只 (资金不冻结, 仅打沪深)" % skipped)
-        print("[ipo] 今日打新完成")
-    except Exception as exc:
-        print("[ipo] 打新流程异常: %s" % exc)
-
-
-def _is_shsz_ipo_code(code):
-    """判断申购代码是否沪深 (SH/SZ). 北交所 920/8/4 开头或 .BJ 后缀 -> False."""
-    c = str(code or "")
-    up = c.upper()
-    if up.endswith(".BJ"):
-        return False
-    if up.endswith(".SH") or up.endswith(".SZ"):
-        return True
-    # 裸码: 920/8/4 开头北交所, 6/0/3 开头沪深
-    if up.startswith(("920", "8", "4")):
-        return False
-    if up[:1] in ("6", "0", "3"):
-        return True
-    return True  # 无法识别默认放行 (申购代码多为 7/0/3 开头)
-
-
 def adjust(ContextInfo, _source="timer"):
     global _adjust_logged
     _record_adjust_tick()
@@ -1106,11 +1002,6 @@ def adjust(ContextInfo, _source="timer"):
             return None
     except Exception:
         pass
-    # 8-28: 每日打新 (QMT 主线程直接调 get_ipo_data + passorder)
-    try:
-        _maybe_run_daily_ipo(ContextInfo)
-    except Exception as exc:
-        print("[ipo] adjust 打新触发异常: %s" % exc)
     if not _adjust_logged:
         print("[bigqmt_signal_trader] adjust ok")
         _adjust_logged = True

--- a/tests/bigqmt_signal_trader/test_ipo_subscribe.py
+++ b/tests/bigqmt_signal_trader/test_ipo_subscribe.py
@@ -194,3 +194,67 @@ class EmptyResultShapeTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class MappingShapeTest(unittest.TestCase):
+    """get_ipo_data answers with a dict keyed by subscription code, not with
+    detail rows. It was being sent through _normalize_detail_rows, which
+    iterates a dict by KEY and attribute-scrapes each code string -- so two real
+    IPOs arrived as [{}, {}]. Live check on 2026-08-28: the server returned
+    [{}] for type="STOCK" and [] for "BOND", i.e. QMT had handed over a
+    non-empty dict and the bridge had emptied it.
+    """
+
+    def test_the_row_normaliser_destroys_a_mapping(self):
+        from bigqmt_signal_trader.redis_rpc import _normalize_detail_rows
+
+        ipos = {"730001": {"issuePrice": 16.0, "maxPurchaseNum": 12000},
+                "001234": {"issuePrice": 8.5, "maxPurchaseNum": 5000}}
+        wrecked = _normalize_detail_rows(ipos)
+
+        self.assertEqual(wrecked, [{}, {}])   # this is why it needed its own path
+
+    def test_the_mapping_path_keeps_codes_and_values(self):
+        from bigqmt_signal_trader.redis_rpc import _normalize_mapping_value
+
+        ipos = {"730001": {"name": "x", "issuePrice": 16.0, "maxPurchaseNum": 12000}}
+        kept = dict((k, _normalize_mapping_value(v)) for k, v in ipos.items())
+
+        self.assertIn("730001", kept)
+        self.assertEqual(kept["730001"]["issuePrice"], 16.0)
+        self.assertEqual(kept["730001"]["maxPurchaseNum"], 12000)
+
+    def test_nested_values_survive(self):
+        from bigqmt_signal_trader.redis_rpc import _normalize_mapping_value
+
+        value = _normalize_mapping_value({"a": [1, 2, {"b": "c"}], "d": None})
+
+        self.assertEqual(value, {"a": [1, 2, {"b": "c"}], "d": None})
+
+    def test_a_wrong_shaped_response_is_reported_not_swallowed(self):
+        """Coercing [{}, {}] to {} reads as "no IPOs today" -- the exact silence
+        that let this survive."""
+        import logging
+
+        class _Client(object):
+            account_id = "acct"
+
+            def call(self, method, params=None, **kwargs):
+                return [{}, {}]
+
+        trader = type("T", (), {"client": _Client()})()
+        with self.assertLogs("bigqmt.xtquant_compat", level=logging.WARNING) as caught:
+            data = compat.BigQmtXtTrader.query_ipo_data(trader, None)
+
+        self.assertEqual(data, {})
+        self.assertIn("too old", "".join(caught.output))
+
+    def test_an_empty_response_logs_nothing(self):
+        class _Client(object):
+            account_id = "acct"
+
+            def call(self, method, params=None, **kwargs):
+                return []
+
+        trader = type("T", (), {"client": _Client()})()
+        self.assertEqual(compat.BigQmtXtTrader.query_ipo_data(trader, None), {})

--- a/tests/bigqmt_signal_trader/test_ipo_subscribe.py
+++ b/tests/bigqmt_signal_trader/test_ipo_subscribe.py
@@ -1,0 +1,196 @@
+"""IPO subscription is something you call, not something the bridge does (#96).
+
+As submitted, PR #96 ran the subscription unconditionally from the adjust
+timer: every deployment that upgraded would place real orders the next trading
+morning without anyone asking, and it called passorder directly, so a user who
+had deliberately set rpc_allow_order_methods=False still got orders placed.
+
+It is an explicit method now, routed through order_stock -- which means it obeys
+that flag and inherits the gateway's passorder settings, including quickTrade=2
+(the submitted version hand-rolled quickTrade=1, which the API reference says is
+wrong outside a bar context and can silently place nothing).
+"""
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader import xtquant_compat as compat
+from bigqmt_signal_trader.xtquant_compat import ipo_market_of
+
+
+class MarketClassificationTest(unittest.TestCase):
+    """The predecessor ended in `return True` -- it guessed in favour of
+    ordering, on a filter meant to keep cash-freezing BJ subscriptions out."""
+
+    def test_shanghai_subscription_codes(self):
+        for code in ("730001", "732123", "780456", "787888", "789001"):
+            self.assertEqual(ipo_market_of(code), "SH", code)
+
+    def test_shenzhen_subscription_codes(self):
+        for code in ("001234", "002999", "300999"):
+            self.assertEqual(ipo_market_of(code), "SZ", code)
+
+    def test_beijing_codes_are_identified_not_guessed(self):
+        for code in ("920001", "889001", "830799", "400001"):
+            self.assertEqual(ipo_market_of(code), "BJ", code)
+
+    def test_suffixes_win_over_prefixes(self):
+        self.assertEqual(ipo_market_of("601398.SH"), "SH")
+        self.assertEqual(ipo_market_of("000001.SZ"), "SZ")
+        self.assertEqual(ipo_market_of("920001.BJ"), "BJ")
+
+    def test_unrecognised_codes_return_none(self):
+        for code in ("", None, "abc", "12", "XYZ123", "5"):
+            self.assertIsNone(ipo_market_of(code), repr(code))
+
+
+class _FakeTrader(object):
+    """Stands in for the parts of BigQmtXtTrader ipo_subscribe_all touches."""
+
+    def __init__(self, ipos, fail_on=()):
+        self._ipos = ipos
+        self._fail_on = set(fail_on)
+        self.orders = []
+
+    def query_ipo_data(self, account=None, stock_type=""):
+        return self._ipos
+
+    def ipo_subscribe(self, account, stock_code, volume, price,
+                      strategy_name="ipo", order_remark="ipo_sub"):
+        if stock_code in self._fail_on:
+            raise RuntimeError("order rpc methods are disabled")
+        self.orders.append((stock_code, volume, price, order_remark))
+        return {"order_sys_id": "sys-%s" % stock_code}
+
+
+def _run(ipos, fail_on=(), **kwargs):
+    trader = _FakeTrader(ipos, fail_on)
+    results = compat.BigQmtXtTrader.ipo_subscribe_all(trader, **kwargs)
+    return trader, results
+
+
+def _by_code(results):
+    return dict((r["stock_code"], r) for r in results)
+
+
+IPOS = {
+    "730001": {"name": "沪主板新股", "issuePrice": 16.0, "maxPurchaseNum": 12000},
+    "001234": {"name": "深主板新股", "issuePrice": 8.5, "maxPurchaseNum": 5000},
+    "920001": {"name": "北交所新股", "issuePrice": 5.0, "maxPurchaseNum": 1000},
+    "XYZ999": {"name": "认不出来", "issuePrice": 9.0, "maxPurchaseNum": 100},
+}
+
+
+class SubscribeAllTest(unittest.TestCase):
+    def test_only_the_allowed_markets_are_ordered(self):
+        trader, results = _run(IPOS)
+
+        self.assertEqual(sorted(c for c, _v, _p, _r in trader.orders),
+                         ["001234", "730001"])
+        self.assertEqual(_by_code(results)["920001"]["action"], "skipped")
+
+    def test_an_unidentifiable_code_is_skipped_not_guessed(self):
+        _trader, results = _run(IPOS)
+        entry = _by_code(results)["XYZ999"]
+
+        self.assertEqual(entry["action"], "skipped")
+        self.assertIn("not identified", entry["reason"])
+
+    def test_beijing_can_be_opted_into(self):
+        trader, _results = _run(IPOS, markets=("SH", "SZ", "BJ"))
+
+        self.assertIn("920001", [c for c, _v, _p, _r in trader.orders])
+
+    def test_dry_run_places_nothing(self):
+        trader, results = _run(IPOS, dry_run=True)
+
+        self.assertEqual(trader.orders, [])
+        self.assertEqual(_by_code(results)["730001"]["action"], "planned")
+
+    def test_price_and_volume_come_from_the_ipo_row(self):
+        trader, _results = _run(IPOS)
+        order = [o for o in trader.orders if o[0] == "730001"][0]
+
+        self.assertEqual(order[1], 12000)
+        self.assertEqual(order[2], 16.0)
+
+    def test_a_row_missing_price_or_volume_is_skipped(self):
+        _trader, results = _run({
+            "730001": {"issuePrice": 0, "maxPurchaseNum": 12000},
+            "730002": {"issuePrice": 16.0, "maxPurchaseNum": 0},
+        })
+
+        for entry in results:
+            self.assertEqual(entry["action"], "skipped")
+            self.assertIn("non-positive", entry["reason"])
+
+    def test_one_rejected_order_does_not_stop_the_rest(self):
+        """Order RPC may be disabled, or the broker may reject one code."""
+        trader, results = _run(IPOS, fail_on=("730001",))
+
+        self.assertEqual([c for c, _v, _p, _r in trader.orders], ["001234"])
+        failed = _by_code(results)["730001"]
+        self.assertEqual(failed["action"], "failed")
+        self.assertIn("disabled", failed["reason"])
+
+    def test_no_ipos_today_is_an_empty_result_not_an_error(self):
+        _trader, results = _run({})
+
+        self.assertEqual(results, [])
+
+    def test_the_remark_identifies_the_subscription(self):
+        trader, _results = _run(IPOS)
+
+        self.assertTrue(all(remark.startswith("ipo:")
+                            for _c, _v, _p, remark in trader.orders))
+
+
+class NoAutomaticSubscriptionTest(unittest.TestCase):
+    """The strategy must not place IPO orders on its own."""
+
+    def _strategy_source(self):
+        path = os.path.join(ROOT, "src", "bigqmt_signal_trader_strategy.py")
+        with open(path, encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_adjust_does_not_run_a_daily_subscription(self):
+        source = self._strategy_source()
+
+        self.assertNotIn("_maybe_run_daily_ipo", source)
+        self.assertNotIn("_run_daily_ipo", source)
+
+    def test_the_strategy_forwards_the_qmt_global_but_never_calls_it(self):
+        """get_ipo_data must stay in the forwarded-globals list -- that is how
+        the RPC handler reaches it -- but the strategy itself must not invoke
+        it, which is what drove the automatic subscription."""
+        source = self._strategy_source()
+
+        self.assertIn('"get_ipo_data",', source)      # still forwarded over RPC
+        self.assertNotIn("get_ipo_data(", source)     # never called here
+        self.assertNotIn("passorder(23, 1101", source)
+
+
+class EmptyResultShapeTest(unittest.TestCase):
+    def test_query_ipo_data_returns_a_dict_when_there_is_nothing(self):
+        """get_ipo_data answers with a dict. Returning [] on the empty path --
+        which is most days -- breaks a caller doing .items()."""
+        class _Client(object):
+            account_id = "acct"
+
+            def call(self, method, params=None, **kwargs):
+                return None
+
+        data = compat.BigQmtXtTrader.query_ipo_data(
+            type("T", (), {"client": _Client()})(), None)
+
+        self.assertEqual(data, {})
+        self.assertEqual(list(data.items()), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
跟进 #96（感谢 @ThomasAnderson01）。RPC 与客户端那半是干净的修复，已随 #96 合入；这里处理服务端自动打新的部分。

## 问题

`adjust()` 里无条件调用，**整个 diff 里没有任何开关**：

```python
_maybe_run_daily_ipo(ContextInfo)
```

后果是：**任何人升级后，第二天 09:40 就开始自动下真实委托**，没人问过他们。而且它直接调 `passorder`，**绕过了 `rpc_allow_order_methods=False`** —— 明确把远程下单关掉的用户，照样会被下单。

## 改成显式接口

删掉那 109 行，改为 `ipo_subscribe_all()`，走 `order_stock`。这不只是"面积更小"，而是让这个功能白拿到：

- **`rpc_allow_order_methods`** —— 和其他所有委托一样保持 opt-in
- **网关的 passorder 参数**：`orderType 1101`、`prType 11`、**`quickTrade 2`**
- 主线程执行、委托记账、exec 事件

`quickTrade` 这条值得单独说：被删的代码手写传了 `1`。API 参考 1.4 写得很明确——

> 在**定时器回调**、行情回调、`after_init` 中调用下单函数**必须传 2**，确保不漏单。

而 `_run_daily_ipo` 正是从 `adjust`（定时器回调）调的。`1` 的语义是"`is_last_bar()` 为 True 时才产生信号"，在定时器回调里可能根本不成立——**委托会静默不发出**。文档自己的打新示例用的也是 `2`。

## 另外两处修正

**代码过滤改为 fail-closed。** 原实现结尾是：

```python
return True  # 无法识别默认放行
```

在一个专门用来排除北交所（申购要冻结资金）的过滤器上，认不出来时倾向于**下单**。现在认不出来就跳过。

**`query_ipo_data` 空值类型不对。** 它在空时返回 `[]`，但 `get_ipo_data` 返回的是 dict——「今天没有新股」是大多数日子的常态，调用方一 `.items()` 就炸。改为返回 `{}`。

## 用法

```python
# 先看计划，不下单
for row in xt_trader.ipo_subscribe_all(acc, dry_run=True):
    print(row)

# 真申购（沪深，北交所默认排除）
results = xt_trader.ipo_subscribe_all(acc)

# 需要北交所就显式打开
results = xt_trader.ipo_subscribe_all(acc, markets=("SH", "SZ", "BJ"))
```

每只返回 `action`（`subscribed` / `planned` / `skipped` / `failed`）和 `reason`。

**每天 09:40 自动执行的行为没有在任何地方重新实现。** 现在它是个普通方法，什么时候调由使用者决定。

## 测试

新增 17 个：市场分类（含 fail-closed）、市场过滤、dry-run、单只失败不影响其余、空结果类型，以及三条断言策略侧不再自行下单。

`570 passed`，47/47 测试文件全部收集。

## 未验证

需要当天真有新股、且会下真实委托，**我没有实盘验证**。@ThomasAnderson01 在 2026-08-28 用原实现成功申购过 301689.SZ；新路径走的是本仓库既有的、每天都在用的下单通道，但打新这条具体链路仍需一次实盘确认。
