### PR TITLE
subscribe_quote 改为真订阅 (#95)

### DIFF
--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -864,6 +864,90 @@ def ipo_market_of(code):
     return None
 
 
+# Bar subscriptions poll, because there is no server-side push for K-lines: the
+# bridge only exposes ContextInfo.subscribe_whole_quote, which carries ticks.
+# Interval is a floor on how stale a bar can be, not a promise of freshness.
+DEFAULT_BAR_POLL_INTERVAL_SECONDS = 3.0
+
+
+class _BarPoller(object):
+    """Emit a K-line callback when the newest bar changes.
+
+    MiniQMT's subscribe_quote pushes each bar update. We approximate it by
+    re-reading the last bars and firing only when the newest one differs, so a
+    caller written against MiniQMT keeps working. Every callback is wrapped:
+    a raising subscriber must not kill the polling thread and silently end the
+    subscription.
+    """
+
+    def __init__(self, fetch, callback, interval_seconds, on_error=None,
+                 on_no_data=None):
+        self._fetch = fetch
+        self._callback = callback
+        self._interval = max(0.2, float(interval_seconds))
+        self._on_error = on_error
+        self._on_no_data = on_no_data
+        self._stop = threading.Event()
+        self._last_signature = None
+        self._reported_no_data = False
+        self._thread = threading.Thread(target=self._loop)
+        self._thread.daemon = True
+
+    def start(self):
+        self._thread.start()
+        return self
+
+    def stop(self):
+        self._stop.set()
+
+    @staticmethod
+    def _signature(data):
+        """Identify the newest bar cheaply, without assuming a container type."""
+        try:
+            for value in (data or {}).values():
+                if value is None:
+                    continue
+                if hasattr(value, "empty"):          # pandas DataFrame
+                    if getattr(value, "empty", True):
+                        continue
+                    return str(value.index[-1]), int(len(value))
+                if isinstance(value, (list, tuple)) and value:
+                    return repr(value[-1]), len(value)
+                if isinstance(value, dict) and value:
+                    key = sorted(value.keys())[-1]
+                    return repr(key), len(value)
+        except Exception:
+            return None
+        return None
+
+    def _loop(self):
+        while not self._stop.is_set():
+            try:
+                data = self._fetch()
+                signature = self._signature(data)
+                if signature is None:
+                    # No bars for this period. The subscription is live and will
+                    # start firing if data appears, but until then the caller
+                    # gets nothing -- which is indistinguishable from a broken
+                    # subscription unless we say so. Reported once, not per poll.
+                    if not self._reported_no_data:
+                        self._reported_no_data = True
+                        if self._on_no_data is not None:
+                            self._on_no_data()
+                elif signature != self._last_signature:
+                    self._reported_no_data = False
+                    self._last_signature = signature
+                    if self._callback is not None:
+                        self._callback(data)
+            except Exception as exc:
+                if self._on_error is not None:
+                    try:
+                        self._on_error(exc)
+                    except Exception:
+                        pass
+            self._stop.wait(self._interval)
+
+
 class BigQmtXtData:
     def __init__(self, client):
         self.client = client
@@ -871,6 +955,8 @@ class BigQmtXtData:
         self._cache_obj = None
         self._quote_session = None          # lazily built WholeQuoteClientSession
         self._quote_session_factory = None  # test hook: returns a session-like object
+        self._bar_pollers = {}              # seq -> _BarPoller, for K-line periods
+        self._bar_poller_lock = threading.Lock()
 
     def _next_seq(self):
         self._subscribe_seq += 1
@@ -1220,34 +1306,82 @@ class BigQmtXtData:
         return out
 
     def subscribe_quote(self, stock_code, period="1d", start_time="", end_time="", count=0, callback=None):
-        seq = self._next_seq()
+        """Subscribe to one instrument, MiniQMT-style: the callback keeps firing.
+
+        This used to invoke the callback exactly once and never again -- a
+        one-shot fetch wearing a subscription's name, which is worse than not
+        having it, because it looks like it works (issue #95).
+
+        Ticks ride the whole-quote push channel; a single code is just a
+        one-element code list. K-lines have no server-side push -- the bridge
+        only exposes ContextInfo.subscribe_whole_quote, which carries ticks --
+        so they are polled and emitted when the newest bar changes.
+        """
         payload = {
-            "seq": seq,
             "stock_code": stock_code,
             "period": period,
             "start_time": start_time,
             "end_time": end_time,
             "count": count,
         }
-        self.client.save_quote_subscription(seq, payload, active=True)
-        self.client.publish_event("subscribe_quote", payload)
-        if callback is not None:
-            try:
-                if str(period).lower() in ("tick", "full_tick"):
+
+        if str(period).lower() in ("tick", "full_tick"):
+            session = self._whole_quote_session()
+            session.start()
+            seq = session.subscribe_whole_quote([stock_code], callback=callback)
+            # The whole-quote callback is incremental; prime it with a snapshot
+            # so a subscriber is not left with nothing until the first change.
+            if callback is not None:
+                try:
                     callback(self.get_full_tick([stock_code]))
-                else:
-                    callback(
-                        self.get_market_data_ex(
-                            stock_list=[stock_code],
-                            period=period,
-                            start_time=start_time,
-                            end_time=end_time,
-                            count=count,
-                        )
-                    )
-            except Exception:
-                pass
+                except Exception:
+                    pass
+            self._record_subscription(seq, payload)
+            return seq
+
+        seq = self._next_seq()
+
+        def fetch():
+            return self.get_market_data_ex(
+                stock_list=[stock_code], period=period,
+                start_time=start_time, end_time=end_time, count=count or 1)
+
+        poller = _BarPoller(
+            fetch, callback, self._bar_poll_interval_seconds(),
+            on_error=lambda exc: log.debug(
+                "subscribe_quote poll failed code=%s period=%s: %s",
+                stock_code, period, exc),
+            on_no_data=lambda: log.warning(
+                "subscribe_quote: no %s bars for %s -- the subscription is live "
+                "but stays silent until this terminal has data for that period. "
+                "Check the period is downloaded (get_market_data_ex returns an "
+                "empty frame for it).", period, stock_code))
+        with self._bar_poller_lock:
+            self._bar_pollers[seq] = poller
+        poller.start()
+        self._record_subscription(seq, payload)
         return seq
+
+    def _bar_poll_interval_seconds(self):
+        config = dict(getattr(self.client, "full_tick_cache_config", {}) or {})
+        value = (config.get("bar_poll_interval_seconds")
+                 or os.environ.get("BIGQMT_BAR_POLL_INTERVAL_SECONDS"))
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return DEFAULT_BAR_POLL_INTERVAL_SECONDS
+
+    def _record_subscription(self, seq, payload, active=True):
+        """Bookkeeping only -- nothing on the server consumes it, and it needs a
+        Redis client, which a zmq deployment does not have. Never let it break
+        an otherwise working subscription."""
+        try:
+            self.client.save_quote_subscription(seq, dict(payload, seq=seq), active=active)
+            self.client.publish_event(
+                "subscribe_quote" if active else "unsubscribe_quote",
+                dict(payload, seq=seq))
+        except Exception:
+            pass
 
     def subscribe_quote2(self, stock_code, period="1d", start_time="", end_time="", count=0, dividend_type=None, callback=None):
         return self.subscribe_quote(
@@ -1310,16 +1444,35 @@ class BigQmtXtData:
         return sub_id
 
     def unsubscribe_quote(self, seq):
-        # subscribe_whole_quote handles are owned by the push session; single-stock
-        # subscribe_quote seqs still retire through the legacy redis-event path.
+        # Three kinds of handle now: whole-quote / tick subscriptions owned by
+        # the push session, K-line pollers owned here, and legacy seqs that only
+        # ever existed as redis bookkeeping.
+        with self._bar_poller_lock:
+            poller = self._bar_pollers.pop(seq, None)
+        if poller is not None:
+            poller.stop()
+            self._record_subscription(seq, {}, active=False)
+            return 0
+
         session = self._quote_session
         if session is not None and session.has_subscription(seq):
             session.unsubscribe_quote(seq)
-        else:
-            payload = {"seq": seq}
-            self.client.save_quote_subscription(seq, payload, active=False)
-            self.client.publish_event("unsubscribe_quote", payload)
+            self._record_subscription(seq, {}, active=False)
+            return 0
+
+        self._record_subscription(seq, {}, active=False)
         return 0
+
+    def stop_all_subscriptions(self):
+        """Stop every K-line poller this object owns. Daemon threads die with
+        the process anyway; this is for tests and for callers that recycle a
+        client without exiting."""
+        with self._bar_poller_lock:
+            pollers = list(self._bar_pollers.values())
+            self._bar_pollers.clear()
+        for poller in pollers:
+            poller.stop()
+        return len(pollers)
 
     def run(self):
         while True:

--- a/tests/bigqmt_signal_trader/test_subscribe_quote.py
+++ b/tests/bigqmt_signal_trader/test_subscribe_quote.py
@@ -1,0 +1,365 @@
+"""subscribe_quote has to keep firing (issue #95).
+
+It used to invoke the callback exactly once and never again -- a one-shot fetch
+wearing a subscription's name. That is worse than not implementing it: a caller
+written against MiniQMT sees data arrive and concludes it works, then waits
+forever for the second update.
+
+Ticks now ride the whole-quote push channel (a single code is a one-element
+code list). K-lines have no server-side push -- the bridge only exposes
+ContextInfo.subscribe_whole_quote, which carries ticks -- so they are polled
+and emitted when the newest bar changes.
+"""
+
+import os
+import sys
+import threading
+import time
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader import xtquant_compat as compat
+
+
+class FakeSession(object):
+    def __init__(self):
+        self.active = set()
+        self.subscribed = []
+        self.started = False
+
+    def start(self):
+        self.started = True
+
+    def subscribe_whole_quote(self, code_list, callback=None):
+        self.subscribed.append((list(code_list), callback))
+        sub_id = 700 + len(self.subscribed)
+        self.active.add(sub_id)
+        return sub_id
+
+    def unsubscribe_quote(self, sub_id):
+        self.active.discard(sub_id)
+        return 0
+
+    def has_subscription(self, sub_id):
+        return sub_id in self.active
+
+    def push(self, payload):
+        """Deliver an update the way the real channel would."""
+        for _codes, callback in self.subscribed:
+            if callback is not None:
+                callback(payload)
+
+
+class FakeClient(object):
+    def __init__(self, bars=None):
+        self.account_id = "acct"
+        self.local_cache_config = {}
+        self.full_tick_cache_config = {"bar_poll_interval_seconds": 0.02}
+        self.transport_name = "redis"
+        self.calls = []
+        self._bars = bars if bars is not None else [[{"time": 1, "close": 1.0}]]
+        self._index = 0
+
+    def call(self, method, params=None, **kwargs):
+        self.calls.append(method)
+        if method == "get_full_tick":
+            return {c: {"lastPrice": 1.0} for c in (params or {}).get("codes") or []}
+        if method == "get_market_data_ex":
+            bars = self._bars[min(self._index, len(self._bars) - 1)]
+            self._index += 1
+            return {(params or {}).get("stock_list", ["x"])[0]: bars}
+        return {}
+
+    def save_quote_subscription(self, seq, payload, active=True):
+        pass
+
+    def publish_event(self, event_type, payload, **kwargs):
+        pass
+
+    def _redis(self):
+        raise AssertionError("redis must not be needed here")
+
+
+def _xtdata(client=None, session=None):
+    data = compat.BigQmtXtData(client or FakeClient())
+    if session is not None:
+        data._quote_session_factory = lambda: session
+    return data
+
+
+class TickSubscriptionTest(unittest.TestCase):
+    def test_tick_period_uses_the_push_session(self):
+        session = FakeSession()
+        data = _xtdata(session=session)
+
+        data.subscribe_quote("600000.SH", period="tick")
+
+        self.assertTrue(session.started)
+        self.assertEqual(session.subscribed[0][0], ["600000.SH"])
+
+    def test_the_callback_fires_more_than_once(self):
+        """The whole point. Before, it fired once and stopped."""
+        session = FakeSession()
+        data = _xtdata(session=session)
+        seen = []
+
+        data.subscribe_quote("600000.SH", period="tick", callback=seen.append)
+        session.push({"600000.SH": {"lastPrice": 10.1}})
+        session.push({"600000.SH": {"lastPrice": 10.2}})
+
+        self.assertGreaterEqual(len(seen), 3)  # 1 priming snapshot + 2 pushes
+
+    def test_the_subscriber_is_primed_with_a_snapshot(self):
+        """Whole-quote pushes only changed symbols, so a fresh subscriber would
+        otherwise see nothing until the instrument next ticks."""
+        session = FakeSession()
+        data = _xtdata(session=session)
+        seen = []
+
+        data.subscribe_quote("600000.SH", period="tick", callback=seen.append)
+
+        self.assertEqual(len(seen), 1)
+        self.assertIn("600000.SH", seen[0])
+
+    def test_unsubscribe_releases_the_session_handle(self):
+        session = FakeSession()
+        data = _xtdata(session=session)
+
+        seq = data.subscribe_quote("600000.SH", period="tick")
+        data.unsubscribe_quote(seq)
+
+        self.assertNotIn(seq, session.active)
+
+    def test_full_tick_is_treated_as_a_tick_period(self):
+        session = FakeSession()
+        data = _xtdata(session=session)
+
+        data.subscribe_quote("600000.SH", period="full_tick")
+
+        self.assertEqual(len(session.subscribed), 1)
+
+
+class BarSubscriptionTest(unittest.TestCase):
+    def _wait(self, predicate, timeout=3.0):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if predicate():
+                return True
+            time.sleep(0.01)
+        return False
+
+    def test_a_new_bar_reaches_the_callback(self):
+        client = FakeClient(bars=[
+            [{"time": 1, "close": 1.0}],
+            [{"time": 1, "close": 1.0}, {"time": 2, "close": 1.1}],
+        ])
+        data = _xtdata(client)
+        seen = []
+
+        seq = data.subscribe_quote("600000.SH", period="1m", callback=seen.append)
+        try:
+            self.assertTrue(self._wait(lambda: len(seen) >= 2),
+                            "second bar never delivered: %r" % (seen,))
+        finally:
+            data.unsubscribe_quote(seq)
+
+    def test_an_unchanged_bar_is_not_re_emitted(self):
+        client = FakeClient(bars=[[{"time": 1, "close": 1.0}]])
+        data = _xtdata(client)
+        seen = []
+
+        seq = data.subscribe_quote("600000.SH", period="1m", callback=seen.append)
+        try:
+            time.sleep(0.3)   # several poll intervals
+            self.assertEqual(len(seen), 1, "re-emitted an unchanged bar")
+        finally:
+            data.unsubscribe_quote(seq)
+
+    def test_unsubscribe_stops_the_polling_thread(self):
+        client = FakeClient()
+        data = _xtdata(client)
+
+        seq = data.subscribe_quote("600000.SH", period="1m", callback=lambda d: None)
+        data.unsubscribe_quote(seq)
+        before = len(client.calls)
+        time.sleep(0.3)
+
+        self.assertEqual(len(client.calls), before, "poller kept running")
+
+    def test_a_raising_callback_does_not_end_the_subscription(self):
+        """A subscriber's bug must not silently unsubscribe them."""
+        client = FakeClient(bars=[
+            [{"time": 1}], [{"time": 2}], [{"time": 3}],
+        ])
+        data = _xtdata(client)
+        calls = []
+
+        def boom(_data):
+            calls.append(1)
+            raise RuntimeError("subscriber bug")
+
+        seq = data.subscribe_quote("600000.SH", period="1m", callback=boom)
+        try:
+            self.assertTrue(self._wait(lambda: len(calls) >= 2),
+                            "polling stopped after the first raise")
+        finally:
+            data.unsubscribe_quote(seq)
+
+    def test_a_failing_fetch_does_not_end_the_subscription(self):
+        class _Flaky(FakeClient):
+            def call(self, method, params=None, **kwargs):
+                self.calls.append(method)
+                if method == "get_market_data_ex" and len(self.calls) < 3:
+                    raise RuntimeError("transport hiccup")
+                return FakeClient.call(self, method, params, **kwargs)
+
+        client = _Flaky(bars=[[{"time": 9, "close": 2.0}]])
+        data = _xtdata(client)
+        seen = []
+
+        seq = data.subscribe_quote("600000.SH", period="1d", callback=seen.append)
+        try:
+            self.assertTrue(self._wait(lambda: len(seen) >= 1),
+                            "never recovered from a transient fetch failure")
+        finally:
+            data.unsubscribe_quote(seq)
+
+    def test_poll_interval_comes_from_config(self):
+        client = FakeClient()
+        client.full_tick_cache_config = {"bar_poll_interval_seconds": 7.5}
+
+        self.assertEqual(_xtdata(client)._bar_poll_interval_seconds(), 7.5)
+
+    def test_poll_interval_falls_back_to_the_default(self):
+        client = FakeClient()
+        client.full_tick_cache_config = {}
+        saved = os.environ.pop("BIGQMT_BAR_POLL_INTERVAL_SECONDS", None)
+        try:
+            self.assertEqual(_xtdata(client)._bar_poll_interval_seconds(),
+                             compat.DEFAULT_BAR_POLL_INTERVAL_SECONDS)
+        finally:
+            if saved is not None:
+                os.environ["BIGQMT_BAR_POLL_INTERVAL_SECONDS"] = saved
+
+    def test_pollers_run_as_daemon_threads(self):
+        """They must never hold the process open."""
+        client = FakeClient()
+        data = _xtdata(client)
+        before = set(threading.enumerate())
+
+        seq = data.subscribe_quote("600000.SH", period="1m", callback=lambda d: None)
+        try:
+            new = [t for t in threading.enumerate() if t not in before]
+            self.assertTrue(new, "no polling thread started")
+            self.assertTrue(all(t.daemon for t in new))
+        finally:
+            data.unsubscribe_quote(seq)
+
+    def test_stop_all_subscriptions_clears_every_poller(self):
+        data = _xtdata(FakeClient())
+        for _ in range(3):
+            data.subscribe_quote("600000.SH", period="1m", callback=lambda d: None)
+
+        self.assertEqual(data.stop_all_subscriptions(), 3)
+        self.assertEqual(data.stop_all_subscriptions(), 0)
+
+
+class BookkeepingTest(unittest.TestCase):
+    def test_a_redis_failure_does_not_break_the_subscription(self):
+        """Bookkeeping needs a Redis client; a zmq deployment has none, and
+        nothing on the server consumes these events anyway."""
+        class _Hostile(FakeClient):
+            def save_quote_subscription(self, seq, payload, active=True):
+                raise RuntimeError("no redis here")
+
+            def publish_event(self, event_type, payload, **kwargs):
+                raise RuntimeError("no redis here")
+
+        session = FakeSession()
+        data = _xtdata(_Hostile(), session)
+
+        seq = data.subscribe_quote("600000.SH", period="tick")
+
+        self.assertIn(seq, session.active)
+        self.assertEqual(data.unsubscribe_quote(seq), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class NoDataDiagnosticTest(unittest.TestCase):
+    """A period this terminal has no bars for produces a live subscription that
+    never fires. Found live: 1m and 5m return empty frames here while 1d and
+    tick return data, so a caller subscribing to 1m sees exactly what a broken
+    subscription looks like.
+    """
+
+    def _wait(self, predicate, timeout=3.0):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if predicate():
+                return True
+            time.sleep(0.01)
+        return False
+
+    def test_an_empty_period_is_reported(self):
+        client = FakeClient(bars=[[]])
+        data = _xtdata(client)
+        import logging
+
+        with self.assertLogs("bigqmt.xtquant_compat", level=logging.WARNING) as caught:
+            seq = data.subscribe_quote("600000.SH", period="1m",
+                                       callback=lambda d: None)
+            try:
+                self.assertTrue(self._wait(lambda: bool(caught.output)))
+            finally:
+                data.unsubscribe_quote(seq)
+
+        message = "".join(caught.output)
+        self.assertIn("no 1m bars", message)
+        self.assertIn("600000.SH", message)
+
+    def test_it_is_reported_once_not_every_poll(self):
+        poller = compat._BarPoller(lambda: {}, None, 0.02,
+                                   on_no_data=lambda: reports.append(1))
+        reports = []
+        poller.start()
+        try:
+            time.sleep(0.3)   # many intervals
+        finally:
+            poller.stop()
+
+        self.assertEqual(len(reports), 1, "reported %d times" % len(reports))
+
+    def test_data_appearing_later_still_fires_the_callback(self):
+        """The subscription must stay live through the quiet period."""
+        client = FakeClient(bars=[[], [], [{"time": 1, "close": 1.0}]])
+        data = _xtdata(client)
+        seen = []
+
+        seq = data.subscribe_quote("600000.SH", period="1m", callback=seen.append)
+        try:
+            self.assertTrue(self._wait(lambda: len(seen) >= 1),
+                            "never recovered once data appeared")
+        finally:
+            data.unsubscribe_quote(seq)
+
+    def test_a_period_with_data_reports_nothing(self):
+        client = FakeClient(bars=[[{"time": 1, "close": 1.0}]])
+        data = _xtdata(client)
+        reports = []
+
+        poller = compat._BarPoller(
+            lambda: client.call("get_market_data_ex", {"stock_list": ["x"]}),
+            None, 0.02, on_no_data=lambda: reports.append(1))
+        poller.start()
+        try:
+            time.sleep(0.2)
+        finally:
+            poller.stop()
+
+        self.assertEqual(reports, [])

--- a/tests/bigqmt_signal_trader/test_xtquant_compat.py
+++ b/tests/bigqmt_signal_trader/test_xtquant_compat.py
@@ -493,11 +493,39 @@ class XtquantCompatTest(unittest.TestCase):
     def test_quote_subscribe_and_unsubscribe_write_redis_events(self):
         xtdata = self._xtdata()
 
+        # Tick subscriptions ride the whole-quote push session now (#95), so
+        # stand one in; the bookkeeping this test covers is unchanged.
+        class _Session(object):
+            def __init__(self):
+                self.active = set()
+                self.subscribed = []
+
+            def start(self):
+                pass
+
+            def subscribe_whole_quote(self, code_list, callback=None):
+                self.subscribed.append(list(code_list))
+                sub_id = 900 + len(self.subscribed)
+                self.active.add(sub_id)
+                return sub_id
+
+            def unsubscribe_quote(self, sub_id):
+                self.active.discard(sub_id)
+                return 0
+
+            def has_subscription(self, sub_id):
+                return sub_id in self.active
+
+        session = _Session()
+        xtdata._quote_session_factory = lambda: session
+
         seq = xtdata.subscribe_quote("600000.SH", period="tick")
         result = xtdata.unsubscribe_quote(seq)
 
         key = "bigqmt:quote_subscriptions:acct"
         self.assertEqual(result, 0)
+        self.assertEqual(session.subscribed, [["600000.SH"]])
+        self.assertNotIn(seq, session.active)
         self.assertNotIn(str(seq), xtdata.client.redis.hashes.get(key, {}))
         self.assertIn((key, str(seq)), xtdata.client.redis.deleted)
         self.assertEqual(xtdata.client.redis.events[0][0], "subscribe_quote")


### PR DESCRIPTION
@frank0532 在 #95 问「是不是暂时还不能订阅实时K线」。答案是：`subscribe_quote` 存在，但**不是订阅**——

```python
if callback is not None:
    callback(self.get_full_tick([stock_code]))   # 只触发这一次
```

回调只被调用一次，之后没有任何推送。这比没实现更容易误导，因为它看起来能用：数据到了，然后永远等不到第二次。

## 改动

- **tick 周期** → 走已有的全推行情通道（单个代码就是一元 code_list），**复用既有推送路径，不新增通道**
- **K 线周期** → 服务端没有 bar 推送机制（桥只暴露了 `ContextInfo.subscribe_whole_quote`，那是 tick），改为轮询，最新 bar 变化时回调
- `unsubscribe_quote` 能停掉轮询线程

## 实盘验证

```
tick, 20s      8 次回调，间隔 ~3s        （原来：1 次，永远）
退订           之后 6s 内新增 0 次
1d 轮询        首帧送达，退订后轮询器归零
```

## 那次实盘顺带暴露的问题，也修了

本终端 `1m` / `5m` 返回**空 DataFrame**，而 `1d` / `tick` 有数据：

```
1d   -> 4 行   signature=('20260827', 4)
1m   -> 0 行   signature=None
5m   -> 0 行   signature=None
tick -> 5 行   signature=('20260828134422', 5)
```

于是订阅 `1m` 会得到一个**活着、正确、且永远沉默**的订阅——和坏掉的订阅长得一模一样。这正是我们这几天一路在修的那类沉默。

现在会说明一次（不刷屏），有数据后自动恢复安静：

```
[WARNING] subscribe_quote: no 1m bars for 600000.SH -- the subscription is live
but stays silent until this terminal has data for that period. Check the period
is downloaded (get_market_data_ex returns an empty frame for it).
```

实盘验证：`1m` 打出告警，`1d` 不打。

## 测试

新增 19 个：tick 走 push session、回调触发多次、首帧快照、退订释放句柄；轮询的新 bar 送达 / 不重发未变 bar / 退订停线程 / 回调抛异常不终止订阅 / 取数失败能恢复 / daemon 线程；以及无数据诊断只报一次、有数据不报。

`594 passed`，48/48 测试文件全部收集。

## 未验证 —— 这条要说清楚

**推送通道不可达的部署没验过。** tick 现在依赖该通道，而原来的一次性路径不依赖——这类部署会从"至少拿到一次快照"变成"完全沉默"。用的是 `subscribe_whole_quote` 已经在跑的同一条通道，但这是个行为变更，值得知道。
