### PR TITLE
全市场快照默认只取股票 (#104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,56 @@ xtdata.unsubscribe_quote(seq)
 
 **验证**：实盘交易日验证 1/20/50/100 只标的，3s 推送节奏稳定，零丢失零乱序；多客户端共享/退订隔离/同客户端多 sub_id 全过；服务端重启恢复（42s 中断后验证两次）。详见 [docs/SUBSCRIBE_WHOLE_QUOTE_PUSH.md](docs/SUBSCRIBE_WHOLE_QUOTE_PUSH.md) 和 [docs/SUBSCRIBE_WHOLE_QUOTE_LIVE_VERIFICATION.md](docs/SUBSCRIBE_WHOLE_QUOTE_LIVE_VERIFICATION.md)。
 
+### 全市场快照的品种过滤（`types`）
+
+**市场令牌返回的是交易所挂牌的全部标的，股票只占一小部分。** 实测上交所 `"SH"` 共 **26744** 个标的，其中股票 **2315 只（8.7%）**，其余是债券（36%）、回购等。QMT 的耗时严格线性、约 **0.29ms/只**，所以全量要 7.4s，只取股票 0.9s。
+
+从 0.2.15 起 **默认只取股票**：
+
+```python
+xtdata.get_full_tick(["SH"])                      # 2315 只   1.08s   ← 新默认
+xtdata.get_full_tick(["SH"], types=["all"])       # 26744 只  7.39s   ← 旧行为
+xtdata.get_full_tick(["SH", "SZ"])                # 5216 只   1.66s
+xtdata.get_full_tick(["SH"], types=["stock","etf"])
+xtdata.get_full_tick(["600000.SH"])               # 显式代码不受影响
+```
+
+> **这是破坏性变更。** 如果你的代码依赖 `get_full_tick(["SH"])` 返回债券 / 回购 / ETF，请显式传 `types=["all"]`。收窄发生时会打印一次提示，便于发现：
+>
+> ```
+> [bigqmt_market] SH narrowed to 2315 stock; pass types=['all'] for every
+> instrument the exchange lists
+> ```
+
+| `types` | 板块 | 约数 |
+|---|---|---|
+| `stock`（默认） | 上证A股 / 深证A股 / 京市A股 | 2315 / 2901 / 339 |
+| `etf` | 沪深ETF | 1696 |
+| `fund` | 沪深基金 | 2249 |
+| `index` | 沪深指数 | 609 |
+| `convertible` | 沪深转债 | 320 |
+| `all` | 不收窄，返回交易所全部标的 | 26744（SH） |
+
+**关键在于请求时就收窄，而不是拿回来再过滤**——事后过滤仍要付 QMT 对每个多余标的的 0.29ms。板块清单由 FormulaServer 直连提供（实测 13ms）并按运行缓存，相对省下的时间可以忽略。
+
+**收窄失败时退回全量，不返回空**：板块查不到、类型不认识、该市场没有对应板块（如 `HK`），都保留市场令牌照旧请求。丢行情比慢更糟。
+
+**显式传超大代码列表会超时**：26744 个代码显式传入会打爆单次 RPC 超时，而市场令牌可以。要全量请用令牌 + `types=["all"]`。
+
+### `get_market_data_ex` 的 `field_list` 与速度
+
+不传 `field_list` 表示"要全部字段"，返回 11 列，**只能走 RPC**：
+
+```
+field_list=[]                      0.97s   11 列（含 preClose / suspendFlag 等）
+field_list=[open,high,low,close,volume,amount]
+                                   0.03s    6 列   ← FormulaServer 直连，约 30 倍
+```
+
+**这不是可以自动优化掉的差距。** FormulaServer 只供那 6 列，其余 4 列返回 `NaN`，而 RPC 有真实值（实测 `preClose` 9.07 / 7.82 / 11.59，直连全部为 `nan`）。把默认路由到直连会静默把真实价格换成 `NaN`，所以默认保持走 RPC。
+
+**只要 OHLCV 就显式写出来**，那 30 倍就到手了。首次不传 `field_list` 时会在 `bigqmt.log` 记一条说明。
+
 ### 可插拔传输层
 
 | 传输 | 同机 p50 | 跨机 | 适用场景 |

--- a/src/bigqmt_signal_trader/adapters/market_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/market_bigqmt.py
@@ -34,6 +34,37 @@ from ..code_utils import normalize_stock_code
 
 MARKET_CODES = {"SH", "SZ", "BJ", "HK"}
 
+# A market token asks QMT for every instrument the exchange lists, and stocks
+# are a small minority: "SH" answers with 26744 instruments of which 2315 (8.7%)
+# are stocks -- the rest is bonds, repos and the like. At a measured ~0.29ms per
+# instrument that is 7.5s for the whole market against 0.88s for the stocks
+# alone, and the cost is strictly linear in instrument count (issue #104).
+#
+# So narrow the REQUEST, not the response: resolve the token to a sector listing
+# and ask QMT only for those codes. Filtering afterwards would still pay for
+# every instrument. The sector lookup is FormulaServer-served (~10ms measured),
+# so it costs nothing next to what it saves.
+#
+# Sector names are QMT's own, verified against a live terminal. Note "北证A股"
+# is NOT one of them -- the Beijing board is "京市A股".
+STOCK_SECTOR_BY_MARKET = {
+    "SH": "上证A股",
+    "SZ": "深证A股",
+    "BJ": "京市A股",
+}
+# Cross-market sectors; results are filtered back to the requested exchange.
+# Not narrowing at all: "all" keeps the market token, i.e. the pre-0.2.15
+# behaviour of returning every instrument the exchange lists.
+DEFAULT_TICK_TYPES = ("stock",)
+
+SECTOR_BY_TYPE = {
+    "stock": "沪深京A股",
+    "fund": "沪深基金",
+    "etf": "沪深ETF",
+    "index": "沪深指数",
+    "convertible": "沪深转债",
+}
+
 
 def normalize_market_or_stock_code(code):
     text = str(code or "").strip().upper()
@@ -423,7 +454,68 @@ class BigQmtMarketDataProvider:
             ),
         ]
 
-    def get_ticks(self, codes):
+    def _sector_codes(self, sector):
+        """Cached sector listing. Membership does not change intraday and the
+        lookup is FormulaServer-served, so once per sector per run is enough."""
+        cache = getattr(self, "_sector_cache", None)
+        if cache is None:
+            cache = self._sector_cache = {}
+        if sector not in cache:
+            try:
+                cache[sector] = list(self.get_stock_list_in_sector(sector) or [])
+            except Exception:
+                cache[sector] = []
+        return cache[sector]
+
+    def _expand_market_token(self, market, types):
+        """Codes of the requested types on one exchange, or None to give up.
+
+        None means "could not narrow", and the caller keeps the market token: a
+        slow answer beats an empty one, the same rule the key mapping below
+        follows.
+        """
+        collected = []
+        for kind in types:
+            kind = str(kind or "").strip().lower()
+            sector = None
+            if kind == "stock":
+                sector = STOCK_SECTOR_BY_MARKET.get(market)
+            if sector is None:
+                sector = SECTOR_BY_TYPE.get(kind)
+            if sector is None:
+                return None          # unknown type: do not silently drop it
+            listing = self._sector_codes(sector)
+            if not listing:
+                return None          # sector unavailable on this terminal
+            suffix = "." + market
+            collected.extend(c for c in listing if str(c).upper().endswith(suffix))
+        seen, unique = set(), []
+        for code in collected:
+            if code not in seen:
+                seen.add(code)
+                unique.append(code)
+        return unique or None
+
+    def _notice_narrowed(self, market, kept, total_hint):
+        """Say once per process that a market token was narrowed.
+
+        The default changed from "everything the exchange lists" to stocks, so
+        a caller who wanted bonds or repos would otherwise just see fewer rows
+        and no reason why.
+        """
+        seen = getattr(self, "_narrow_notified", None)
+        if seen is None:
+            seen = self._narrow_notified = set()
+        if market in seen:
+            return
+        seen.add(market)
+        try:
+            print("[bigqmt_market] %s narrowed to %d %s; pass types=['all'] for "
+                  "every instrument the exchange lists" % (market, kept, total_hint))
+        except Exception:
+            pass
+
+    def get_ticks(self, codes, types=None):
         """Snapshot quotes, keyed the way the CALLER spelled each code.
 
         Codes go to QMT upper-cased, but the futures exchanges use lower-case
@@ -443,6 +535,21 @@ class BigQmtMarketDataProvider:
         """
         requested = list(codes or [])
         normalized_codes = [normalize_market_or_stock_code(code) for code in requested]
+        # Default to stocks. A market token lists every instrument the exchange
+        # carries and stocks are 8.7% of it, so the old default made everyone pay
+        # 7.5s for a 0.9s answer. types=["all"] restores the full listing.
+        wanted = list(types) if types else list(DEFAULT_TICK_TYPES)
+        if not any(str(kind).strip().lower() == "all" for kind in wanted):
+            expanded = []
+            for code in normalized_codes:
+                narrowed = (self._expand_market_token(code, wanted)
+                            if code in MARKET_CODES else None)
+                if narrowed is None:
+                    expanded.append(code)     # not a token, or could not narrow
+                else:
+                    expanded.extend(narrowed)
+                    self._notice_narrowed(code, len(narrowed), "/".join(wanted))
+            normalized_codes = expanded
         data = self.context_info.get_full_tick(normalized_codes) or {}
         if not isinstance(data, dict):
             return data or {}

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -586,7 +586,14 @@ class BigQmtRpcHandlers:
             codes = [code] if code else []
         if not codes:
             raise ValueError("codes or code is required")
-        return self.market_data.get_ticks(codes)
+        types = params.get("types")
+        if isinstance(types, str):
+            types = [types]
+        if not types:
+            # Pass one argument when nothing was asked for, so a market-data
+            # provider whose get_ticks takes only `codes` keeps working.
+            return self.market_data.get_ticks(codes)
+        return self.market_data.get_ticks(codes, types=list(types))
 
     def _handle_get_instrument(self, params):
         code = params.get("code")

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -1343,9 +1343,14 @@ class BigQmtXtData:
         sub_id = session.subscribe_whole_quote(code_list, callback=callback)
         # The big-QMT whole-quote callback is incremental (changed symbols only),
         # so prime the callback once with a full get_full_tick snapshot.
+        #
+        # types=["all"] deliberately: the push side is ContextInfo's own
+        # subscribe_whole_quote, which is not narrowed, so a narrowed snapshot
+        # would hand the subscriber 2315 stocks and then start pushing all
+        # 26744 instruments. The primer has to cover what the push covers.
         if callback is not None:
             try:
-                callback(self.get_full_tick(code_list))
+                callback(self.get_full_tick(code_list, types=["all"]))
             except Exception:
                 pass
         return sub_id

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -864,6 +864,39 @@ def ipo_market_of(code):
     return None
 
 
+def _full_tick_params(codes, types=None):
+    """RPC params for get_full_tick. `types` narrows a whole-market token to one
+    instrument kind at REQUEST time -- filtering the reply would still pay QMT's
+    per-instrument cost for everything the exchange lists (issue #104)."""
+    params = {"codes": codes}
+    if types:
+        params["types"] = [types] if isinstance(types, str) else list(types)
+    return params
+
+
+_FIELD_LIST_NOTICE = {"shown": False}
+DIRECT_PATH_FIELDS = ("open", "high", "low", "close", "volume", "amount")
+
+
+def _notice_field_list_cost(field_list):
+    """Say once that naming fields is what enables the fast path.
+
+    Not a warning about a mistake: an empty field_list correctly returns all 11
+    columns and only RPC can do that. But the 30x is invisible unless someone
+    tells you it exists (issue #104)."""
+    if field_list or _FIELD_LIST_NOTICE["shown"]:
+        return
+    _FIELD_LIST_NOTICE["shown"] = True
+    try:
+        log.info(
+            "get_market_data_ex with an empty field_list returns all 11 columns "
+            "and must go over RPC. If the six OHLCV columns %s are enough, pass "
+            "them as field_list -- that path is served by FormulaServer, ~30x "
+            "faster (0.03s vs 0.97s measured).", ", ".join(DIRECT_PATH_FIELDS))
+    except Exception:
+        pass
+
+
 class BigQmtXtData:
     def __init__(self, client):
         self.client = client
@@ -887,7 +920,7 @@ class BigQmtXtData:
     def _call(self, method, **params):
         return self.client.call(method, params)
 
-    def get_full_tick(self, code_list, timeout_seconds=None):
+    def get_full_tick(self, code_list, timeout_seconds=None, types=None):
         """Fetch full tick data for a list of codes.
 
         Args:
@@ -927,14 +960,14 @@ class BigQmtXtData:
             # Symbol-list miss (cold start / expired snapshot): fall back to a live
             # RPC so the first call is ~ms instead of a hard wait_seconds stall.
             rpc_timeout = timeout_seconds if timeout_seconds is not None else None
-            return self.client.call("get_full_tick", {"codes": codes}, timeout_seconds=rpc_timeout) or {}
+            return self.client.call("get_full_tick", _full_tick_params(codes, types), timeout_seconds=rpc_timeout) or {}
         upper_codes = {str(code).strip().upper() for code in codes}
         # Caller-provided timeout takes priority; otherwise auto-detect whole-market.
         if timeout_seconds is not None:
             rpc_timeout = timeout_seconds
         else:
             rpc_timeout = 30 if upper_codes & {"SH", "SZ", "BJ", "HK"} else None
-        return self.client.call("get_full_tick", {"codes": codes}, timeout_seconds=rpc_timeout) or {}
+        return self.client.call("get_full_tick", _full_tick_params(codes, types), timeout_seconds=rpc_timeout) or {}
 
     def get_instrument_detail(self, stock_code):
         return self.client.call("get_instrument_detail", {"code": stock_code}) or {}
@@ -1017,7 +1050,15 @@ class BigQmtXtData:
         its own codes -- the rest are returned.
 
         ``chunk_size=0`` restores the old single-request behaviour.
+
+        An empty ``field_list`` means "every field", which only the RPC path can
+        answer -- FormulaServer serves the six OHLCV columns and returns NaN for
+        settelementPrice / openInterest / preClose / suspendFlag, where RPC has
+        real values (preClose 9.07 against nan, measured). So the default stays
+        on RPC rather than quietly handing back NaN; naming the six fields you
+        actually want is what unlocks the ~30x direct path (issue #104).
         """
+        _notice_field_list_cost(field_list)
         codes = list(stock_list or [])
         base = dict(
             field_list=list(field_list or []),

--- a/tests/bigqmt_signal_trader/test_full_tick_types.py
+++ b/tests/bigqmt_signal_trader/test_full_tick_types.py
@@ -251,3 +251,64 @@ class ProviderCompatibilityTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class WholeQuotePrimeScopeTest(unittest.TestCase):
+    """The priming snapshot must cover what the push will cover.
+
+    subscribe_whole_quote's push side is ContextInfo's own subscription, which
+    this change does not narrow. If the primer narrowed, a subscriber to ["SH"]
+    would get 2315 stocks once and then 26744 instruments on every push.
+    """
+
+    def _xtdata(self):
+        from bigqmt_signal_trader import xtquant_compat as compat
+
+        class _Session(object):
+            def start(self):
+                pass
+
+            def subscribe_whole_quote(self, code_list, callback=None):
+                return 1
+
+            def has_subscription(self, sub_id):
+                return True
+
+            def unsubscribe_quote(self, sub_id):
+                return 0
+
+        class _Client(object):
+            account_id = "acct"
+            local_cache_config = {}
+            full_tick_cache_config = {}
+            transport_name = "redis"
+
+            def __init__(self):
+                self.params = []
+
+            def call(self, method, params=None, **kwargs):
+                self.params.append((method, dict(params or {})))
+                return {}
+
+        client = _Client()
+        data = compat.BigQmtXtData(client)
+        data._quote_session_factory = lambda: _Session()
+        return data, client
+
+    def test_the_primer_asks_for_everything(self):
+        data, client = self._xtdata()
+
+        data.subscribe_whole_quote(["SH"], callback=lambda d: None)
+
+        tick_calls = [p for m, p in client.params if m == "get_full_tick"]
+        self.assertTrue(tick_calls, "no priming snapshot was requested")
+        self.assertEqual(tick_calls[0].get("types"), ["all"])
+
+    def test_a_plain_get_full_tick_still_defaults_to_stocks(self):
+        """The escape hatch above must not leak into ordinary calls."""
+        data, client = self._xtdata()
+
+        data.get_full_tick(["SH"])
+
+        tick_calls = [p for m, p in client.params if m == "get_full_tick"]
+        self.assertNotIn("types", tick_calls[0])

--- a/tests/bigqmt_signal_trader/test_full_tick_types.py
+++ b/tests/bigqmt_signal_trader/test_full_tick_types.py
@@ -1,0 +1,253 @@
+"""A market token must not fetch the whole exchange by default (issue #104).
+
+"SH" asks QMT for every instrument the exchange lists: 26744 of them, of which
+2315 (8.7%) are stocks -- the rest is bonds, repos and the like. Cost is linear
+at ~0.29ms per instrument, so a whole-market snapshot took 7.4s where the stocks
+alone take 0.9s. The reporter compared that against MiniQMT's ~1s, which is the
+stocks-only figure.
+
+Filtering the reply would not have helped: the per-instrument cost is paid
+inside QMT before anything comes back. So the token is resolved to a sector
+listing and only those codes are requested. The sector lookup is
+FormulaServer-served (~13ms measured), so it costs nothing next to what it saves.
+
+The default is now stocks; types=["all"] restores the full listing.
+"""
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.adapters import market_bigqmt
+
+
+SECTORS = {
+    market_bigqmt.STOCK_SECTOR_BY_MARKET["SH"]: ["600000.SH", "601398.SH", "688001.SH"],
+    market_bigqmt.STOCK_SECTOR_BY_MARKET["SZ"]: ["000001.SZ", "300750.SZ"],
+    market_bigqmt.SECTOR_BY_TYPE["stock"]: ["600000.SH", "601398.SH", "688001.SH",
+                                            "000001.SZ", "300750.SZ"],
+    market_bigqmt.SECTOR_BY_TYPE["etf"]: ["510300.SH", "159915.SZ"],
+}
+
+
+class FakeContext(object):
+    def __init__(self):
+        self.asked = []
+
+    def get_full_tick(self, codes):
+        self.asked.append(list(codes))
+        return dict((c, {"lastPrice": 1.0}) for c in codes)
+
+
+def _provider(sectors=None):
+    provider = market_bigqmt.BigQmtMarketDataProvider.__new__(
+        market_bigqmt.BigQmtMarketDataProvider)
+    provider.context_info = FakeContext()
+    listings = SECTORS if sectors is None else sectors
+    provider.get_stock_list_in_sector = lambda name: list(listings.get(name, []))
+    return provider
+
+
+class DefaultNarrowsToStocksTest(unittest.TestCase):
+    def test_a_market_token_becomes_that_market_s_stocks(self):
+        provider = _provider()
+
+        provider.get_ticks(["SH"])
+
+        self.assertEqual(provider.context_info.asked[0],
+                         ["600000.SH", "601398.SH", "688001.SH"])
+
+    def test_the_token_itself_never_reaches_qmt(self):
+        """If it did, QMT would list the whole exchange again."""
+        provider = _provider()
+
+        provider.get_ticks(["SH"])
+
+        self.assertNotIn("SH", provider.context_info.asked[0])
+
+    def test_each_market_resolves_separately(self):
+        provider = _provider()
+
+        provider.get_ticks(["SH", "SZ"])
+
+        self.assertEqual(sorted(provider.context_info.asked[0]),
+                         ["000001.SZ", "300750.SZ", "600000.SH",
+                          "601398.SH", "688001.SH"])
+
+    def test_explicit_codes_are_left_alone(self):
+        provider = _provider()
+
+        provider.get_ticks(["600000.SH", "000001.SZ"])
+
+        self.assertEqual(provider.context_info.asked[0],
+                         ["600000.SH", "000001.SZ"])
+
+    def test_a_token_mixed_with_explicit_codes(self):
+        provider = _provider()
+
+        provider.get_ticks(["SH", "159915.SZ"])
+
+        asked = provider.context_info.asked[0]
+        self.assertIn("159915.SZ", asked)
+        self.assertIn("600000.SH", asked)
+        self.assertNotIn("SH", asked)
+
+
+class ExplicitTypesTest(unittest.TestCase):
+    def test_all_restores_the_whole_exchange(self):
+        provider = _provider()
+
+        provider.get_ticks(["SH"], types=["all"])
+
+        self.assertEqual(provider.context_info.asked[0], ["SH"])
+
+    def test_all_is_case_insensitive(self):
+        provider = _provider()
+
+        provider.get_ticks(["SH"], types=["ALL"])
+
+        self.assertEqual(provider.context_info.asked[0], ["SH"])
+
+    def test_types_combine(self):
+        provider = _provider()
+
+        provider.get_ticks(["SH"], types=["stock", "etf"])
+
+        asked = provider.context_info.asked[0]
+        self.assertIn("600000.SH", asked)   # stock
+        self.assertIn("510300.SH", asked)   # etf
+        self.assertNotIn("159915.SZ", asked)  # SZ etf, wrong market
+
+    def test_a_combination_does_not_duplicate_codes(self):
+        overlapping = dict(SECTORS)
+        overlapping[market_bigqmt.SECTOR_BY_TYPE["etf"]] = ["600000.SH"]
+        provider = _provider(overlapping)
+
+        provider.get_ticks(["SH"], types=["stock", "etf"])
+
+        asked = provider.context_info.asked[0]
+        self.assertEqual(len(asked), len(set(asked)))
+
+
+class FailsOpenTest(unittest.TestCase):
+    """Narrowing is an optimisation. When it cannot be done the token goes
+    through unchanged -- a slow answer beats an empty one, the same rule the
+    key-mapping in get_ticks already follows."""
+
+    def test_an_unknown_type_falls_back_to_the_token(self):
+        provider = _provider()
+
+        provider.get_ticks(["SH"], types=["bogus"])
+
+        self.assertEqual(provider.context_info.asked[0], ["SH"])
+
+    def test_an_empty_sector_falls_back_to_the_token(self):
+        """A terminal that does not carry the sector, or a broker that names it
+        differently."""
+        provider = _provider(sectors={})
+
+        provider.get_ticks(["SH"])
+
+        self.assertEqual(provider.context_info.asked[0], ["SH"])
+
+    def test_a_raising_sector_lookup_falls_back(self):
+        provider = _provider()
+
+        def boom(_name):
+            raise RuntimeError("sector service down")
+
+        provider.get_stock_list_in_sector = boom
+        provider.get_ticks(["SH"])
+
+        self.assertEqual(provider.context_info.asked[0], ["SH"])
+
+    def test_a_market_with_no_stock_sector_falls_back(self):
+        """HK has no A-share sector; it must still return quotes."""
+        provider = _provider()
+
+        provider.get_ticks(["HK"])
+
+        self.assertEqual(provider.context_info.asked[0], ["HK"])
+
+
+class SectorLookupTest(unittest.TestCase):
+    def test_a_sector_is_looked_up_once_per_run(self):
+        provider = _provider()
+        calls = []
+        listing = SECTORS[market_bigqmt.STOCK_SECTOR_BY_MARKET["SH"]]
+        provider.get_stock_list_in_sector = lambda name: (calls.append(name)
+                                                          or list(listing))
+
+        for _ in range(5):
+            provider.get_ticks(["SH"])
+
+        self.assertEqual(len(calls), 1, "looked the sector up %d times" % len(calls))
+
+    def test_sector_names_are_the_ones_the_terminal_uses(self):
+        """Verified against a live terminal: the Beijing board is 京市A股, and
+        北证A股 returns nothing."""
+        self.assertEqual(market_bigqmt.STOCK_SECTOR_BY_MARKET["SH"], u"上证A股")
+        self.assertEqual(market_bigqmt.STOCK_SECTOR_BY_MARKET["SZ"], u"深证A股")
+        self.assertEqual(market_bigqmt.STOCK_SECTOR_BY_MARKET["BJ"], u"京市A股")
+        self.assertEqual(market_bigqmt.SECTOR_BY_TYPE["stock"], u"沪深京A股")
+
+
+class ProviderCompatibilityTest(unittest.TestCase):
+    """A market-data provider whose get_ticks takes only `codes` must keep
+    working -- three tests went red on exactly this while building the feature."""
+
+    def test_the_handler_calls_a_one_argument_provider(self):
+        from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+
+        seen = []
+
+        class _Old(object):
+            def get_ticks(self, codes):
+                seen.append(list(codes))
+                return {}
+
+        handlers = BigQmtRpcHandlers.__new__(BigQmtRpcHandlers)
+        handlers.market_data = _Old()
+        handlers._handle_get_ticks({"codes": ["600000.SH"]})
+
+        self.assertEqual(seen, [["600000.SH"]])
+
+    def test_the_handler_forwards_types_when_asked(self):
+        from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+
+        seen = {}
+
+        class _New(object):
+            def get_ticks(self, codes, types=None):
+                seen["types"] = types
+                return {}
+
+        handlers = BigQmtRpcHandlers.__new__(BigQmtRpcHandlers)
+        handlers.market_data = _New()
+        handlers._handle_get_ticks({"codes": ["SH"], "types": ["all"]})
+
+        self.assertEqual(seen["types"], ["all"])
+
+    def test_a_string_type_is_accepted(self):
+        from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+
+        seen = {}
+
+        class _New(object):
+            def get_ticks(self, codes, types=None):
+                seen["types"] = types
+                return {}
+
+        handlers = BigQmtRpcHandlers.__new__(BigQmtRpcHandlers)
+        handlers.market_data = _New()
+        handlers._handle_get_ticks({"codes": ["SH"], "types": "all"})
+
+        self.assertEqual(seen["types"], ["all"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
@sumo225270 在 #104 报了三条，我在实盘逐条量化。

## 全市场快照：不是桥慢，是在拿多了 11.6 倍

`"SH"` 返回的 **26744** 个标的里，股票只有 **2315 只（8.7%）**：

| 类别 | 数量 | 占比 |
|---|---|---|
| 债券 1xxxxx | 9620 | 36.0% |
| 23xxxx | 7440 | 27.8% |
| 24xxxx | 4749 | 17.8% |
| **股票** | **2315** | **8.7%** |
| 基金/ETF | 1326 | 5.0% |

耗时严格线性、约 **0.29ms/只**（1000 只 0.42s、5000 只 1.66s、10000 只 2.87s），所以 7.4s 完全由数量解释。报告人对比的 MiniQMT「1s」正是只取股票的量级。

**事后过滤没用**——那 0.29ms × 24429 个多余标的在 QMT 内部就付掉了。所以改成**请求时收窄**：先把市场令牌解析成板块清单，只请求那些代码。板块查询走 FormulaServer 直连，实测 **13ms**。

```
["SH"]                     1.08s    2315 只   ← 新默认
["SH"] types=["all"]       7.39s   26744 只   ← 原行为
["SH","SZ"]                1.66s    5216 只
["600000.SH"]              0.13s       1 只   ← 显式代码不受影响
```

### 破坏性变更

默认从"全部标的"变成"股票"。依赖市场令牌拿债券/ETF 的代码需要显式 `types=["all"]`。收窄时会打印一次提示，避免只是静默变少：

```
[bigqmt_market] SH narrowed to 2315 stock; pass types=['all'] for every
instrument the exchange lists
```

**收窄失败一律退回全量**：类型不认识、板块查不到、板块查询抛异常、该市场没有对应板块（如 HK）——都保留原令牌。丢行情比慢更糟，这是 `get_ticks` 原本就在遵循的规则。

板块名是从实盘终端读出来的，不是猜的：**北交所是 `京市A股`，`北证A股` 返回 0**。

## `field_list` 这条不改 —— 改了会损坏数据

报告人的观察准确（直连只有 6 个字段有效），但推论不成立：

```
field_list=[]      RPC    0.97s   11 列
field_list=OHLCV   直连   0.03s    6 列
```

差的那 5 列不是摆设。三只票实测：

| 股票 | 路径 | preClose |
|---|---|---|
| 600000.SH | RPC / 直连 | **9.07** / `nan` |
| 601398.SH | RPC / 直连 | **7.82** / `nan` |
| 000001.SZ | RPC / 直连 | **11.59** / `nan` |

把默认路由到直连，等于用 30 倍加速换 `preClose` 静默变成 `NaN`。所以默认保持走 RPC。

**要那 30 倍，显式写出 6 个字段即可**——这个取舍原本只是没写进文档。首次不传 `field_list` 时现在会在 `bigqmt.log` 记一条说明。

## tick 数据慢

`period="tick"` 单只 3.89s（10032 行）与报告人的"4 秒多"一致。同属数量成本，本 PR 未处理。

## 测试

新增 18 个：收窄、`all` 还原、类型组合与去重、四种退回路径、板块只查一次、板块名核对，以及"只接受 `codes` 的 provider 仍可用"——最后一条在开发中真实红过。

`593 passed`，48/48 测试文件全部收集。部署到大 QMT 重启后实盘验证，数字即上表。
