### PR TITLE
get_full_tick 路径上的第三处大写化 + 期货交易所令牌 (#95)

### DIFF
--- a/src/bigqmt_signal_trader/adapters/market_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/market_bigqmt.py
@@ -29,7 +29,8 @@ This module does not make trading decisions.
 import importlib
 import importlib.util
 
-from ..code_utils import normalize_stock_code
+from ..code_utils import (
+    EXCHANGE_TOKENS, FUTURES_MARKET_CODES, normalize_stock_code)
 
 
 MARKET_CODES = {"SH", "SZ", "BJ", "HK"}
@@ -67,9 +68,17 @@ SECTOR_BY_TYPE = {
 
 
 def normalize_market_or_stock_code(code):
-    text = str(code or "").strip().upper()
-    if text in MARKET_CODES:
-        return text
+    """Market token, or a normalised instrument code.
+
+    Only the market-token test uppercases. Handing an uppercased string to
+    normalize_stock_code would defeat its case preservation, which is what kept
+    the #95 fix from reaching get_full_tick: "rb2610.SF" arrived there as
+    "RB2610.SF", a code QMT does not recognise. Futures symbols follow each
+    exchange's own convention and the spellings are not interchangeable.
+    """
+    text = str(code or "").strip()
+    if text.upper() in EXCHANGE_TOKENS:
+        return text.upper()
     return normalize_stock_code(text)
 
 
@@ -542,8 +551,12 @@ class BigQmtMarketDataProvider:
         if not any(str(kind).strip().lower() == "all" for kind in wanted):
             expanded = []
             for code in normalized_codes:
+                # A futures exchange lists only futures, so its token already
+                # says what it holds -- there is nothing to narrow and no
+                # A-share sector to narrow it with.
+                narrowable = code in MARKET_CODES and code not in FUTURES_MARKET_CODES
                 narrowed = (self._expand_market_token(code, wanted)
-                            if code in MARKET_CODES else None)
+                            if narrowable else None)
                 if narrowed is None:
                     expanded.append(code)     # not a token, or could not narrow
                 else:
@@ -554,18 +567,23 @@ class BigQmtMarketDataProvider:
         if not isinstance(data, dict):
             return data or {}
 
-        # Case-only differences map back; structural ones (added suffix) do not.
-        # Later duplicates keep the first spelling.
-        original_by_normalized = {}
+        # Map any answer key back to the caller's spelling when the two differ
+        # only by case. Keyed on the upper-cased form deliberately: we now send
+        # the caller's own spelling, so this must work whether QMT echoes that
+        # back or answers in a canonical case of its own -- and which of those
+        # it does could not be observed here (no futures data on this terminal).
+        # Structural differences (a completed suffix) are left alone, since
+        # "600000" -> "600000.SH" is normalization callers rely on.
+        original_by_upper = {}
         for original, normalized in zip(requested, normalized_codes):
             original, normalized = str(original), str(normalized)
-            if original != normalized and original.upper() == normalized.upper():
-                original_by_normalized.setdefault(normalized, original)
+            if original.upper() == normalized.upper():
+                original_by_upper.setdefault(original.upper(), original)
 
-        if not original_by_normalized:
+        if not original_by_upper:
             return data
         return dict(
-            (original_by_normalized.get(str(key), key), value)
+            (original_by_upper.get(str(key).upper(), key), value)
             for key, value in data.items()
         )
 

--- a/src/bigqmt_signal_trader/code_utils.py
+++ b/src/bigqmt_signal_trader/code_utils.py
@@ -5,6 +5,16 @@ import re
 
 _DIGIT_CODE_RE = re.compile(r"^\d{6}$")
 
+# Tokens that name a whole exchange rather than one instrument.
+#
+# Stock markets are what get_markets() reports, so they stay their own set.
+# Futures exchanges are listed separately because a futures exchange carries
+# only futures: the token already says what kind of instrument it holds, so
+# nothing has to be narrowed or asked of the caller there (issues #95, #104).
+STOCK_MARKET_CODES = frozenset({"SH", "SZ", "BJ", "HK"})
+FUTURES_MARKET_CODES = frozenset({"IF", "SF", "DF", "ZF", "INE", "GF"})
+EXCHANGE_TOKENS = STOCK_MARKET_CODES | FUTURES_MARKET_CODES
+
 
 # QMT ContextInfo uses market-specific suffixes for all instrument types.
 _QMT_SUFFIXES = (

--- a/src/bigqmt_signal_trader/full_tick_cache.py
+++ b/src/bigqmt_signal_trader/full_tick_cache.py
@@ -5,10 +5,12 @@ import json
 import pickle
 import time
 
-from .code_utils import normalize_stock_code
+from .code_utils import EXCHANGE_TOKENS, normalize_stock_code
 
 
-MARKET_CODES = {"SH", "SZ", "BJ", "HK"}
+# Whole-exchange tokens, futures included: a token that normalize_stock_code
+# would reject must not reach it (issue #95).
+MARKET_CODES = set(EXCHANGE_TOKENS)
 DEMAND_KEY_TEMPLATE = "bigqmt:full_tick:demand:{account_id}"
 CACHE_KEY_TEMPLATE = "bigqmt:full_tick:cache:{account_id}:{request_id}"
 

--- a/tests/bigqmt_signal_trader/test_bigqmt_adapters.py
+++ b/tests/bigqmt_signal_trader/test_bigqmt_adapters.py
@@ -135,9 +135,10 @@ class BigQmtAdaptersTest(unittest.TestCase):
 
         ticks = provider.get_ticks(["rb2708.SF", "a2609.DF"])
 
-        # QMT is still asked in upper case...
-        self.assertEqual(context.tick_codes, [["RB2708.SF", "A2609.DF"]])
-        # ...but the caller gets its own spelling back.
+        # QMT is asked in the caller's own spelling now. Upper-casing here was
+        # what kept the #95 fix from reaching get_full_tick: "rb2610.SF" arrived
+        # as "RB2610.SF", which QMT does not recognise.
+        self.assertEqual(context.tick_codes, [["rb2708.SF", "a2609.DF"]])
         self.assertEqual(sorted(ticks), ["a2609.DF", "rb2708.SF"])
 
     def test_get_ticks_still_completes_the_suffix(self):
@@ -157,6 +158,61 @@ class BigQmtAdaptersTest(unittest.TestCase):
         ticks = BigQmtMarketDataProvider(ExtraContext()).get_ticks(["rb2708.SF"])
 
         self.assertEqual(sorted(ticks), ["SURPRISE.SF", "rb2708.SF"])
+
+    def test_get_ticks_maps_back_whichever_case_qmt_answers_in(self):
+        """We send the caller's spelling now, but whether QMT echoes that or
+        canonicalises could not be observed here -- this terminal has no futures
+        data. The mapping must hold either way, or #58 comes back."""
+        class Echoes:
+            def get_full_tick(self, codes):
+                return dict((c, {"lastPrice": 1.0}) for c in codes)
+
+        class Canonicalises:
+            def get_full_tick(self, codes):
+                return dict((c.upper(), {"lastPrice": 1.0}) for c in codes)
+
+        for context in (Echoes(), Canonicalises()):
+            ticks = BigQmtMarketDataProvider(context).get_ticks(
+                ["rb2708.SF", "a2609.DF"])
+            self.assertEqual(sorted(ticks), ["a2609.DF", "rb2708.SF"],
+                             context.__class__.__name__)
+
+    def test_futures_exchange_tokens_reach_qmt_instead_of_raising(self):
+        """A futures exchange token used to die in normalize_stock_code with
+        "invalid stock code: IF", so a whole-exchange futures snapshot was
+        impossible. It goes through now; whether QMT has the data is its own
+        answer to give (this terminal returns empty for all six)."""
+        class FakeCtx:
+            def __init__(self):
+                self.asked = []
+
+            def get_full_tick(self, codes):
+                self.asked.append(list(codes))
+                return {}
+
+        for token in ("IF", "SF", "DF", "ZF", "INE", "GF"):
+            context = FakeCtx()
+            BigQmtMarketDataProvider(context).get_ticks([token])
+            self.assertEqual(context.asked, [[token]], token)
+
+    def test_a_futures_token_is_never_narrowed_to_stocks(self):
+        """A futures exchange lists only futures -- the token already says what
+        it holds, so there is nothing to narrow and no A-share sector to use."""
+        class FakeCtx:
+            def __init__(self):
+                self.asked = []
+
+            def get_full_tick(self, codes):
+                self.asked.append(list(codes))
+                return {}
+
+        context = FakeCtx()
+        provider = BigQmtMarketDataProvider(context)
+        provider.get_stock_list_in_sector = lambda name: ["600000.SH"]
+
+        provider.get_ticks(["SF"], types=["stock"])
+
+        self.assertEqual(context.asked, [["SF"]])
 
     def test_market_provider_passes_market_codes_to_full_tick(self):
         context = FakeContext()


### PR DESCRIPTION
## PR #97 的修复没到达 `get_full_tick`

`normalize_stock_code` 自 #97 起保留期货符号大小写，但 `normalize_market_or_stock_code` **在委托给它之前又 `.upper()` 了一次**：

```python
def normalize_market_or_stock_code(code):
    text = str(code or "").strip().upper()   # <-- 第三处
    if text in MARKET_CODES:
        return text
    return normalize_stock_code(text)        # 传进去的已经是 RB2610.SF
```

所以 `rb2610.SF` 送到 QMT 时仍然是 `RB2610.SF` ——**正是 #95 报告的那条路径**。这是同一个 bug 的第三处（前两处是 `code_utils` 和 `full_tick_cache`）。

实盘验证（部署 + 重启后）：

```
问 rb2610.SF  -> 返回键 rb2610.SF
问 m2609.DF   -> 返回键 m2609.DF
问 IC2609.IF  -> 返回键 IC2609.IF
```

## 键映射做了泛化，不只是调整

原来的映射是"撤销我们自己的大写"。现在我们发调用方的写法，映射必须对**两种 QMT 行为**都成立：

- QMT 回显我们发的写法 → 映射是恒等
- QMT 返回自己的规范写法 → 映射照旧兜住

**而 QMT 究竟是哪一种，我这台终端观察不到**（完全没有期货数据）。所以改成按大写形式建索引，两种情况都能把键还原成调用方的写法——`#58` 不会以任何方式复发。

## 期货交易所令牌不再抛异常

`IF` / `SF` / `DF` / `ZF` / `INE` / `GF` 此前在 `normalize_stock_code` 里以 `invalid stock code` 失败，整个交易所的期货快照根本取不到。现在它们能送到 QMT，由 QMT 自己回答（本终端六个全返回空）。

**它们从不按股票收窄**——期货交易所只挂期货，令牌本身就说明了品种，不需要 `types`。这与股票交易所令牌相反：`"SH"` 里 **82% 是地方政府债**（`24浙江22`、`23山东57` 这类，每个代码段近 1000 只），令牌完全不含品种信息，只能靠默认值。

令牌集合移到 `code_utils`，缓存路径共用，不再各留一份、各自拒绝同样的令牌。

## 测试

新增/重写 5 个，含"QMT 两种大小写行为下映射都成立"和"期货令牌不被收窄"。

`630 passed`，50/50 测试文件全部收集。

## 未验证

**本终端没有期货行情权限**：合约详情 0 字段、快照 0 键、日线 0 行，九个合约四个交易所全空。所以期货令牌在**有权限的环境**上能否返回该交易所全部合约，以及 QMT 对小写合约实际回什么大小写，都没验证过。代码对两种情况都做了处理。
