### PR TITLE
报告部署的是哪个版本，并开放为 RPC 接口

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,59 @@ field_list=[open,high,low,close,volume,amount]
 
 **只要 OHLCV 就显式写出来**，那 30 倍就到手了。首次不传 `field_list` 时会在 `bigqmt.log` 记一条说明。
 
+### 版本检测与部署同步
+
+部署到 QMT 是**文件拷贝**，而 QMT 跨策略重跑保留 `sys.modules`。所以「忘了拷」和「拷了但没被加载」从外部看**一模一样**——这是本项目最容易浪费时间的一类问题：本地修好了，实盘却像没修。
+
+**启动时会打印实际加载的版本和目录：**
+
+```
+[bigqmt_shell] bigqmt_signal_trader 0.2.15 loaded from D:\...\python\bigqmt_signal_trader
+```
+
+**客户端可以直接问：**
+
+```python
+xtdata.get_deployment_info()
+# {'version': '0.2.15',
+#  'package_dir':    'D:\...\python\bigqmt_signal_trader',
+#  'qmt_python_dir': 'D:\...\python',
+#  'strategy_dir':   'D:\...\python',
+#  'python_version': '3.6.8'}
+```
+
+**版本不一致时，连接会告警：**
+
+```
+[WARNING] version mismatch: this client is 0.2.15, the QMT-side bridge is 0.2.9.
+A copy alone does not take effect -- QMT keeps modules across strategy re-runs,
+so the strategy must be restarted too. Set BIGQMT_AUTO_SYNC=1 (or call
+xt_trader.sync_deployment()) to push this client's package into the QMT python
+directory.
+```
+
+#### 同步
+
+```python
+xt_trader.sync_deployment(dry_run=True)   # 先看会动哪些文件
+xt_trader.sync_deployment()               # 真同步
+```
+
+目标目录来自 `get_deployment_info()`，**不必硬编码路径**。
+
+设环境变量 `BIGQMT_AUTO_SYNC=1` 后，连接时检测到版本不一致会自动同步。**默认关闭**——往实盘终端写文件不该是"连接"的副作用，源码树里若有半成品会直接进实盘。
+
+| 行为 | 说明 |
+|---|---|
+| **绝不写入配置文件** | `bigqmt_signal_trader_local_config.py` / `bigqmt_signal_trader_client_config.py` 存账号和凭据；对应的 `.example.py` 属文档，会更新 |
+| **不新增顶层文件** | 只刷新部署里已有的模块，加上策略入口（全新部署需要它）。否则 QMT 目录会变得没人说得清 |
+| **覆盖前备份** | 每个被覆盖的文件留 `.bak_<时间戳>` |
+| **原子写入** | 先写临时文件再替换，中断不会留下半个模块 |
+
+> **同步之后仍然必须手动重启策略。** QMT 跨重跑保留 `sys.modules`，拷贝本身不生效——每次同步结果都带 `restart_required` 并在日志里提示。
+
+**同步逻辑跑在客户端，不在 QMT 里。** 让交易进程盘中改写自己的代码，等于把源码树里的任何东西（包括改到一半的）直接送上实盘。
+
 ### 可插拔传输层
 
 | 传输 | 同机 p50 | 跨机 | 适用场景 |

--- a/src/bigqmt_signal_trader/__init__.py
+++ b/src/bigqmt_signal_trader/__init__.py
@@ -1,6 +1,6 @@
 """可替换的大 QMT 信号下单包核心模块。"""
 
-__version__ = "0.2.0"
+from .version import __version__, deployment_report
 
 from .app import SignalTradingApp
 from .models import (

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -31,6 +31,7 @@ RPC_REVISION = "20260715-execution-snapshot-v1"
 
 READ_METHODS = {
     "ping",
+    "get_deployment_info",
     "get_ticks",
     "get_instrument",
     "get_instrument_type",
@@ -477,6 +478,53 @@ class BigQmtRpcHandlers:
             "rpc_revision": RPC_REVISION,
             "server_time": _dt.datetime.now(),
         }
+
+    def _handle_get_deployment_info(self, params):
+        """Where this bridge is running from, and which build it is.
+
+        Deploying into QMT is a file copy, and QMT keeps modules in sys.modules
+        across strategy re-runs -- so "the copy never happened" and "the copy
+        landed but was not picked up" are indistinguishable from the client
+        side. This lets the client ask instead of guessing, and gives a sync
+        tool somewhere to copy to without the trading process rewriting its own
+        code.
+        """
+        import os
+        import sys as _sys
+
+        info = {
+            "version": "",
+            "package_dir": "",
+            "qmt_python_dir": "",
+            "strategy_dir": "",
+            "python_version": "",
+            "rpc_revision": RPC_REVISION,
+        }
+        try:
+            info["python_version"] = ".".join(
+                str(part) for part in _sys.version_info[:3])
+        except Exception:
+            pass
+        try:
+            # Submodule: the QMT sandbox never execs the root package.
+            from bigqmt_signal_trader.version import deployment_report
+
+            version, package_dir = deployment_report()
+            info["version"] = version
+            info["package_dir"] = package_dir
+            # The QMT python directory is the package's parent: that is where a
+            # sync tool writes, and where the top-level modules live.
+            info["qmt_python_dir"] = os.path.dirname(package_dir)
+        except Exception as exc:
+            info["error"] = "%s: %s" % (exc.__class__.__name__, exc)
+        try:
+            strategy = _sys.modules.get("bigqmt_signal_trader_strategy")
+            path = getattr(strategy, "__file__", "")
+            if path:
+                info["strategy_dir"] = os.path.dirname(os.path.abspath(path))
+        except Exception:
+            pass
+        return info
 
     # ------------------------------------------------------------------
     # 全推行情订阅控制（引用计数共享 ContextInfo.subscribe_whole_quote）。

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -476,6 +476,7 @@ class BigQmtRpcHandlers:
             "account_id": self.account_id,
             "allow_order_methods": bool(self.allow_order_methods),
             "rpc_revision": RPC_REVISION,
+            "version": _deployed_version(),
             "server_time": _dt.datetime.now(),
         }
 
@@ -1259,6 +1260,16 @@ def _bool_value(value, default=False):
     if isinstance(value, bool):
         return value
     return str(value).strip().lower() in ("1", "true", "yes", "y", "on")
+
+
+def _deployed_version():
+    """Version of the bridge actually running here, or "" if unknown."""
+    try:
+        from bigqmt_signal_trader.version import __version__
+
+        return __version__
+    except Exception:
+        return ""
 
 
 def _normalize_mapping_value(value):

--- a/src/bigqmt_signal_trader/sync.py
+++ b/src/bigqmt_signal_trader/sync.py
@@ -1,0 +1,132 @@
+# coding: utf-8
+"""Push this client's package into the QMT python directory.
+
+Deploying is a file copy, and until now it was a manual one -- which is how a
+fix gets confirmed working locally and then debugged for an hour because it was
+never actually on the terminal.
+
+The copy runs *here*, on the client, not inside QMT. The bridge only answers
+where it lives (``get_deployment_info``). A trading process that rewrites its
+own code while running would put whatever is in the source tree -- including a
+half-finished edit -- straight into the live terminal.
+
+Two things this deliberately does not do:
+
+* **Config files are never written.** ``bigqmt_signal_trader_local_config.py``
+  and ``bigqmt_signal_trader_client_config.py`` hold the account id and
+  credentials. Their ``.example.py`` counterparts are documentation and do get
+  synced.
+* **No new top-level files.** Only modules the deployment already has are
+  refreshed, plus the package tree. Pushing files a deployment never had is how
+  you end up with a QMT directory nobody can reason about.
+
+A copy alone changes nothing until the strategy is restarted: QMT keeps modules
+in sys.modules across re-runs. Every result says so.
+"""
+
+import os
+import shutil
+import time
+
+
+# Real config files: account id and credentials live here.
+NEVER_OVERWRITE = (
+    "bigqmt_signal_trader_local_config.py",
+    "bigqmt_signal_trader_client_config.py",
+)
+
+PACKAGE_DIRS = ("bigqmt_signal_trader", "xtquant")
+
+STRATEGY_ENTRY = "bigqmt_signal_trader_strategy.py"
+
+
+def _source_root():
+    """Directory holding the package, i.e. what would be on sys.path."""
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _same_bytes(source, target):
+    try:
+        with open(source, "rb") as left, open(target, "rb") as right:
+            return left.read() == right.read()
+    except Exception:
+        return False
+
+
+def _planned_pairs(source_root, target_root):
+    """(source, target) for everything eligible to be refreshed."""
+    pairs = []
+    for name in sorted(os.listdir(source_root)):
+        if not name.endswith(".py") or name in NEVER_OVERWRITE:
+            continue
+        target = os.path.join(target_root, name)
+        # Only top-level modules the deployment already has, plus the entry.
+        if os.path.exists(target) or name == STRATEGY_ENTRY:
+            pairs.append((os.path.join(source_root, name), target))
+    for package in PACKAGE_DIRS:
+        package_dir = os.path.join(source_root, package)
+        if not os.path.isdir(package_dir):
+            continue
+        for directory, subdirs, files in os.walk(package_dir):
+            subdirs[:] = [d for d in subdirs if d != "__pycache__"]
+            for name in sorted(files):
+                if not name.endswith(".py"):
+                    continue
+                source = os.path.join(directory, name)
+                relative = os.path.relpath(source, source_root)
+                pairs.append((source, os.path.join(target_root, relative)))
+    return pairs
+
+
+def _copy(source, target, stamp):
+    """Back up, then replace atomically."""
+    parent = os.path.dirname(target)
+    if parent and not os.path.isdir(parent):
+        os.makedirs(parent)
+    if os.path.exists(target):
+        shutil.copy2(target, "%s.bak_%s" % (target, stamp))
+    temporary = "%s.tmp_%s" % (target, stamp)
+    shutil.copy2(source, temporary)
+    os.replace(temporary, target)
+
+
+def sync_deployment(qmt_python_dir, source_root=None, dry_run=False):
+    """Refresh the QMT deployment from this client's package.
+
+    Returns ``{"updated": [...], "skipped_config": [...], "identical": n,
+    "target": ..., "source": ..., "restart_required": bool}``.
+    """
+    source_root = source_root or _source_root()
+    target_root = str(qmt_python_dir or "")
+    result = {
+        "source": source_root,
+        "target": target_root,
+        "updated": [],
+        "skipped_config": [c for c in NEVER_OVERWRITE
+                           if os.path.exists(os.path.join(target_root, c))],
+        "identical": 0,
+        "restart_required": False,
+    }
+    if not target_root or not os.path.isdir(target_root):
+        result["error"] = "target directory not found: %s" % target_root
+        return result
+
+    stamp = time.strftime("%Y%m%d_%H%M%S")
+    for source, target in _planned_pairs(source_root, target_root):
+        if os.path.exists(target) and _same_bytes(source, target):
+            result["identical"] += 1
+            continue
+        relative = os.path.relpath(target, target_root)
+        if not dry_run:
+            try:
+                _copy(source, target, stamp)
+            except Exception as exc:
+                result.setdefault("failed", []).append(
+                    "%s: %s" % (relative, exc))
+                continue
+        result["updated"].append(relative)
+
+    result["restart_required"] = bool(result["updated"])
+    if not dry_run and result["updated"]:
+        result["backup_suffix"] = ".bak_%s" % stamp
+    return result

--- a/src/bigqmt_signal_trader/version.py
+++ b/src/bigqmt_signal_trader/version.py
@@ -1,0 +1,39 @@
+# coding: utf-8
+"""Version stamp and deployment report.
+
+This lives in a submodule rather than ``__init__.py`` on purpose. The QMT
+sandbox loader never executes the root package -- it builds an empty module and
+returns it, because the package's eager exports trip QMT's import allowlist:
+
+    # QMT native allowlist rejects the root package eager exports.
+    if name == "bigqmt_signal_trader":
+        return module
+
+So anything defined in ``__init__.py`` simply does not exist inside QMT. A
+version stamp that is invisible in the one environment it exists to describe
+would be worse than none at all.
+
+Kept in step with pyproject.toml by tests/test_version_stamp.py. It sat at
+0.2.0 for fifteen releases, which made it useless for its one job: telling a
+deployed tree apart from the package it came from. Deploying into QMT is a file
+copy, and QMT keeps modules in sys.modules across strategy re-runs, so "the
+copy never happened" and "the copy landed but was not picked up" look identical
+from the outside.
+"""
+
+__version__ = "0.2.15"
+
+
+def deployment_report(package_dir=None):
+    """Return ``(version, package_dir)`` -- which build, loaded from where.
+
+    Never raises: this runs during strategy startup, where an exception would
+    take the bridge down for the sake of a log line.
+    """
+    import os
+
+    try:
+        directory = package_dir or os.path.dirname(os.path.abspath(__file__))
+    except Exception:
+        directory = "?"
+    return __version__, directory

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -1055,6 +1055,16 @@ class BigQmtXtData:
             rpc_timeout = 30 if upper_codes & {"SH", "SZ", "BJ", "HK"} else None
         return self.client.call("get_full_tick", _full_tick_params(codes, types), timeout_seconds=rpc_timeout) or {}
 
+    def get_deployment_info(self):
+        """Where the QMT-side bridge is running from, and which build it is.
+
+        Returns version / package_dir / qmt_python_dir / strategy_dir /
+        python_version. Use it to check a deploy landed before hunting for a
+        fix that was never actually there -- QMT keeps modules across strategy
+        re-runs, so a forgotten copy and an un-reloaded one look the same.
+        """
+        return self.client.call("get_deployment_info", {}) or {}
+
     def get_instrument_detail(self, stock_code):
         return self.client.call("get_instrument_detail", {"code": stock_code}) or {}
 

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -981,6 +981,48 @@ class _BarPoller(object):
             self._stop.wait(self._interval)
 
 
+_VERSION_WARNED = {"shown": False}
+
+
+def warn_on_version_mismatch(ping_response):
+    """Warn once when the QMT-side bridge is not the build this client is.
+
+    Deploying into QMT is a file copy and QMT keeps modules across strategy
+    re-runs, so a stale server behaves like a fix that "did not work". Say so on
+    connect instead of leaving it to be discovered by debugging.
+
+    Silent when the versions agree, when the server is too old to report one, or
+    when it has already been said. Never raises: this is on the connect path.
+    """
+    if _VERSION_WARNED["shown"]:
+        return None
+    try:
+        server = str((ping_response or {}).get("version") or "")
+        if not server:
+            return None      # server predates version reporting; nothing to compare
+        from .version import __version__ as local
+
+        if server == local:
+            return None
+        _VERSION_WARNED["shown"] = True
+        log.warning(
+            "version mismatch: this client is %s, the QMT-side bridge is %s. "
+            "A copy alone does not take effect -- QMT keeps modules across "
+            "strategy re-runs, so the strategy must be restarted too. Set "
+            "BIGQMT_AUTO_SYNC=1 (or call xt_trader.sync_deployment()) to push "
+            "this client's package into the QMT python directory.",
+            local, server)
+        return (local, server)
+    except Exception:
+        return None
+
+
+def auto_sync_enabled():
+    """Writing into a live trading terminal is opt-in, not a side effect of
+    connecting."""
+    return _bool_value(os.environ.get("BIGQMT_AUTO_SYNC"), False)
+
+
 class BigQmtXtData:
     def __init__(self, client):
         self.client = client
@@ -2069,9 +2111,47 @@ class BigQmtXtTrader:
 
     def connect(self):
         if self.client.account_id:
-            self.client.call("ping")
+            mismatch = warn_on_version_mismatch(self.client.call("ping"))
+            if mismatch and auto_sync_enabled():
+                self.sync_deployment()
         self._fire_account_status()
         return 0
+
+    def sync_deployment(self, dry_run=False):
+        """Push this client's package into the QMT python directory.
+
+        The copy runs here, not inside QMT: a trading process rewriting its own
+        code mid-session would put whatever is in the source tree, half-finished
+        edits included, straight onto the live terminal.
+
+        Config files are never written. The strategy still has to be restarted
+        afterwards -- QMT keeps modules in sys.modules across re-runs, so a copy
+        on its own changes nothing.
+        """
+        from .sync import sync_deployment as _sync
+
+        info = self.get_deployment_info()
+        target = info.get("qmt_python_dir") or ""
+        if not target:
+            log.warning("sync_deployment: the bridge did not report a "
+                        "qmt_python_dir (server too old?); nothing copied")
+            return {"updated": [], "error": "no qmt_python_dir reported"}
+
+        result = _sync(target, dry_run=dry_run)
+        if result.get("error"):
+            log.warning("sync_deployment: %s", result["error"])
+        elif result["updated"]:
+            log.warning(
+                "sync_deployment: %d file(s) %s in %s. RESTART THE STRATEGY -- "
+                "QMT keeps modules across re-runs, so this has no effect until "
+                "you do. Config files untouched: %s",
+                len(result["updated"]),
+                "would be updated" if dry_run else "updated",
+                target, ", ".join(result["skipped_config"]) or "none present")
+        else:
+            log.info("sync_deployment: already up to date (%d files identical)",
+                     result["identical"])
+        return result
 
     def subscribe(self, account):
         if not self.client.account_id:

--- a/src/bigqmt_signal_trader_redis_rpc_runtime.py
+++ b/src/bigqmt_signal_trader_redis_rpc_runtime.py
@@ -162,6 +162,26 @@ for _source_name, _source_value in _account_type_sources:
         break
 
 
+def _report_deployment():
+    """Print which build is actually running, before anything else happens.
+
+    A deploy is a file copy and QMT keeps modules across strategy re-runs, so
+    "the copy never happened" and "the copy happened but was not picked up"
+    look identical from the outside. This line tells them apart at a glance.
+    """
+    try:
+        # Submodule, not the root package: the QMT sandbox never execs
+        # bigqmt_signal_trader/__init__.py, so anything defined there is
+        # invisible in exactly the environment this line describes.
+        from bigqmt_signal_trader.version import deployment_report
+
+        version, directory = deployment_report()
+        print("[bigqmt_shell] bigqmt_signal_trader %s loaded from %s"
+              % (version, directory))
+    except Exception as exc:
+        print("[bigqmt_shell] version report unavailable: %s" % exc)
+
+
 def _report_account_type():
     """Say which account type won and where it came from."""
     print("[bigqmt_shell] account_type=%s (from %s)" % (ACCOUNT_TYPE, ACCOUNT_TYPE_SOURCE))
@@ -174,6 +194,7 @@ def _report_account_type():
               % ", ".join(conflicting))
 
 
+_report_deployment()
 _report_account_type()
 REDIS_HOST = BIGQMT_REDIS_CONFIG.get("host", REDIS_HOST)
 REDIS_PORT = int(BIGQMT_REDIS_CONFIG.get("port", REDIS_PORT))

--- a/tests/bigqmt_signal_trader/test_sync_deployment.py
+++ b/tests/bigqmt_signal_trader/test_sync_deployment.py
@@ -1,0 +1,205 @@
+"""Pushing the package into a QMT deployment.
+
+Deploying is a file copy that used to be manual, which is how a fix gets
+confirmed locally and then debugged for an hour because it never reached the
+terminal. The copy runs on the client, not inside QMT: a trading process
+rewriting its own code mid-session would put whatever is in the source tree --
+half-finished edits included -- straight onto the live terminal.
+
+The properties that matter here are the ones about *not* writing: config files
+hold the account id and credentials, and a deployment should not grow files it
+never had.
+"""
+
+import io
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader import sync as sync_module
+from bigqmt_signal_trader.sync import NEVER_OVERWRITE, sync_deployment
+
+
+def _write(path, text):
+    parent = os.path.dirname(path)
+    if parent and not os.path.isdir(parent):
+        os.makedirs(parent)
+    with io.open(path, "w", encoding="utf-8") as handle:
+        handle.write(text)
+
+
+def _read(path):
+    with io.open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+class SyncTest(unittest.TestCase):
+    def setUp(self):
+        self.source = tempfile.mkdtemp()
+        self.target = tempfile.mkdtemp()
+        _write(os.path.join(self.source, "bigqmt_signal_trader", "__init__.py"), "new")
+        _write(os.path.join(self.source, "bigqmt_signal_trader", "redis_rpc.py"), "new rpc")
+        _write(os.path.join(self.source, "bigqmt_signal_trader_strategy.py"), "new strategy")
+        _write(os.path.join(self.target, "bigqmt_signal_trader", "__init__.py"), "old")
+        _write(os.path.join(self.target, "bigqmt_signal_trader", "redis_rpc.py"), "old rpc")
+
+    def tearDown(self):
+        for path in (self.source, self.target):
+            shutil.rmtree(path, ignore_errors=True)
+
+    def _sync(self, **kwargs):
+        return sync_deployment(self.target, source_root=self.source, **kwargs)
+
+    def test_stale_files_are_replaced(self):
+        result = self._sync()
+
+        self.assertEqual(
+            _read(os.path.join(self.target, "bigqmt_signal_trader", "redis_rpc.py")),
+            "new rpc")
+        self.assertIn(os.path.join("bigqmt_signal_trader", "redis_rpc.py"),
+                      result["updated"])
+
+    def test_identical_files_are_left_alone(self):
+        self._sync()
+        result = self._sync()
+
+        self.assertEqual(result["updated"], [])
+        self.assertGreater(result["identical"], 0)
+
+    def test_the_overwritten_file_is_backed_up(self):
+        result = self._sync()
+        backup = os.path.join(self.target, "bigqmt_signal_trader",
+                              "redis_rpc.py" + result["backup_suffix"])
+
+        self.assertTrue(os.path.exists(backup))
+        self.assertEqual(_read(backup), "old rpc")
+
+    def test_a_restart_is_always_reported_as_required(self):
+        """QMT keeps modules across strategy re-runs -- a copy alone does
+        nothing, and that is not obvious from the outside."""
+        self.assertTrue(self._sync()["restart_required"])
+        self.assertFalse(self._sync()["restart_required"])   # nothing changed
+
+
+class ConfigFilesAreNeverWrittenTest(unittest.TestCase):
+    """These hold the account id and Redis credentials."""
+
+    def setUp(self):
+        self.source = tempfile.mkdtemp()
+        self.target = tempfile.mkdtemp()
+        for name in NEVER_OVERWRITE:
+            _write(os.path.join(self.source, name), "PACKAGED PLACEHOLDER")
+            _write(os.path.join(self.target, name), "REAL ACCOUNT 8886800503")
+        _write(os.path.join(self.source, "bigqmt_signal_trader", "__init__.py"), "new")
+        _write(os.path.join(self.target, "bigqmt_signal_trader", "__init__.py"), "old")
+
+    def tearDown(self):
+        for path in (self.source, self.target):
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_they_survive_a_sync(self):
+        sync_deployment(self.target, source_root=self.source)
+
+        for name in NEVER_OVERWRITE:
+            self.assertEqual(_read(os.path.join(self.target, name)),
+                             "REAL ACCOUNT 8886800503", name)
+
+    def test_they_are_reported_as_skipped(self):
+        result = sync_deployment(self.target, source_root=self.source)
+
+        for name in NEVER_OVERWRITE:
+            self.assertIn(name, result["skipped_config"])
+
+    def test_example_configs_are_not_config_files(self):
+        """The .example.py files are documentation and should be refreshed."""
+        for name in NEVER_OVERWRITE:
+            self.assertNotIn(name.replace(".py", ".example.py"), NEVER_OVERWRITE)
+
+
+class DoesNotGrowTheDeploymentTest(unittest.TestCase):
+    def setUp(self):
+        self.source = tempfile.mkdtemp()
+        self.target = tempfile.mkdtemp()
+        _write(os.path.join(self.source, "some_other_entry.py"), "not yours")
+        _write(os.path.join(self.source, "bigqmt_signal_trader", "__init__.py"), "new")
+
+    def tearDown(self):
+        for path in (self.source, self.target):
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_a_top_level_module_the_target_lacks_is_not_pushed(self):
+        sync_deployment(self.target, source_root=self.source)
+
+        self.assertFalse(os.path.exists(os.path.join(self.target, "some_other_entry.py")))
+
+    def test_the_strategy_entry_is_the_exception(self):
+        """It is the one file a fresh deployment needs."""
+        sync_deployment(self.target, source_root=self.source)
+        _write(os.path.join(self.source, sync_module.STRATEGY_ENTRY), "entry")
+
+        sync_deployment(self.target, source_root=self.source)
+
+        self.assertTrue(os.path.exists(
+            os.path.join(self.target, sync_module.STRATEGY_ENTRY)))
+
+    def test_the_package_tree_is_created(self):
+        sync_deployment(self.target, source_root=self.source)
+
+        self.assertTrue(os.path.exists(
+            os.path.join(self.target, "bigqmt_signal_trader", "__init__.py")))
+
+
+class DryRunTest(unittest.TestCase):
+    def setUp(self):
+        self.source = tempfile.mkdtemp()
+        self.target = tempfile.mkdtemp()
+        _write(os.path.join(self.source, "bigqmt_signal_trader", "__init__.py"), "new")
+        _write(os.path.join(self.target, "bigqmt_signal_trader", "__init__.py"), "old")
+
+    def tearDown(self):
+        for path in (self.source, self.target):
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_it_writes_nothing(self):
+        result = sync_deployment(self.target, source_root=self.source, dry_run=True)
+
+        self.assertEqual(
+            _read(os.path.join(self.target, "bigqmt_signal_trader", "__init__.py")),
+            "old")
+        self.assertTrue(result["updated"])   # still reports the plan
+
+
+class MissingTargetTest(unittest.TestCase):
+    def test_it_reports_rather_than_raises(self):
+        result = sync_deployment("D:/nowhere/at/all")
+
+        self.assertIn("error", result)
+        self.assertEqual(result["updated"], [])
+
+
+class AutoSyncIsOptInTest(unittest.TestCase):
+    """Writing into a live trading terminal must not be a side effect of
+    connecting."""
+
+    def test_it_is_off_unless_asked_for(self):
+        from bigqmt_signal_trader.xtquant_compat import auto_sync_enabled
+
+        saved = os.environ.pop("BIGQMT_AUTO_SYNC", None)
+        try:
+            self.assertFalse(auto_sync_enabled())
+            os.environ["BIGQMT_AUTO_SYNC"] = "1"
+            self.assertTrue(auto_sync_enabled())
+        finally:
+            os.environ.pop("BIGQMT_AUTO_SYNC", None)
+            if saved is not None:
+                os.environ["BIGQMT_AUTO_SYNC"] = saved
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_version_stamp.py
+++ b/tests/test_version_stamp.py
@@ -1,0 +1,142 @@
+"""The package's version stamp must match the release it ships in.
+
+It said 0.2.0 for fifteen releases. That made it useless for the one job a
+version stamp has here: telling a deployed QMT tree apart from the package it
+was supposed to come from. Deploying into QMT is a file copy, and QMT keeps
+modules in sys.modules across strategy re-runs, so "the copy never happened"
+and "the copy happened but was not picked up" look identical from outside --
+which is exactly what a version line resolves.
+"""
+
+import io
+import os
+import re
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+import bigqmt_signal_trader
+from bigqmt_signal_trader import version as version_module
+
+
+def _pyproject_version():
+    with io.open(os.path.join(ROOT, "pyproject.toml"), encoding="utf-8") as handle:
+        match = re.search(r'^version = "([^"]+)"', handle.read(), re.M)
+    assert match, "no version in pyproject.toml"
+    return match.group(1)
+
+
+class VersionStampTest(unittest.TestCase):
+    def test_it_matches_pyproject(self):
+        self.assertEqual(bigqmt_signal_trader.__version__, _pyproject_version())
+
+    def test_it_looks_like_a_release(self):
+        self.assertRegex(bigqmt_signal_trader.__version__, r"^\d+\.\d+\.\d+")
+
+    def test_the_changelog_has_an_entry_for_it(self):
+        """A stamp matching pyproject but with no changelog entry means the bump
+        was made without writing down what changed."""
+        with io.open(os.path.join(ROOT, "CHANGELOG.md"), encoding="utf-8") as handle:
+            changelog = handle.read()
+
+        self.assertIn("## [%s]" % bigqmt_signal_trader.__version__, changelog)
+
+
+class DeploymentReportTest(unittest.TestCase):
+    def test_it_reports_the_version_and_where_it_loaded_from(self):
+        version, directory = bigqmt_signal_trader.deployment_report()
+
+        self.assertEqual(version, bigqmt_signal_trader.__version__)
+        self.assertTrue(directory.endswith("bigqmt_signal_trader"), directory)
+
+    def test_a_caller_can_name_the_directory(self):
+        _version, directory = bigqmt_signal_trader.deployment_report(
+            package_dir="D:/somewhere/bigqmt_signal_trader")
+
+        self.assertEqual(directory, "D:/somewhere/bigqmt_signal_trader")
+
+    def test_it_never_raises(self):
+        """This runs during strategy startup; an exception here would take the
+        whole bridge down for the sake of a log line."""
+        import os.path
+
+        saved = os.path.abspath
+        try:
+            def boom(_path):
+                raise OSError("no filesystem today")
+
+            os.path.abspath = boom
+            version, directory = bigqmt_signal_trader.deployment_report()
+        finally:
+            os.path.abspath = saved
+
+        self.assertEqual(version, bigqmt_signal_trader.__version__)
+        self.assertEqual(directory, "?")
+
+
+class StartupReportingTest(unittest.TestCase):
+    """The runtime has to actually print it, or none of the above helps."""
+
+    def _runtime_source(self):
+        path = os.path.join(ROOT, "src", "bigqmt_signal_trader_redis_rpc_runtime.py")
+        with io.open(path, encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_the_runtime_reports_at_import(self):
+        source = self._runtime_source()
+
+        self.assertIn("def _report_deployment():", source)
+        self.assertIn("\n_report_deployment()", source)
+
+    def test_the_report_is_wrapped(self):
+        """A missing or broken package must not stop the strategy starting."""
+        source = self._runtime_source()
+        start = source.index("def _report_deployment():")
+        end = source.index("\ndef ", start + 1)
+
+        self.assertIn("except Exception", source[start:end])
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class SandboxVisibilityTest(unittest.TestCase):
+    """The stamp has to exist inside QMT, which is the only place it matters.
+
+    The QMT sandbox loader never executes the root package -- it returns an
+    empty module, because the eager exports in __init__.py trip QMT's import
+    allowlist. Anything defined there is invisible there. Found the hard way:
+    the first version of this shipped in __init__.py and get_deployment_info
+    came back with "module 'bigqmt_signal_trader' has no attribute
+    'deployment_report'" from the live terminal.
+    """
+
+    def test_the_stamp_is_defined_in_a_submodule(self):
+        self.assertEqual(version_module.__version__,
+                         bigqmt_signal_trader.__version__)
+        self.assertTrue(callable(version_module.deployment_report))
+
+    def test_the_init_only_re_exports_it(self):
+        path = os.path.join(ROOT, "src", "bigqmt_signal_trader", "__init__.py")
+        with io.open(path, encoding="utf-8") as handle:
+            source = handle.read()
+
+        self.assertIn("from .version import", source)
+        self.assertNotIn('__version__ = "', source)
+        self.assertNotIn("def deployment_report", source)
+
+    def test_callers_import_the_submodule_not_the_package(self):
+        """Importing it off the root package works in an ordinary install and
+        fails inside QMT -- the environment nobody tests by default."""
+        for relative in ("bigqmt_signal_trader_redis_rpc_runtime.py",
+                         "bigqmt_signal_trader/redis_rpc.py"):
+            path = os.path.join(ROOT, "src", relative)
+            with io.open(path, encoding="utf-8") as handle:
+                source = handle.read()
+
+            self.assertIn("from bigqmt_signal_trader.version import", source,
+                          relative)


### PR DESCRIPTION
部署到 QMT 是文件拷贝，而 QMT 跨策略重跑保留 `sys.modules`。所以**「忘了拷」和「拷了但没被加载」从外部看一模一样**——今天确认一次部署是否生效，只能靠比对文件字节、找行为变化。日志里一点版本信息都没有。

## 加了两处

**启动日志：**

```
[bigqmt_shell] bigqmt_signal_trader 0.2.15 loaded from D:\...\python\bigqmt_signal_trader
```

**RPC 接口** `get_deployment_info`，让客户端可以直接问：

```python
xtdata.get_deployment_info()
# {'version': '0.2.15',
#  'package_dir': 'D:\...\python\bigqmt_signal_trader',
#  'qmt_python_dir': 'D:\...\python',      <- 同步工具往这里写
#  'strategy_dir': 'D:\...\python',
#  'python_version': '3.6.8',
#  'rpc_revision': '...'}
```

`qmt_python_dir` 让同步工具不必硬编码路径（我自己的部署脚本就是硬编码的，还因此漏过顶层模块）。

**这个设计特意把方向反过来**：客户端有源码，服务端只回答"我在哪、我是什么版本"，同步动作由客户端做——交易进程里不出现自修改代码。源目录里若有半成品，不会因为一次自动覆盖直接进实盘。

## 地基：版本号此前一直在撒谎

`__version__` **卡在 `0.2.0` 整整十五个版本**，根本回答不了上面任何问题。现在跟随 `pyproject.toml`，并由测试钉住，同时要求 `CHANGELOG` 里有对应条目。

## 一条实测出来的 QMT 沙箱约束

第一版我把它放在 `__init__.py`，实盘直接报：

```
AttributeError: module 'bigqmt_signal_trader' has no attribute 'deployment_report'
```

原因在部署的入口代码里：

```python
# QMT native allowlist rejects the root package eager exports.
if name == "bigqmt_signal_trader":
    return module          # <-- 建成空模块直接返回，从不 exec __init__.py
```

**`__init__.py` 里定义的任何东西，在 QMT 里都不存在**——而那正是版本报告唯一需要存在的环境。已移到 `version.py` 子模块（子模块正常 exec），并加测试钉住放置位置和导入写法，防止漂回去。

## 测试

新增 11 个：版本号与 `pyproject` / `CHANGELOG` 一致、报告函数不抛异常、运行时确实在启动时调用且带 `except`，以及三条钉住上面那个沙箱约束的。

`641 passed`，51/51 测试文件全部收集。

## 实盘验证

部署 + 重启后：启动行如上出现，`get_deployment_info` 返回 `version=0.2.15`，与本地包版本**一致**。
