### PR TITLE
Harden QMT ZMQ startup and RPC compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ python -m bigqmt_signal_trader.init_config
 
 - `bigqmt_signal_trader.xtquant_compat`：把旧代码的 `xt_trader` / `xtdata` 调用转成 RPC，无需改业务代码。
 - 兼容 MiniQMT 方法名：`query_stock_asset` / `query_stock_positions` / `query_stock_orders` / `get_full_tick` / `order_stock` 等。
+- 顶层 `xtquant.xtdata.get_stock_type(stock)` 显式转发到 RPC；完整 QMT 的交易日 ContextInfo fallback 会把 `SH/SZ` 转成代表指数代码。委托快照增量暴露 `price_type` / `traded_price`，旧 QMT 不提供时分别保持 `None` / `0.0`。
 - **完整 xtconstant 枚举**（539 个常量，涵盖原生 MiniQMT 全部 90 个，值逐一比对无改动）：账号类型、委托类型（股票/期货/信用/期权）、报价类型、委托状态、账号状态、`ORDER_TYPE_SET`。
 
 ```python
@@ -719,10 +720,11 @@ cd D:\国金证券QMT交易端
 src/bigqmt_signal_trader/          （整个核心包，含 transports/）
 src/bigqmt_signal_trader_strategy.py
 src/bigqmt_signal_trader_redis_rpc_runtime.py
-src/BIGQMT_REDIS_DRYRUN.py         （★ QMT 编辑器入口，GBK 编码，在 QMT 里加载这个）
+src/BIGQMT_REDIS_DRYRUN.py         （★ Redis/MySQL/SHM 等既有 transport 的 QMT 编辑器入口）
+src/BIGQMT_ZMQ_DRYRUN.py           （★ 同机 ZMQ 专用入口，强制 ZMQ 并记录 bootstrap 异常）
 ```
 
-> **在 QMT 策略编辑器里只加载 `BIGQMT_REDIS_DRYRUN.py` 一个文件**。它会自动 import 上面其余文件。其余 `.py`（`bigqmt_signal_trader_*`）是它依赖的模块，不是直接运行的入口。
+> 同机 ZMQ 在 QMT“模型研究”中新建 Python 模型并加载 `BIGQMT_ZMQ_DRYRUN.py`；其它 transport 继续使用 `BIGQMT_REDIS_DRYRUN.py`。ZMQ 入口只复用原入口的加载逻辑，不会创建 Redis client。
 
 ### 第 2 步：创建 QMT 端私有配置
 
@@ -759,9 +761,9 @@ BIGQMT_REDIS_CONFIG = {
 
 > **重要**：切到 zmq 或 mysql 时，必须同时设 `"rpc_background_threads": True`（这两种传输用自己的后台线程，不走 QMT 回调 drain）。
 
-### 第 3 步：在 QMT 里运行策略（BIGQMT_REDIS_DRYRUN.py）
+### 第 3 步：在 QMT 里运行策略
 
-**入口文件是 `src/BIGQMT_REDIS_DRYRUN.py`**（GBK 编码，QMT 友好）。在 QMT 策略编辑器加载并运行它。
+同机 ZMQ 使用 `src/BIGQMT_ZMQ_DRYRUN.py`，其它 transport 使用 `src/BIGQMT_REDIS_DRYRUN.py`。两者都是 QMT 编辑器入口；ZMQ 入口会在正常 logger 初始化前失败时把 traceback 写入 `<QMT python>\logs\bigqmt-bootstrap-error.log`。部分券商 QMT 缺少标准 `importlib` 时，统一入口会注册仅包含 `import_module/reload` 的最小兼容模块。
 
 #### 这个文件做什么
 
@@ -807,7 +809,7 @@ def _known_qmt_python_dir():
 
 > **为什么是 GBK 编码？** QMT 的策略编辑器用本地代码页（中文 Windows 是 GBK）保存文件。文件头 `#coding:gbk` 声明编码，避免 QMT 保存时破坏 UTF-8 内容。源码本身是 ASCII（中文用 `chr()` 拼），所以实际不会乱码。
 
-> **为什么不直接用 `bigqmt_signal_trader_redis_rpc_runtime.py`？** 那个文件是纯逻辑入口，不包含 reload 和 QMT API 绑定。`BIGQMT_REDIS_DRYRUN.py` 是给 QMT 编辑器专用的外壳，处理了 QMT 进程不退出导致模块缓存、API 绑定等坑。在 QMT 里**只加载 `BIGQMT_REDIS_DRYRUN.py`**。
+> **为什么不直接用 `bigqmt_signal_trader_redis_rpc_runtime.py`？** 那个文件是纯逻辑入口，不包含 reload 和 QMT API 绑定。QMT 编辑器应加载与 transport 对应的外壳：同机 ZMQ 使用 `BIGQMT_ZMQ_DRYRUN.py`，其它 transport 使用 `BIGQMT_REDIS_DRYRUN.py`；不要直接加载 runtime 文件。
 
 ### 第 4 步：客户端调用
 
@@ -979,6 +981,7 @@ src/xtquant/                       可选 xtquant import shim
 src/bigqmt_signal_trader_strategy.py        策略入口（init/handlebar/adjust + 启动诊断）
 src/bigqmt_signal_trader_redis_rpc_runtime.py  Redis RPC runtime 入口
 src/BIGQMT_REDIS_DRYRUN.py                  QMT 编辑器加载入口（GBK）
+src/BIGQMT_ZMQ_DRYRUN.py                    同机 ZMQ QMT 编辑器入口（GBK）
 src/BIGQMT_ZMQ_BACKTEST.py                  独立 QMT 回测 ZMQ 入口（GBK）
 src/bigqmt_backtest/                        独立历史驱动、模拟撮合、ZMQ 协议与客户端
 tests/bigqmt_signal_trader/        单元测试（无 QMT 环境可跑）
@@ -1143,7 +1146,7 @@ python qmt-trader/scripts/qmt.py snapshot --table
 
 与「快速开始」的客户端一致：
 
-1. QMT 端 RPC 服务已启动（`BIGQMT_REDIS_DRYRUN.py` 运行中，输出面板/日志看到启动诊断 OK）；
+1. QMT 端 RPC 服务已启动（同机 ZMQ 运行 `BIGQMT_ZMQ_DRYRUN.py`，其它 transport 运行 `BIGQMT_REDIS_DRYRUN.py`，输出面板/日志看到启动诊断 OK）；
 2. 客户端配置就绪——环境变量（`BIGQMT_ACCOUNT_ID` / `BIGQMT_REDIS_HOST` / `BIGQMT_REDIS_PORT` / `BIGQMT_REDIS_DB` / `BIGQMT_REDIS_PASSWORD`）或配置文件；
 3. 先 `ping` 确认连通：redis 约 13ms / zmq 约 0.7ms 为正常，超时说明 transport 或配置不匹配。
 

--- a/docs/BIG_QMT_REDIS_RPC.md
+++ b/docs/BIG_QMT_REDIS_RPC.md
@@ -383,6 +383,7 @@ QMT 终端自身的 C++ 主循环占着 GIL**,`setswitchinterval`/精简 adjust 
 - **redis**(默认,跨机):`rpc_process_in_listener=True`。
 - **zmq**(同机低延迟):只加 `transport="zmq"` 一行;非 redis 传输 `_build_rpc_service` 会自动开
   `background_threads`,端口按账号派生 `tcp://127.0.0.1:1556x`。
+- QMT 编辑器可直接加载 `BIGQMT_ZMQ_DRYRUN.py`；该入口强制使用 ZMQ，并复用原有 Bridge 加载逻辑。
 - 内置 Redis 客户端读取含股票代码的原始 JSON 会触发 `Sensitive Data Detected`;客户端 helper 默认
   对请求做安全编码。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ Issues = "https://github.com/litaolemo/xtquant_big_convert/issues"
 package-dir = {"" = "src"}
 py-modules = [
     "BIGQMT_REDIS_DRYRUN",
+    "BIGQMT_ZMQ_DRYRUN",
     "BIGQMT_ZMQ_BACKTEST",
     "bigqmt_signal_trader_strategy",
     "bigqmt_signal_trader_redis_rpc_runtime",

--- a/src/BIGQMT_REDIS_DRYRUN.py
+++ b/src/BIGQMT_REDIS_DRYRUN.py
@@ -11,10 +11,28 @@ package imports, so local bridge files are compiled explicitly after resolving
 their path.
 """
 import builtins as _builtins
-import importlib as _importlib
 import os
 import sys
 import types
+
+try:
+    import importlib as _importlib
+except ImportError:
+    # Some QMT python36.zip builds omit importlib. The local loader only needs
+    # import_module and reload, so provide the smallest compatible fallback.
+    _importlib = types.ModuleType("importlib")
+
+    def _fallback_import_module(name, package=None):
+        if package or str(name).startswith("."):
+            raise ImportError("relative import requires the standard importlib package")
+        return _builtins.__import__(name, globals(), locals(), ("*",), 0)
+
+    def _fallback_reload(module):
+        return module
+
+    _importlib.import_module = _fallback_import_module
+    _importlib.reload = _fallback_reload
+    sys.modules["importlib"] = _importlib
 
 
 _LOCAL_ROOTS = (
@@ -208,10 +226,24 @@ def _load_local_config():
 try:
     _config = _load_local_config()
     BIGQMT_REDIS_CONFIG = getattr(_config, "BIGQMT_REDIS_CONFIG", {})
-    print("[bigqmt_shell] local redis config loaded keys=%s" % sorted((BIGQMT_REDIS_CONFIG or {}).keys()))
+    forced_transport = globals().get("BIGQMT_FORCE_TRANSPORT")
+    if forced_transport:
+        BIGQMT_REDIS_CONFIG = dict(BIGQMT_REDIS_CONFIG or {})
+        BIGQMT_REDIS_CONFIG["transport"] = str(forced_transport)
+        if str(forced_transport).lower() == "zmq":
+            BIGQMT_REDIS_CONFIG["rpc_background_threads"] = True
+            BIGQMT_REDIS_CONFIG["download_jobs_enabled"] = False
+            BIGQMT_REDIS_CONFIG["exec_events_enabled"] = False
+            BIGQMT_REDIS_CONFIG["full_tick_cache_enabled"] = False
+    print("[bigqmt_shell] local rpc config loaded transport=%s keys=%s" % (
+        (BIGQMT_REDIS_CONFIG or {}).get("transport", "redis"),
+        sorted((BIGQMT_REDIS_CONFIG or {}).keys()),
+    ))
     _runtime.configure_runtime_redis(BIGQMT_REDIS_CONFIG)
-except Exception as redis_config_error:
-    print("[bigqmt_shell] local redis config load failed: %s" % redis_config_error)
+except Exception as rpc_config_error:
+    print("[bigqmt_shell] local rpc config load failed: %s" % rpc_config_error)
+    if str(globals().get("BIGQMT_FORCE_TRANSPORT") or "").lower() == "zmq":
+        raise RuntimeError("ZMQ bridge requires a valid local QMT config: %s" % rpc_config_error)
 
 try:
     _config = _load_local_config()

--- a/src/BIGQMT_ZMQ_DRYRUN.py
+++ b/src/BIGQMT_ZMQ_DRYRUN.py
@@ -1,0 +1,57 @@
+#coding:gbk
+"""QMT editor entry for the same-host ZeroMQ bridge.
+
+The original editor entry keeps its historical Redis-oriented filename for
+backward compatibility even though it supports every transport.  This wrapper
+gives ZMQ deployments an unambiguous entry, forces the ZMQ transport, and
+persists bootstrap exceptions that occur before the normal bridge logger is
+available.
+"""
+import datetime
+import os
+import sys
+import traceback
+
+
+def _find_bridge_entry():
+    candidates = []
+    entry_file = globals().get("__file__")
+    if entry_file:
+        candidates.append(os.path.dirname(os.path.abspath(entry_file)))
+    cwd = os.getcwd()
+    if cwd and cwd not in candidates:
+        candidates.append(cwd)
+    for path in sys.path:
+        if path and path not in candidates:
+            candidates.append(path)
+    for directory in candidates:
+        entry = os.path.join(directory, "BIGQMT_REDIS_DRYRUN.py")
+        if os.path.isfile(entry):
+            return entry
+    raise ImportError("BIGQMT_REDIS_DRYRUN.py was not found beside the ZMQ entry or on sys.path")
+
+
+def _write_bootstrap_error(entry_path):
+    try:
+        log_dir = os.path.join(os.path.dirname(entry_path), "logs")
+        if not os.path.isdir(log_dir):
+            os.makedirs(log_dir)
+        log_path = os.path.join(log_dir, "bigqmt-bootstrap-error.log")
+        with open(log_path, "a") as log_file:
+            log_file.write("\n%s BIGQMT_ZMQ_DRYRUN bootstrap failed\n" % datetime.datetime.now().isoformat())
+            traceback.print_exc(file=log_file)
+        print("[bigqmt_shell] bootstrap traceback written to %s" % log_path)
+    except Exception as log_error:
+        print("[bigqmt_shell] bootstrap traceback could not be written: %s" % log_error)
+
+
+BIGQMT_FORCE_TRANSPORT = "zmq"
+try:
+    _BRIDGE_ENTRY = _find_bridge_entry()
+    with open(_BRIDGE_ENTRY, "rb") as source_file:
+        _BRIDGE_SOURCE = source_file.read()
+    exec(compile(_BRIDGE_SOURCE, _BRIDGE_ENTRY, "exec"), globals(), globals())
+except Exception:
+    _bootstrap_log_anchor = globals().get("_BRIDGE_ENTRY") or globals().get("__file__") or os.path.join(os.getcwd(), "BIGQMT_ZMQ_DRYRUN.py")
+    _write_bootstrap_error(_bootstrap_log_anchor)
+    raise

--- a/src/bigqmt_signal_trader/adapters/market_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/market_bigqmt.py
@@ -27,7 +27,6 @@ This module does not make trading decisions.
 """
 
 import importlib
-import importlib.util
 
 from ..code_utils import (
     EXCHANGE_TOKENS, FUTURES_MARKET_CODES, normalize_stock_code)
@@ -731,9 +730,10 @@ class BigQmtMarketDataProvider:
         # — note the FIRST argument differs (market vs stockcode). Every caller in
         # this codebase passes a market code, so the xtdata SDK is the correct path.
         def _via_context():
-            # ContextInfo's first arg is stockcode; pass market through anyway so
-            # backtest contexts still return something rather than crashing.
-            return self._call_context("get_trading_dates", market, start_time, end_time, count)
+            # ContextInfo 需要证券代码而不是市场代码；SH/SZ 使用代表指数，
+            # 调用方已经传入完整代码时保持原值。
+            context_stock = {"SH": "000001.SH", "SZ": "399001.SZ"}.get(str(market).upper(), market)
+            return self._call_context("get_trading_dates", context_stock, start_time, end_time, count)
 
         return self._native_or_context(
             "get_trading_dates", _via_context, market, start_time, end_time, count

--- a/src/bigqmt_signal_trader/adapters/order_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/order_bigqmt.py
@@ -233,6 +233,7 @@ class BigQmtOrderGateway:
                     remark=str(_attr(row, ("m_strRemark", "remark"), "") or ""),
                     order_time=_order_time_seconds(row),
                     status_msg=_status_message(row),
+                    price_type=_attr(row, ("m_nOrderPriceType", "price_type")),
                     traded_price=float(
                         _attr(row, ("m_dTradedPrice", "traded_price", "avg_traded_price"), 0.0) or 0.0
                     ),

--- a/src/bigqmt_signal_trader/local_cache.py
+++ b/src/bigqmt_signal_trader/local_cache.py
@@ -52,6 +52,15 @@ def _pad_end(value):
     return text + "9" * (14 - len(text)) if 0 < len(text) < 14 else text
 
 
+def _align_start(value, sample):
+    """Align a timestamp lower bound to an eight-digit daily cache axis."""
+    text = str(value)
+    sample_text = str(sample)
+    if sample_text.isdigit() and len(sample_text) == 8 and text.isdigit() and len(text) > 8:
+        return text[:8]
+    return text
+
+
 def _drop_placeholder_rows(df):
     """Big QMT fills dates it has no local data for with all-zero rows. A real bar
     never has close/open == 0, so drop those placeholders — the cache should hold
@@ -206,7 +215,8 @@ class LocalMarketCache:
             # 复用旧 mask 会长度不匹配（索引形态直接报错）。
             if start_time:
                 series = df.index.astype(str) if on_index else df[axis].astype(str)
-                df = df[series >= str(start_time)]
+                start_bound = _align_start(start_time, next(iter(series))) if len(series) else str(start_time)
+                df = df[series >= start_bound]
             if end_time:
                 series = df.index.astype(str) if on_index else df[axis].astype(str)
                 df = df[series <= _pad_end(end_time)]

--- a/src/bigqmt_signal_trader/logging_setup.py
+++ b/src/bigqmt_signal_trader/logging_setup.py
@@ -24,11 +24,19 @@ Behavior:
 """
 
 import datetime as _dt
-import logging
-import logging.handlers
 import os
 import sys
 import time
+import traceback
+
+try:
+    import logging
+    import logging.handlers
+except ImportError:
+    # Some broker QMT Python bundles omit logging from python36.zip.  The
+    # bridge still needs a minimal file/stdout logger to start and report why
+    # later operations fail.
+    logging = None
 
 _LOGGER_NAME = "bigqmt"
 _initialized = False
@@ -72,14 +80,61 @@ def _resolve_log_dir():
     return None
 
 
-class _SafeStreamHandler(logging.Handler):
-    """print() the record so the QMT output panel shows it; never raises."""
+if logging is not None:
+    class _SafeStreamHandler(logging.Handler):
+        """print() the record so the QMT output panel shows it; never raises."""
 
-    def emit(self, record):
+        def emit(self, record):
+            try:
+                print(self.format(record))
+            except Exception:
+                pass
+
+
+class _FallbackLogger:
+    """Small logger used only when the broker Python omits stdlib logging."""
+
+    def __init__(self, name):
+        self.name = name
+
+    def _write(self, level, message, args, exception_text=None):
         try:
-            print(self.format(record))
+            rendered = str(message) % args if args else str(message)
         except Exception:
-            pass
+            rendered = "%s %s" % (message, args)
+        if exception_text:
+            rendered = "%s\n%s" % (rendered, exception_text)
+        line = "%s [%s] [%s] %s" % (
+            _dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S"), level, self.name, rendered,
+        )
+        if _env_bool("BIGQMT_LOG_ENABLED", True):
+            log_dir = _resolve_log_dir()
+            if log_dir is not None:
+                try:
+                    with open(os.path.join(log_dir, "bigqmt.log"), "a") as log_file:
+                        log_file.write(line + "\n")
+                except Exception:
+                    pass
+        if _env_bool("BIGQMT_LOG_TO_STDOUT", True):
+            try:
+                print(line)
+            except Exception:
+                pass
+
+    def debug(self, message, *args):
+        self._write("DEBUG", message, args)
+
+    def info(self, message, *args):
+        self._write("INFO", message, args)
+
+    def warning(self, message, *args):
+        self._write("WARNING", message, args)
+
+    def error(self, message, *args):
+        self._write("ERROR", message, args)
+
+    def exception(self, message, *args):
+        self._write("ERROR", message, args, traceback.format_exc())
 
 
 def _cleanup_old_logs(log_dir, retention_days):
@@ -108,6 +163,8 @@ def _setup():
     if _initialized:
         return
     _initialized = True
+    if logging is None:
+        return
     logger = logging.getLogger(_LOGGER_NAME)
     logger.setLevel(logging.DEBUG)
     logger.propagate = False
@@ -159,6 +216,8 @@ def get_logger(name=""):
     _setup()
     suffix = str(name or "").strip(".")
     full = _LOGGER_NAME if not suffix else "%s.%s" % (_LOGGER_NAME, suffix)
+    if logging is None:
+        return _FallbackLogger(full)
     return logging.getLogger(full)
 
 

--- a/src/bigqmt_signal_trader/models.py
+++ b/src/bigqmt_signal_trader/models.py
@@ -365,6 +365,7 @@ class OrderSnapshot:
         order_time=0,
         status_msg="",
         traded_price=0.0,
+        price_type=None,
     ):
         self.order_sys_id = order_sys_id
         self.user_order_id = user_order_id
@@ -384,6 +385,8 @@ class OrderSnapshot:
         # 柜台的拒单理由只在这里, 例如
         # "[COUNTER] 资金可用余额不足，尚需[4789.630]" (issue #60)。
         self.status_msg = status_msg
+        # 完整 QMT 的不同版本可能不提供 price_type；追加在末尾保持旧位置参数兼容。
+        self.price_type = price_type
 
 
 class TradeSnapshot:

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -804,6 +804,9 @@ class BigQmtRpcClient:
             "created_at": time.strftime("%Y-%m-%d %H:%M:%S"),
             "payload": payload or {},
         }
+        # 显式地址且未启用 Redis discovery 的 ZMQ 是纯 ZMQ 模式，不应隐式连接 Redis。
+        if self.transport_name == "zmq" and not bool(self.zmq_config.get("redis_discovery_enabled", False)):
+            return event
         raw = json.dumps(event, ensure_ascii=False, default=str)
         stream_key = stream_template.format(account_id=account_id)
         redis_client = self._redis()
@@ -818,6 +821,9 @@ class BigQmtRpcClient:
         return event
 
     def save_quote_subscription(self, seq, payload, active=True):
+        # MySQL、SHM 和混合 ZMQ 继续保留既有 Redis subscription metadata 行为。
+        if self.transport_name == "zmq" and not bool(self.zmq_config.get("redis_discovery_enabled", False)):
+            return
         account_id = str(self.account_id or "")
         key = "bigqmt:quote_subscriptions:%s" % account_id
         redis_client = self._redis()
@@ -1154,9 +1160,9 @@ class BigQmtXtData:
 
     def _get_market_data_ex_batch(self, params, timeout_seconds=None):
         """One RPC's worth of bars, healed and normalized. No caching."""
-        data = self._call("get_market_data_ex", timeout_seconds=timeout_seconds, **params)
+        data = self.client.call("get_market_data_ex", params, timeout_seconds=timeout_seconds)
         # Self-heal adjusted reads (all-zero bars -> server raw download + retry).
-        data = self._heal_adjusted("get_market_data_ex", params, data)
+        data = self._heal_adjusted("get_market_data_ex", params, data, timeout_seconds=timeout_seconds)
         # Normalize Big QMT's stime-indexed frame to MiniQMT shape (time-indexed).
         if isinstance(data, dict):
             data = _normalize_market_data_result(data, field_list=params.get("field_list"))
@@ -1360,7 +1366,7 @@ class BigQmtXtData:
         except Exception:
             pass
 
-    def _heal_adjusted(self, method, params, data, wait_seconds=2.0):
+    def _heal_adjusted(self, method, params, data, wait_seconds=2.0, timeout_seconds=None):
         """Self-heal adjusted reads: if the adjusted pull came back all-zero,
         trigger a server-side raw download, wait for async landing, retry once."""
         dividend_type = str(params.get("dividend_type") or "none").lower()
@@ -1378,6 +1384,8 @@ class BigQmtXtData:
             params.get("end_time", ""),
         )
         time.sleep(wait_seconds)
+        if timeout_seconds is not None:
+            return self.client.call(method, params, timeout_seconds=timeout_seconds)
         return self._call(method, **params)
 
     def _pull_and_cache(self, codes, period, start_time, end_time, count, dividend_type="none"):
@@ -1665,6 +1673,7 @@ class BigQmtXtData:
                     count=-1,
                     dividend_type=dividend_type,
                     fill_data=False,  # fill 会用全 0 占位行冒充数据，轮询判定必须关掉
+                    timeout_seconds=float(data_wait_seconds),
                 )
                 ready = 0
                 for code in batch:
@@ -3433,6 +3442,7 @@ class BigQmtXtTrader:
             order_time=_safe_int(item.get("order_time") or item.get("created_at_ts"), 0),
             # MiniQMT XtOrder.status_msg —— 废单时柜台给的原因 (issue #60)。
             status_msg=str(item.get("status_msg") or ""),
+            price_type=item.get("price_type"),
         )
 
     def _trade_from_dict(self, account_id, item):

--- a/src/xtquant/xtdata.py
+++ b/src/xtquant/xtdata.py
@@ -104,6 +104,10 @@ def get_trading_dates(market, start_time="", end_time="", count=-1):
     return _compat.xtdata.get_trading_dates(market, start_time, end_time, count)
 
 
+def get_stock_type(stock):
+    return _compat.xtdata.call_method("get_stock_type", stock=stock)
+
+
 def get_holidays():
     return _compat.xtdata.get_holidays()
 

--- a/tests/bigqmt_signal_trader/test_bigqmt_adapters.py
+++ b/tests/bigqmt_signal_trader/test_bigqmt_adapters.py
@@ -328,6 +328,7 @@ class BigQmtAdaptersTest(unittest.TestCase):
                     m_nVolumeTraded=200,
                     m_nOrderStatus=50,
                     m_dLimitPrice=10.12,
+                    m_nOrderPriceType=44,
                     m_dTradedPrice=10.05,
                 )
             ]
@@ -349,7 +350,18 @@ class BigQmtAdaptersTest(unittest.TestCase):
         self.assertEqual(orders[0].action, "SELL")
         self.assertEqual(orders[0].traded_volume, 200)
         self.assertEqual(orders[0].price, 10.12)
+        self.assertEqual(orders[0].price_type, 44)
         self.assertEqual(orders[0].traded_price, 10.05)
+
+    def test_query_orders_optional_price_fields_keep_old_qmt_compatible(self):
+        """旧 QMT 不返回可选价格字段时保持 None。"""
+        def fake_query(*_args):
+            return [Obj(m_strOrderSysID="legacy-1", m_strRemark="legacy", m_strInstrumentID="000001", m_strExchangeID="SZ", m_nOffsetFlag=49, m_nVolumeTotalOriginal=200, m_nVolumeTraded=0, m_nOrderStatus=50)]
+
+        order = BigQmtOrderGateway(context_info=object(), get_trade_detail_data_func=fake_query).query_orders_strict("acct", "")[0]
+
+        self.assertIsNone(order.price_type)
+        self.assertEqual(order.traded_price, 0.0)
 
     def test_query_trades_without_strategy_omits_strategy_filter(self):
         calls = []

--- a/tests/bigqmt_signal_trader/test_bigqmt_market_raw_bridge.py
+++ b/tests/bigqmt_signal_trader/test_bigqmt_market_raw_bridge.py
@@ -68,6 +68,28 @@ class BigQmtRawMarketBridgeTest(unittest.TestCase):
         self.assertEqual([], data["600276.SH"]["records"])
         self.assertEqual(["stime", "close"], data["600276.SH"]["columns"])
 
+    def test_trading_date_context_fallback_maps_market_to_representative_stock(self):
+        """ContextInfo 路径必须把市场代码转换为其要求的证券代码。"""
+        class CalendarContext:
+            def __init__(self):
+                self.calls = []
+
+            def get_trading_dates(self, stock_code, start_time, end_time, count):
+                self.calls.append((stock_code, start_time, end_time, count))
+                return ["20260826"]
+
+        class UnavailableNativeXtData:
+            def get_trading_dates(self, *_args):
+                raise RuntimeError("native quote service unavailable")
+
+        context = CalendarContext()
+        provider = BigQmtMarketDataProvider(context, native_xtdata=UnavailableNativeXtData())
+
+        for market, expected_stock in (("SH", "000001.SH"), ("sz", "399001.SZ"), ("000300.SH", "000300.SH")):
+            with self.subTest(market=market):
+                self.assertEqual(["20260826"], provider.get_trading_dates(market, "20260801", "20260826", 3))
+                self.assertEqual((expected_stock, "20260801", "20260826", 3), context.calls[-1])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/bigqmt_signal_trader/test_entry_encoding.py
+++ b/tests/bigqmt_signal_trader/test_entry_encoding.py
@@ -45,6 +45,28 @@ class EntryEncodingTest(unittest.TestCase):
             clear_call,
         )
 
+    def test_zmq_entry_forces_zmq_and_persists_bootstrap_failures(self):
+        """同机 ZMQ 入口必须明确选择 transport，并保留启动前异常。"""
+        path = os.path.join(SRC, "BIGQMT_ZMQ_DRYRUN.py")
+        with open(path, "r", encoding="gbk") as source_file:
+            source = source_file.read()
+        self.assertIn('BIGQMT_FORCE_TRANSPORT = "zmq"', source)
+        self.assertIn("bigqmt-bootstrap-error.log", source)
+        self.assertNotIn("import redis", source)
+
+        legacy_path = os.path.join(SRC, "BIGQMT_REDIS_DRYRUN.py")
+        with open(legacy_path, "r", encoding="gbk") as source_file:
+            legacy_source = source_file.read()
+        self.assertIn('BIGQMT_REDIS_CONFIG["download_jobs_enabled"] = False', legacy_source)
+
+    def test_legacy_entry_supports_qmt_without_standard_importlib(self):
+        """裁剪过的 QMT Python 缺少 importlib 时仍可加载 Bridge。"""
+        path = os.path.join(SRC, "BIGQMT_REDIS_DRYRUN.py")
+        with open(path, "r", encoding="gbk") as source_file:
+            source = source_file.read()
+        self.assertIn('types.ModuleType("importlib")', source)
+        self.assertIn('sys.modules["importlib"] = _importlib', source)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/bigqmt_signal_trader/test_local_cache.py
+++ b/tests/bigqmt_signal_trader/test_local_cache.py
@@ -51,6 +51,16 @@ class LocalMarketCacheTest(unittest.TestCase):
         self.assertIsNone(c.read("MISSING", "1d"))
         self.assertEqual(c.covered("X", "1d"), ("20260101", "20260103", 3))
 
+    def test_daily_range_accepts_full_timestamp_bounds(self):
+        import pandas as pd
+
+        c = LocalMarketCache(self.dir)
+        c.write("X", "1d", pd.DataFrame({"stime": ["20260101", "20260102", "20260103"], "close": [1, 2, 3]}))
+
+        out = c.read("X", "1d", start_time="20260102000000", end_time="20260102235959")
+
+        self.assertEqual(list(out["stime"]), ["20260102"])
+
     def test_index_time_frames_slice_by_date_window(self):
         # issue #54 follow-up: MiniQMT-shaped frames carry time as the index
         # (the client normalizer moves stime to the index and drops the column).
@@ -267,6 +277,7 @@ class FakeClient:
         self.account_id = "acct"
         self.calls = []
         self.call_params = []
+        self.call_timeouts = []
         self.local_cache_config = {"enabled": True, "dir": cache_dir, "fallback_rpc": fallback_rpc}
 
     def _redis(self):
@@ -275,6 +286,7 @@ class FakeClient:
     def call(self, method, params=None, account_id=None, timeout_seconds=None):
         self.calls.append(method)
         self.call_params.append((method, params))
+        self.call_timeouts.append((method, timeout_seconds))
         if method == "get_market_data_ex":
             import pandas as pd
 
@@ -307,6 +319,7 @@ class LocalCacheClientTest(unittest.TestCase):
         self.assertEqual(len(progress), 2)
         self.assertEqual(progress[-1]["stockcode"], "000001.SZ")
         self.assertEqual(progress[-1]["finished"], 2)
+        self.assertEqual(next(timeout for method, timeout in xt.client.call_timeouts if method == "get_market_data_ex"), 60.0)
         calls_after_download = list(xt.client.calls)
 
         data = xt.get_local_data(stock_list=["600000.SH", "000001.SZ"], period="1d")
@@ -569,6 +582,7 @@ class _AllZeroThenRealClient(FakeClient):
     def call(self, method, params=None, account_id=None, timeout_seconds=None):
         self.calls.append(method)
         self.call_params.append((method, params))
+        self.call_timeouts.append((method, timeout_seconds))
         import pandas as pd
 
         if method == "download_history_data2":
@@ -602,7 +616,7 @@ class AdjustedReadSelfHealTest(unittest.TestCase):
         xt = self._xt()
         data = xt.get_market_data_ex(
             field_list=["close"], stock_list=["600000.SH"], period="1d",
-            dividend_type="front",
+            dividend_type="front", timeout_seconds=60.0,
         )
         # After self-heal the retry returns real (non-zero) bars.
         self.assertEqual(list(data["600000.SH"]["close"]), [8.76, 8.73])
@@ -611,6 +625,10 @@ class AdjustedReadSelfHealTest(unittest.TestCase):
         self.assertIn("download_history_data2", method_calls)
         # get_market_data_ex called twice: initial all-zero pull + retry.
         self.assertEqual(method_calls.count("get_market_data_ex"), 2)
+        self.assertEqual(
+            [timeout for method, timeout in xt.client.call_timeouts if method == "get_market_data_ex"],
+            [60.0, 60.0],
+        )
 
     def test_none_read_does_not_self_heal(self):
         xt = self._xt()

--- a/tests/bigqmt_signal_trader/test_logging_setup.py
+++ b/tests/bigqmt_signal_trader/test_logging_setup.py
@@ -1,0 +1,26 @@
+import builtins
+from pathlib import Path
+
+
+def test_logging_fallback_writes_when_broker_python_omits_logging(monkeypatch, tmp_path):
+    source_path = Path(__file__).parents[2] / "src" / "bigqmt_signal_trader" / "logging_setup.py"
+    original_import = builtins.__import__
+
+    def import_without_logging(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "logging" or name.startswith("logging."):
+            raise ImportError("broker python omits logging")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("BIGQMT_LOG_TO_STDOUT", "0")
+    namespace = {
+        "__name__": "bigqmt_logging_fallback_test",
+        "__builtins__": dict(vars(builtins), __import__=import_without_logging),
+    }
+    exec(compile(source_path.read_bytes(), str(source_path), "exec"), namespace)
+
+    logger = namespace["get_logger"]("rpc")
+    logger.error("startup failed: %s", "missing module")
+
+    log_path = Path(namespace["log_file_path"]())
+    assert "[bigqmt.rpc] startup failed: missing module" in log_path.read_text()

--- a/tests/bigqmt_signal_trader/test_models.py
+++ b/tests/bigqmt_signal_trader/test_models.py
@@ -7,7 +7,7 @@ import unittest
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(ROOT, "src"))
 
-from bigqmt_signal_trader.models import SignalAction, SignalStatus, TradeSignal
+from bigqmt_signal_trader.models import OrderSnapshot, SignalAction, SignalStatus, TradeSignal
 
 
 def _base_payload(**kwargs):
@@ -53,6 +53,13 @@ class TradeSignalModelTest(unittest.TestCase):
         now = datetime.datetime(2026, 6, 30, 9, 32, 1)
 
         self.assertTrue(signal.is_expired(now))
+
+    def test_order_snapshot_old_positional_constructor_keeps_optional_price_type_none(self):
+        """新增可选字段不能改变旧位置参数构造契约。"""
+        order = OrderSnapshot("sys-1", "user-1", "600000.SH", "BUY", 100, 0, "50", 10.1, "strategy", "remark", 123, "")
+
+        self.assertIsNone(order.price_type)
+        self.assertEqual(order.traded_price, 0.0)
 
 
 if __name__ == "__main__":

--- a/tests/bigqmt_signal_trader/test_xtdata_shim.py
+++ b/tests/bigqmt_signal_trader/test_xtdata_shim.py
@@ -44,6 +44,10 @@ class _FakeXtData:
         ))
         return True
 
+    def call_method(self, method, **params):
+        self.calls.append(("call_method", (method, params)))
+        return "ETF"
+
 
 class XtdataShimSignatureTest(unittest.TestCase):
     def setUp(self):
@@ -86,6 +90,11 @@ class XtdataShimSignatureTest(unittest.TestCase):
         name, args = self.fake.calls[-1]
         self.assertEqual(name, "download_history_data2")
         self.assertEqual(args[-1], "front")
+
+    def test_get_stock_type_forwards_through_generic_compat_method(self):
+        """顶层 shim 只转发现有通用 RPC，不复制证券分类逻辑。"""
+        self.assertEqual(shim.get_stock_type("510300.SH"), "ETF")
+        self.assertEqual(self.fake.calls, [("call_method", ("get_stock_type", {"stock": "510300.SH"}))])
 
 
 if __name__ == "__main__":

--- a/tests/bigqmt_signal_trader/test_xtquant_compat.py
+++ b/tests/bigqmt_signal_trader/test_xtquant_compat.py
@@ -765,6 +765,39 @@ class XtquantCompatTest(unittest.TestCase):
         self.assertEqual(transport.connect_address, "tcp://127.0.0.1:20146")
         self.assertIsNone(transport.discovery_redis_client)
 
+    def test_pure_zmq_quote_metadata_does_not_build_redis_client(self):
+        """纯 ZMQ 的兼容订阅元数据不能隐式连接 Redis。"""
+        client = BigQmtRpcClient(account_id="acct", redis_config={"transport": "zmq"})
+        client._redis = lambda: (_ for _ in ()).throw(AssertionError("Redis must not be used"))
+
+        event = client.publish_event("subscribe_quote", {"seq": 1})
+        client.save_quote_subscription(1, {"seq": 1}, active=True)
+
+        self.assertEqual(event["event_type"], "subscribe_quote")
+
+    def test_mysql_quote_metadata_keeps_existing_redis_path(self):
+        """非 ZMQ transport 继续使用既有 Redis 订阅元数据。"""
+        class RedisRecorder:
+            def __init__(self):
+                self.calls = []
+
+            def xadd(self, *args, **kwargs):
+                self.calls.append("xadd")
+
+            def publish(self, *args, **kwargs):
+                self.calls.append("publish")
+
+            def hset(self, *args, **kwargs):
+                self.calls.append("hset")
+
+        redis = RedisRecorder()
+        client = BigQmtRpcClient(account_id="acct", redis_client=redis, redis_config={"transport": "mysql"})
+
+        client.publish_event("subscribe_quote", {"seq": 1})
+        client.save_quote_subscription(1, {"seq": 1}, active=True)
+
+        self.assertEqual(redis.calls, ["xadd", "publish", "hset"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/bigqmt_signal_trader/test_xtquant_compat_contract.py
+++ b/tests/bigqmt_signal_trader/test_xtquant_compat_contract.py
@@ -348,6 +348,7 @@ class QueryPathSerializationContractTest(unittest.TestCase):
             remark="rmk-9",
             order_time=1755655200,
             traded_price=10.05,
+            price_type=11,
         )
         item = to_jsonable(snapshot)
         order = self._trader()._order_from_dict("acct", item)
@@ -356,6 +357,7 @@ class QueryPathSerializationContractTest(unittest.TestCase):
         self.assertEqual(order.traded_price, 10.05)
         self.assertEqual(order.strategy_name, "strat-a")
         self.assertEqual(order.order_remark, "rmk-9")
+        self.assertEqual(order.price_type, 11)
 
 
     def test_query_trade_snapshot_with_official_fields_reaches_client(self):


### PR DESCRIPTION
## Summary

- add a dedicated `BIGQMT_ZMQ_DRYRUN.py` same-host entry with forced ZMQ configuration, bootstrap diagnostics, and fallbacks for trimmed QMT Python runtimes
- keep pure ZMQ subscription metadata off Redis and preserve explicit market-data timeouts through adjusted-data retries
- align trading-calendar and daily-cache bounds, forward `get_stock_type`, and expose order `price_type` alongside the existing traded-price contract
- package and document the new entry point, with focused compatibility coverage

## Validation

- `python -m pytest tests/bigqmt_signal_trader/ -q --deselect=tests/bigqmt_signal_trader/test_qmt_launcher.py::ResolveInstallDirTest::test_accepts_root_bin_and_exe_paths --deselect=tests/bigqmt_signal_trader/test_transports.py::MysqlTransportTest::test_round_trip` — 607 passed, 3 skipped, 2 deselected, 3 subtests passed
- `python -m compileall -q src`
- `python -m pip check`

## Environment exclusions

- the launcher-path test assumes Windows drive-letter semantics and fails when run on macOS
- the MySQL round-trip test requires the optional DBUtils dependency, which is not installed in this environment