### PR TITLE
版本号补到 0.3.0

### DIFF
--- a/src/bigqmt_signal_trader/version.py
+++ b/src/bigqmt_signal_trader/version.py
@@ -21,7 +21,7 @@ copy never happened" and "the copy landed but was not picked up" look identical
 from the outside.
 """
 
-__version__ = "0.2.16"
+__version__ = "0.3.0"
 
 
 def deployment_report(package_dir=None):


### PR DESCRIPTION
`pyproject.toml` 和 CHANGELOG 都是 `0.3.0`，但 `version.py` 还停在 `0.2.16`——于是 0.3.0 的部署**把自己报告成 0.2.16**，启动日志和 `get_deployment_info` 都是。

#103 的报告人已经贴出日志：

```
[bigqmt_shell] bigqmt_signal_trader 0.2.16 loaded from D:\app\国金QMT交易端\python\bigqmt_signal_trader
[bigqmt_shell] local rpc config loaded transport=redis keys=[...]     <- 这行来自 #108，即 0.3.0
```

他跑的是 0.3.0 的代码，日志却说 0.2.16——而他正是照着这个数字确认已经是最新版。

`tests/test_version_stamp.py` 本来就红着，它存在的唯一目的就是拦这个（版本号曾经卡在 0.2.0 整整十五个版本）。这次发布时没跑它。

`664 passed`。