### PR TITLE
长代码列表失败时用市场令牌兜底 (#104)

### DIFF
--- a/src/bigqmt_signal_trader/version.py
+++ b/src/bigqmt_signal_trader/version.py
@@ -21,7 +21,7 @@ copy never happened" and "the copy landed but was not picked up" look identical
 from the outside.
 """
 
-__version__ = "0.2.16"
+__version__ = "0.3.0"
 
 
 def deployment_report(package_dir=None):

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -870,6 +870,29 @@ def ipo_market_of(code):
     return None
 
 
+MARKET_TOKENS = frozenset({"SH", "SZ", "BJ", "HK"})
+# Above this many explicit codes, one RPC's single timeout starts to matter more
+# than the extra payload of reading the exchange and filtering (issue #104).
+LARGE_CODE_LIST = 1000
+# What the fallback reads first. Stocks are 8.7% of an exchange listing, so
+# starting narrow is 1.08s against 7.4s; it widens to "all" only if that misses.
+DEFAULT_FALLBACK_TYPES = ("stock",)
+
+
+def _markets_of(codes):
+    """Market tokens the given suffixed codes live on, or empty if any code
+    carries no recognised suffix -- filtering an exchange read cannot recover a
+    code we cannot place."""
+    markets = set()
+    for code in codes or []:
+        _, _, suffix = str(code).rpartition(".")
+        suffix = suffix.upper()
+        if suffix not in MARKET_TOKENS:
+            return set()
+        markets.add(suffix)
+    return markets
+
+
 def _full_tick_params(codes, types=None):
     """RPC params for get_full_tick. `types` narrows a whole-market token to one
     instrument kind at REQUEST time -- filtering the reply would still pay QMT's
@@ -1101,7 +1124,86 @@ class BigQmtXtData:
             rpc_timeout = timeout_seconds
         else:
             rpc_timeout = 30 if upper_codes & {"SH", "SZ", "BJ", "HK"} else None
-        return self.client.call("get_full_tick", _full_tick_params(codes, types), timeout_seconds=rpc_timeout) or {}
+        try:
+            data = self.client.call(
+                "get_full_tick", _full_tick_params(codes, types),
+                timeout_seconds=rpc_timeout) or {}
+        except Exception:
+            data = None
+            if not self._can_fall_back_to_markets(codes, upper_codes):
+                raise
+        if self._should_fall_back(codes, upper_codes, data):
+            recovered = self._full_tick_via_markets(codes, rpc_timeout, types)
+            if recovered is not None:
+                return recovered
+            if data is None:
+                raise
+        return data or {}
+
+    def _can_fall_back_to_markets(self, codes, upper_codes):
+        """Only an explicit list of suffixed codes can be recovered this way."""
+        if upper_codes & MARKET_TOKENS:
+            return False          # already a whole-market request
+        if len(codes) <= LARGE_CODE_LIST:
+            return False          # small list: a failure here is a real failure
+        return bool(_markets_of(codes))
+
+    def _should_fall_back(self, codes, upper_codes, data):
+        if data is None:
+            return True           # the request raised
+        if not self._can_fall_back_to_markets(codes, upper_codes):
+            return False
+        # Short answer: the server dropped codes, or truncated. Anything missing
+        # is worth one whole-market read rather than silently returning less
+        # than was asked for (issue #104).
+        return len(data) < len(set(str(c) for c in codes))
+
+    def _full_tick_via_markets(self, codes, rpc_timeout, types=None):
+        """Read the exchange(s) these codes live on, then filter to them.
+
+        A long explicit list is one RPC carrying one timeout, so it either fits
+        or loses everything; a market token is a single cheap argument that
+        cannot truncate.
+
+        Narrowed first, "all" only if that came up short. An exchange listing is
+        mostly bonds -- "SH" is 26744 instruments of which 2315 are stocks -- so
+        reading all of it costs 7.4s against 1.08s for the stocks. No reason to
+        pay that when the codes being recovered are stocks (issue #104).
+        """
+        markets = _markets_of(codes)
+        if not markets:
+            return None
+        wanted = set(str(code) for code in codes)
+
+        attempts = [list(types) if types else list(DEFAULT_FALLBACK_TYPES)]
+        if not any(str(k).lower() == "all" for k in attempts[0]):
+            attempts.append(["all"])
+
+        merged = {}
+        for attempt in attempts:
+            merged = {}
+            try:
+                for market in sorted(markets):
+                    snapshot = self.client.call(
+                        "get_full_tick", _full_tick_params([market], attempt),
+                        timeout_seconds=max(rpc_timeout or 0, 60)) or {}
+                    for key, value in snapshot.items():
+                        if str(key) in wanted:
+                            merged[key] = value
+            except Exception:
+                return None
+            if len(merged) >= len(wanted):
+                break          # everything asked for; no need to widen
+
+        log.warning(
+            "get_full_tick: %d codes did not come back directly; re-read %s as "
+            "%s and filtered to %d. A market token with types= is cheaper than "
+            "a list this long.",
+            len(wanted), "/".join(sorted(markets)), "/".join(attempts[-1]
+                                                             if len(merged) < len(wanted)
+                                                             else attempts[0]),
+            len(merged))
+        return merged
 
     def get_deployment_info(self):
         """Where the QMT-side bridge is running from, and which build it is.

--- a/tests/bigqmt_signal_trader/test_large_code_list.py
+++ b/tests/bigqmt_signal_trader/test_large_code_list.py
@@ -1,0 +1,203 @@
+"""A long explicit code list must not lose everything (issue #104).
+
+One RPC carries one timeout, so a list that does not fit does not degrade -- it
+returns nothing at all. Measured here: 1000 codes answer in 0.42s, 10000 in
+2.87s, 26744 time out. A reporter hit it at a lower threshold than that, which
+is what a timeout does: where it lands depends on the machine.
+
+So a long list that fails, or comes back short, is retried as a market-token
+read filtered to the codes asked for. A token is one cheap argument that cannot
+truncate.
+
+Narrowed first. An exchange listing is mostly bonds -- "SH" is 26744
+instruments of which 2315 are stocks -- so reading all of it costs 7.4s against
+1.08s for the stocks, and widening to "all" only happens if the narrow read
+came up short.
+"""
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader import xtquant_compat as compat
+from bigqmt_signal_trader.xtquant_compat import LARGE_CODE_LIST, _markets_of
+
+
+def _codes(count, market="SH"):
+    return ["%06d.%s" % (600000 + i, market) for i in range(count)]
+
+
+class FakeClient(object):
+    """Answers get_full_tick; records how each request was made."""
+
+    def __init__(self, direct=None, market_answers=None, raise_direct=False):
+        self.account_id = "acct"
+        self.local_cache_config = {}
+        self.full_tick_cache_config = {}
+        self.transport_name = "zmq"
+        self.requests = []
+        self._direct = direct
+        self._market_answers = market_answers or {}
+        self._raise_direct = raise_direct
+
+    def call(self, method, params=None, timeout_seconds=None, **kwargs):
+        params = params or {}
+        codes = list(params.get("codes") or [])
+        types = list(params.get("types") or [])
+        self.requests.append((codes, types))
+        if len(codes) == 1 and codes[0] in ("SH", "SZ", "BJ", "HK"):
+            return dict(self._market_answers.get(
+                (codes[0], tuple(types) or ("stock",)), {}))
+        if self._raise_direct:
+            raise TimeoutError("zmq rpc timeout: get_full_tick")
+        return dict(self._direct or {})
+
+    def _redis(self):
+        raise AssertionError("redis not expected here")
+
+
+def _xtdata(client):
+    return compat.BigQmtXtData(client)
+
+
+class MarketsOfTest(unittest.TestCase):
+    def test_it_collects_the_suffixes(self):
+        self.assertEqual(_markets_of(["600000.SH", "000001.SZ"]), {"SH", "SZ"})
+
+    def test_an_unsuffixed_code_disables_the_fallback(self):
+        """Filtering an exchange read cannot recover a code we cannot place."""
+        self.assertEqual(_markets_of(["600000.SH", "600001"]), set())
+
+    def test_a_futures_code_disables_it_too(self):
+        self.assertEqual(_markets_of(["rb2610.SF"]), set())
+
+
+class FallbackTriggersTest(unittest.TestCase):
+    def test_a_long_list_that_times_out_is_recovered(self):
+        codes = _codes(LARGE_CODE_LIST + 1)
+        answers = {("SH", ("stock",)): dict((c, {"lastPrice": 1.0}) for c in codes)}
+        client = FakeClient(raise_direct=True, market_answers=answers)
+
+        result = _xtdata(client).get_full_tick(codes)
+
+        self.assertEqual(len(result), len(codes))
+
+    def test_a_short_answer_is_recovered(self):
+        """The server dropped codes rather than raising."""
+        codes = _codes(LARGE_CODE_LIST + 1)
+        answers = {("SH", ("stock",)): dict((c, {"lastPrice": 1.0}) for c in codes)}
+        client = FakeClient(direct={codes[0]: {"lastPrice": 1.0}},
+                            market_answers=answers)
+
+        result = _xtdata(client).get_full_tick(codes)
+
+        self.assertEqual(len(result), len(codes))
+
+    def test_only_the_requested_codes_come_back(self):
+        codes = _codes(LARGE_CODE_LIST + 1)
+        listing = dict((c, {"lastPrice": 1.0}) for c in codes)
+        listing["999999.SH"] = {"lastPrice": 2.0}       # not asked for
+        client = FakeClient(raise_direct=True,
+                            market_answers={("SH", ("stock",)): listing})
+
+        result = _xtdata(client).get_full_tick(codes)
+
+        self.assertNotIn("999999.SH", result)
+
+    def test_both_exchanges_are_read(self):
+        codes = _codes(600, "SH") + _codes(600, "SZ")
+        client = FakeClient(raise_direct=True, market_answers={
+            ("SH", ("stock",)): dict((c, {}) for c in codes if c.endswith(".SH")),
+            ("SZ", ("stock",)): dict((c, {}) for c in codes if c.endswith(".SZ")),
+        })
+
+        result = _xtdata(client).get_full_tick(codes)
+
+        self.assertEqual(len(result), len(codes))
+
+
+class FallbackDoesNotTriggerTest(unittest.TestCase):
+    def test_a_short_list_failure_is_raised(self):
+        """Below the threshold a failure is a real failure, not a size problem
+        -- swallowing it would hide a broken bridge."""
+        client = FakeClient(raise_direct=True)
+
+        with self.assertRaises(TimeoutError):
+            _xtdata(client).get_full_tick(_codes(10))
+
+    def test_a_short_list_that_answers_partially_is_left_alone(self):
+        """Missing instruments are normal: suspended, delisted, not subscribed."""
+        codes = _codes(10)
+        client = FakeClient(direct={codes[0]: {"lastPrice": 1.0}})
+
+        result = _xtdata(client).get_full_tick(codes)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(len(client.requests), 1)   # no second read
+
+    def test_a_market_token_request_is_not_re_read(self):
+        client = FakeClient(market_answers={("SH", ("stock",)): {"600000.SH": {}}})
+
+        _xtdata(client).get_full_tick(["SH"])
+
+        self.assertEqual(len(client.requests), 1)
+
+    def test_unsuffixed_codes_still_raise(self):
+        codes = ["%06d" % (600000 + i) for i in range(LARGE_CODE_LIST + 1)]
+        client = FakeClient(raise_direct=True)
+
+        with self.assertRaises(TimeoutError):
+            _xtdata(client).get_full_tick(codes)
+
+
+class NarrowsBeforeWideningTest(unittest.TestCase):
+    """Reading a whole exchange is 7.4s against 1.08s for its stocks."""
+
+    def test_it_asks_for_stocks_first(self):
+        codes = _codes(LARGE_CODE_LIST + 1)
+        client = FakeClient(raise_direct=True, market_answers={
+            ("SH", ("stock",)): dict((c, {}) for c in codes)})
+
+        _xtdata(client).get_full_tick(codes)
+
+        market_requests = [t for c, t in client.requests if c == ["SH"]]
+        self.assertEqual(market_requests[0], ["stock"])
+
+    def test_it_does_not_widen_when_the_narrow_read_was_enough(self):
+        codes = _codes(LARGE_CODE_LIST + 1)
+        client = FakeClient(raise_direct=True, market_answers={
+            ("SH", ("stock",)): dict((c, {}) for c in codes)})
+
+        _xtdata(client).get_full_tick(codes)
+
+        self.assertNotIn(["all"], [t for c, t in client.requests if c == ["SH"]])
+
+    def test_it_widens_to_all_when_the_narrow_read_falls_short(self):
+        """The codes were not stocks -- bonds, say."""
+        codes = _codes(LARGE_CODE_LIST + 1)
+        client = FakeClient(raise_direct=True, market_answers={
+            ("SH", ("stock",)): {},
+            ("SH", ("all",)): dict((c, {}) for c in codes)})
+
+        result = _xtdata(client).get_full_tick(codes)
+
+        self.assertEqual(len(result), len(codes))
+        self.assertIn(["all"], [t for c, t in client.requests if c == ["SH"]])
+
+    def test_a_caller_supplied_type_is_used_for_the_re_read(self):
+        codes = _codes(LARGE_CODE_LIST + 1)
+        client = FakeClient(raise_direct=True, market_answers={
+            ("SH", ("etf",)): dict((c, {}) for c in codes)})
+
+        _xtdata(client).get_full_tick(codes, types=["etf"])
+
+        market_requests = [t for c, t in client.requests if c == ["SH"]]
+        self.assertEqual(market_requests[0], ["etf"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
@frank0532 报的：显式传大量代码会报错。按他建议的兜底思路实现。

## 为什么会失败

一次 RPC 只带一个超时，所以**装不下的列表不是降级，是全丢**。本机实测：

```
 1000 个 ->  0.42s
10000 个 ->  2.87s
26744 个 ->  超时
```

他在 1000 附近就撞上了——超时就是这样，落点取决于机器。

## 改动

长列表**失败或返回不全**时，改用市场令牌重读一次再筛选。令牌是一个廉价参数，不会被截断。

**重读会先窄后宽。** 交易所挂牌绝大多数是债券——`"SH"` 的 26744 个里股票只有 2315 个——所以整读要 7.4s，只读股票 1.08s。先按 `stock`（或调用方给的 `types=`）读，**不够才退到 `all`**。

## 为什么不做成"超过阈值就切换"

1000 个代码直接请求是 **0.42s**，整市场是 **7.4s**。无条件切换会把本来正常的请求拖慢 17 倍，所以做成兜底而不是阈值切换。

## 不越界的地方

| 情况 | 行为 |
|---|---|
| 列表短且失败 | **抛出**——小列表失败是桥坏了，不是尺寸问题，吞掉会掩盖它 |
| 列表短且返回不全 | **不重读**——停牌、退市、未订阅本来就会缺 |
| 代码没有可识别后缀 | **不重读**——放不到交易所上，筛选也救不回来 |
| 本来就是市场令牌 | **不重读** |

## 测试

新增 15 个：超时触发、返回不全触发、只返回请求的代码、跨两市、四种不触发的情形，以及"先窄后宽"的四条（先问 stock、够了不加宽、不够才 all、尊重调用方的 types）。

`679 passed`，54/54 测试文件全部收集。

## 顺带

把 `version.py` 补到 `0.3.0`（`pyproject` 和 CHANGELOG 已是）。与 #110 同一处修复，带在这里是为了本分支测试全绿——两者合并任一即可。

## 未验证

本机 QMT 桥当前不响应，**这条改动没在实盘验过**。逻辑由单测覆盖，触发条件（超时、返回不全）都是模拟出来的。
