### PR TITLE
信用委托类型不再被塌缩成普通买卖 (#103)

### DIFF
--- a/src/bigqmt_signal_trader/adapters/order_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/order_bigqmt.py
@@ -5,6 +5,8 @@ The passorder signature follows src/api/qmt_jq_trade.
 
 import hashlib
 
+from xtquant import xtconstant as _xtconstant
+
 from ..code_utils import normalize_stock_code
 from ..exec_events import date_time_seconds
 from ..models import CancelResult, OrderSnapshot, OrderSubmitResult, SignalAction, TradeSnapshot
@@ -19,6 +21,75 @@ PRICE_TYPE_ALIASES = {
     "MARKET_SH_CONVERT_5_LIMIT": 43,
     "MARKET_SZ_CONVERT_5_CANCEL": 47,
 }
+
+
+# MiniQMT's order_type (xtconstant) and passorder's opType are two different
+# numberings. They agree on 27-32 and diverge on the special-margin family:
+#
+#   meaning            xtconstant           passorder opType (API ref 10.1)
+#   融资买入 .. 直接还款   27-32                27-32      same
+#   担保品买入 / 卖出      -- (CREDIT_BUY/SELL)  33 / 34
+#   专项两融              40-45                70-75      DIFFERENT
+#
+# Sending 40 through unchanged would reach passorder as "期货组合开多", so the
+# translation is not optional. Values are taken from xtconstant by NAME: PR #88
+# asserted them as literals and encoded the same mistake in its tests, which is
+# why they passed while the mapping was wrong.
+_XC = _xtconstant
+
+CREDIT_OPTYPE_BY_ORDER_TYPE = {
+    _XC.CREDIT_FIN_BUY: 27,                    # 融资买入
+    _XC.CREDIT_SLO_SELL: 28,                   # 融券卖出
+    _XC.CREDIT_BUY_SECU_REPAY: 29,             # 买券还券
+    _XC.CREDIT_DIRECT_SECU_REPAY: 30,          # 直接还券
+    _XC.CREDIT_SELL_SECU_REPAY: 31,            # 卖券还款
+    _XC.CREDIT_DIRECT_CASH_REPAY: 32,          # 直接还款
+    _XC.CREDIT_FIN_BUY_SPECIAL: 70,            # 专项融资买入
+    _XC.CREDIT_SLO_SELL_SPECIAL: 71,           # 专项融券卖出
+    _XC.CREDIT_BUY_SECU_REPAY_SPECIAL: 72,     # 专项买券还券
+    _XC.CREDIT_DIRECT_SECU_REPAY_SPECIAL: 73,  # 专项直接还券
+    _XC.CREDIT_SELL_SECU_REPAY_SPECIAL: 74,    # 专项卖券还款
+    _XC.CREDIT_DIRECT_CASH_REPAY_SPECIAL: 75,  # 专项直接还款
+}
+
+# Which side of the book each one is, for bookkeeping only -- the opType above
+# is what actually goes to passorder. Repayment operations that move securities
+# are classified by what they do to the holding.
+_CREDIT_BUY_SIDE = frozenset({
+    _XC.CREDIT_FIN_BUY, _XC.CREDIT_BUY_SECU_REPAY,
+    _XC.CREDIT_FIN_BUY_SPECIAL, _XC.CREDIT_BUY_SECU_REPAY_SPECIAL,
+})
+_CREDIT_SELL_SIDE = frozenset({
+    _XC.CREDIT_SLO_SELL, _XC.CREDIT_SELL_SECU_REPAY,
+    _XC.CREDIT_DIRECT_SECU_REPAY,
+    _XC.CREDIT_SLO_SELL_SPECIAL, _XC.CREDIT_SELL_SECU_REPAY_SPECIAL,
+    _XC.CREDIT_DIRECT_SECU_REPAY_SPECIAL,
+})
+
+
+def credit_action_of(order_type):
+    """BUY / SELL for a credit order_type, or None if it is not one.
+
+    直接还款 (32 / 45) moves cash rather than securities, so it has no side;
+    callers must pass an action for it explicitly.
+    """
+    try:
+        value = int(order_type)
+    except (TypeError, ValueError):
+        return None
+    if value in _CREDIT_BUY_SIDE:
+        return SignalAction.BUY.value
+    if value in _CREDIT_SELL_SIDE:
+        return SignalAction.SELL.value
+    return None
+
+
+def credit_optype_of(order_type):
+    """passorder opType for a MiniQMT credit order_type, or None."""
+    try:
+        return CREDIT_OPTYPE_BY_ORDER_TYPE.get(int(order_type))
+    except (TypeError, ValueError):
+        return None
 
 
 def _action_from_offset_flag(offset_flag):
@@ -166,7 +237,14 @@ class BigQmtOrderGateway:
     def submit(self, request):
         passorder = self._require_passorder()
         action = str(request.action).upper()
-        if action == SignalAction.BUY.value:
+        credit_optype = credit_optype_of(getattr(request, "order_type", None))
+        if credit_optype is not None:
+            # A credit operation carries more than a side: mapping it back to
+            # BUY/SELL would turn 融资买入 into an ordinary buy, which is the
+            # bug behind issue #103 -- worse than the rejection it replaced,
+            # because it places a real but different order.
+            op_type = credit_optype
+        elif action == SignalAction.BUY.value:
             op_type = 23
         elif action == SignalAction.SELL.value:
             op_type = 24

--- a/src/bigqmt_signal_trader/models.py
+++ b/src/bigqmt_signal_trader/models.py
@@ -329,7 +329,12 @@ class OrderRequest:
         price_type,
         strategy_name,
         remark="",
+        order_type=None,
     ):
+        # MiniQMT-style order_type (xtconstant). Only set for operations a
+        # BUY/SELL action cannot express -- credit financing, repayment and the
+        # special-margin family. None means an ordinary stock order.
+        self.order_type = order_type
         self.signal_id = signal_id
         self.account_id = account_id
         self.action = action

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -996,12 +996,28 @@ class BigQmtRpcHandlers:
         action = str(params.get("action") or "").upper()
         if action:
             return action
-        order_type = str(params.get("order_type") or "").upper()
+        raw = params.get("order_type")
+        order_type = str(raw or "").upper()
         if order_type in BUY_ORDER_TYPES:
             return "BUY"
         if order_type in SELL_ORDER_TYPES:
             return "SELL"
+        # Credit operations carry their side in the type itself (issue #103).
+        # 直接还款 moves cash rather than securities and has no side, so it
+        # still needs an explicit action rather than being guessed at.
+        credit = _credit_action_of(raw)
+        if credit:
+            return credit
+        if _credit_optype_of(raw) is not None:
+            raise ValueError(
+                "order_type %s has no implicit buy/sell side; pass action "
+                "explicitly" % raw)
         raise ValueError("action or order_type is required")
+
+    def _credit_order_type_from_params(self, params):
+        """The MiniQMT order_type to forward, when it is a credit operation."""
+        raw = params.get("order_type")
+        return raw if _credit_optype_of(raw) is not None else None
 
     def _handle_submit_order(self, params):
         if self.order_gateway is None:
@@ -1021,6 +1037,7 @@ class BigQmtRpcHandlers:
             price_type=params.get("price_type") or "LIMIT",
             strategy_name=str(params.get("strategy_name") or "bigqmt_rpc"),
             remark=order_tag,
+            order_type=self._credit_order_type_from_params(params),
         )
         if request.action not in ("BUY", "SELL"):
             raise ValueError("action must be BUY or SELL")
@@ -1260,6 +1277,24 @@ def _bool_value(value, default=False):
     if isinstance(value, bool):
         return value
     return str(value).strip().lower() in ("1", "true", "yes", "y", "on")
+
+
+def _credit_action_of(order_type):
+    try:
+        from bigqmt_signal_trader.adapters.order_bigqmt import credit_action_of
+
+        return credit_action_of(order_type)
+    except Exception:
+        return None
+
+
+def _credit_optype_of(order_type):
+    try:
+        from bigqmt_signal_trader.adapters.order_bigqmt import credit_optype_of
+
+        return credit_optype_of(order_type)
+    except Exception:
+        return None
 
 
 def _deployed_version():

--- a/tests/bigqmt_signal_trader/test_credit_order_types.py
+++ b/tests/bigqmt_signal_trader/test_credit_order_types.py
@@ -1,0 +1,203 @@
+"""Credit orders must reach passorder as credit orders (issue #103).
+
+Two layers were wrong. The RPC rejected anything that was not 23/24, so
+order_stock(acc, code, 27, ...) came back as "action or order_type is
+required". And had it got past that, submit() maps action to opType, so BUY
+would have become 23 -- an ordinary buy placed in place of a margin buy, which
+is worse than the rejection: a real order, for the wrong thing.
+
+The values themselves are the trap. MiniQMT's order_type (xtconstant) and
+passorder's opType are two numberings that agree on 27-32 and diverge above it:
+
+    meaning              xtconstant    passorder opType (API reference 10.1)
+    融资买入 .. 直接还款    27-32         27-32
+    担保品买入 / 卖出       --            33 / 34
+    专项两融               40-45         70-75
+
+So 40 forwarded unchanged reaches passorder as 期货组合开多. Every value here is
+taken from xtconstant by name: PR #88 asserted them as literals and its tests
+encoded the same mistake, which is why they passed while the mapping was wrong.
+"""
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from xtquant import xtconstant
+from bigqmt_signal_trader.adapters.order_bigqmt import (
+    BigQmtOrderGateway, credit_action_of, credit_optype_of)
+from bigqmt_signal_trader.models import OrderRequest
+from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+
+
+class _Recorder(object):
+    def __init__(self):
+        self.op_type = None
+
+    def __call__(self, op_type, order_type, account, code, price_type, price,
+                 volume, strategy, quick, remark, context=None, *args, **kwargs):
+        self.op_type = op_type
+
+
+def _submit(order_type, action="BUY"):
+    recorder = _Recorder()
+    gateway = BigQmtOrderGateway(account_id="acct", passorder_func=recorder,
+                                 context_info=object())
+    gateway.submit(OrderRequest(
+        signal_id="s", account_id="acct", stock_code="600000.SH", action=action,
+        volume=100, price=10.0, price_type="LIMIT", strategy_name="s",
+        order_type=order_type))
+    return recorder.op_type
+
+
+class OpTypeTranslationTest(unittest.TestCase):
+    def test_the_plain_family_passes_through(self):
+        for name, expected in (("CREDIT_FIN_BUY", 27), ("CREDIT_SLO_SELL", 28),
+                               ("CREDIT_BUY_SECU_REPAY", 29),
+                               ("CREDIT_DIRECT_SECU_REPAY", 30),
+                               ("CREDIT_SELL_SECU_REPAY", 31),
+                               ("CREDIT_DIRECT_CASH_REPAY", 32)):
+            self.assertEqual(credit_optype_of(getattr(xtconstant, name)),
+                             expected, name)
+
+    def test_the_special_family_is_renumbered(self):
+        """40 forwarded unchanged would be 期货组合开多 to passorder."""
+        for name, expected in (("CREDIT_FIN_BUY_SPECIAL", 70),
+                               ("CREDIT_SLO_SELL_SPECIAL", 71),
+                               ("CREDIT_BUY_SECU_REPAY_SPECIAL", 72),
+                               ("CREDIT_DIRECT_SECU_REPAY_SPECIAL", 73),
+                               ("CREDIT_SELL_SECU_REPAY_SPECIAL", 74),
+                               ("CREDIT_DIRECT_CASH_REPAY_SPECIAL", 75)):
+            self.assertEqual(credit_optype_of(getattr(xtconstant, name)),
+                             expected, name)
+
+    def test_the_two_numberings_really_do_differ_there(self):
+        """If they ever coincided this translation would look pointless."""
+        self.assertNotEqual(xtconstant.CREDIT_FIN_BUY_SPECIAL,
+                            credit_optype_of(xtconstant.CREDIT_FIN_BUY_SPECIAL))
+
+    def test_a_plain_stock_order_type_is_not_a_credit_one(self):
+        self.assertIsNone(credit_optype_of(xtconstant.STOCK_BUY))
+        self.assertIsNone(credit_optype_of(xtconstant.STOCK_SELL))
+
+    def test_junk_is_rejected_not_guessed(self):
+        for value in (None, "", "abc", 99, -1, 9999):
+            self.assertIsNone(credit_optype_of(value), repr(value))
+
+    def test_every_credit_constant_is_covered(self):
+        """A new one appearing in xtconstant should be a visible gap, not a
+        silent passthrough."""
+        missing = []
+        for name in dir(xtconstant):
+            if not name.startswith("CREDIT_") or name == "CREDIT_ACCOUNT":
+                continue
+            value = getattr(xtconstant, name)
+            if not isinstance(value, int) or value in (xtconstant.CREDIT_BUY,
+                                                       xtconstant.CREDIT_SELL):
+                continue
+            if credit_optype_of(value) is None:
+                missing.append(name)
+        self.assertEqual(missing, [])
+
+
+class SideTest(unittest.TestCase):
+    def test_buy_side_operations(self):
+        for name in ("CREDIT_FIN_BUY", "CREDIT_BUY_SECU_REPAY",
+                     "CREDIT_FIN_BUY_SPECIAL", "CREDIT_BUY_SECU_REPAY_SPECIAL"):
+            self.assertEqual(credit_action_of(getattr(xtconstant, name)),
+                             "BUY", name)
+
+    def test_sell_side_operations(self):
+        for name in ("CREDIT_SLO_SELL", "CREDIT_SELL_SECU_REPAY",
+                     "CREDIT_DIRECT_SECU_REPAY", "CREDIT_SLO_SELL_SPECIAL"):
+            self.assertEqual(credit_action_of(getattr(xtconstant, name)),
+                             "SELL", name)
+
+    def test_cash_repayment_has_no_side(self):
+        """直接还款 moves cash, not securities. Guessing a side would be
+        inventing a direction the operation does not have."""
+        self.assertIsNone(credit_action_of(xtconstant.CREDIT_DIRECT_CASH_REPAY))
+        self.assertIsNone(
+            credit_action_of(xtconstant.CREDIT_DIRECT_CASH_REPAY_SPECIAL))
+
+
+class SubmitTest(unittest.TestCase):
+    """The layer that used to collapse everything into 23/24."""
+
+    def test_a_margin_buy_is_not_placed_as_an_ordinary_buy(self):
+        self.assertEqual(_submit(xtconstant.CREDIT_FIN_BUY), 27)
+
+    def test_a_special_margin_buy_is_renumbered_on_the_way_out(self):
+        self.assertEqual(_submit(xtconstant.CREDIT_FIN_BUY_SPECIAL), 70)
+
+    def test_a_short_sell_reaches_passorder_as_one(self):
+        self.assertEqual(_submit(xtconstant.CREDIT_SLO_SELL, action="SELL"), 28)
+
+    def test_an_ordinary_order_is_untouched(self):
+        self.assertEqual(_submit(None, action="BUY"), 23)
+        self.assertEqual(_submit(None, action="SELL"), 24)
+
+    def test_an_unrecognised_order_type_falls_back_to_the_action(self):
+        """Not a credit type: behave as before rather than refusing."""
+        self.assertEqual(_submit(9999, action="BUY"), 23)
+
+
+class RpcAcceptanceTest(unittest.TestCase):
+    """The layer that rejected these outright."""
+
+    def _handlers(self):
+        return BigQmtRpcHandlers.__new__(BigQmtRpcHandlers)
+
+    def test_a_credit_type_is_accepted_and_given_a_side(self):
+        handlers = self._handlers()
+        for name, expected in (("CREDIT_FIN_BUY", "BUY"),
+                               ("CREDIT_SLO_SELL", "SELL"),
+                               ("CREDIT_FIN_BUY_SPECIAL", "BUY")):
+            action = handlers._order_action_from_params(
+                {"order_type": getattr(xtconstant, name)})
+            self.assertEqual(action, expected, name)
+
+    def test_cash_repayment_asks_for_an_explicit_action(self):
+        handlers = self._handlers()
+
+        with self.assertRaises(ValueError) as caught:
+            handlers._order_action_from_params(
+                {"order_type": xtconstant.CREDIT_DIRECT_CASH_REPAY})
+
+        self.assertIn("no implicit buy/sell side", str(caught.exception))
+
+    def test_an_explicit_action_still_wins(self):
+        handlers = self._handlers()
+        action = handlers._order_action_from_params(
+            {"order_type": xtconstant.CREDIT_DIRECT_CASH_REPAY, "action": "SELL"})
+
+        self.assertEqual(action, "SELL")
+
+    def test_the_credit_type_is_forwarded_to_the_request(self):
+        handlers = self._handlers()
+        forwarded = handlers._credit_order_type_from_params(
+            {"order_type": xtconstant.CREDIT_FIN_BUY})
+
+        self.assertEqual(credit_optype_of(forwarded), 27)
+
+    def test_a_plain_order_forwards_no_credit_type(self):
+        handlers = self._handlers()
+
+        self.assertIsNone(handlers._credit_order_type_from_params(
+            {"order_type": xtconstant.STOCK_BUY}))
+
+    def test_unknown_types_still_raise_the_original_error(self):
+        handlers = self._handlers()
+
+        with self.assertRaises(ValueError) as caught:
+            handlers._order_action_from_params({"order_type": 9999})
+
+        self.assertIn("action or order_type is required", str(caught.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
@fengzhizialex 在 #103 报的：`order_stock(acc, '***.SH', 27, ...)` 报"不支持该类型"。

## 有两层，第二层更危险

**第一层**：RPC 只认 23/24。

```
order_type=27  ->  ValueError: action or order_type is required
order_type=28  ->  同上（融券卖出）
order_type=31  ->  同上（卖券还款）
```

**第二层**：就算放行也没用。`submit()` 按 action 映射 opType，`BUY` 恒等于 `23`——**融资买入会被当成普通买入下出去**。一笔真实的、但下错了品种的委托，比直接报错更危险。

## 数值本身就是陷阱

MiniQMT 的 `order_type`（`xtconstant`）和 `passorder` 的 `opType` 是**两套编号**，在 27–32 一致，往上分叉：

| 含义 | xtconstant | passorder opType（API 参考 10.1） |
|---|---|---|
| 融资买入 … 直接还款 | 27–32 | 27–32（相同） |
| 担保品买入 / 卖出 | — | 33 / 34 |
| **专项两融** | **40–45** | **70–75** |

所以 `40` 原样转发到 `passorder` 会变成**期货组合开多**。这个翻译不是可选项。

### 我在 #88 的 review 里说错过

我说 33/34 是期权操作——那是查 `xtconstant` 得到的。在 `passorder` 的编号里 33/34 是**担保品买入/卖出**，期权是 50–59。已在 #88 更正。

## 实现

```
order_type   含义            action   passorder opType
27           融资买入         BUY      27
28           融券卖出         SELL     28
29           买券还券         BUY      29
31           卖券还款         SELL     31
40           专项融资买入      BUY      70      ← 翻译
41           专项融券卖出      SELL     71      ← 翻译
None         普通买入         BUY      23      ← 不受影响
```

**所有数值按常量名取自 `xtconstant`，不写字面量。** PR #88 正是把它们写成字面量、测试又编码了同一个错误前提，所以 499 个测试全绿而映射是错的。

**`直接还款`（32 / 45）移动的是现金不是证券，没有买卖方向**——不猜，而是报错要求显式传 `action`。

还有一条测试：若 `xtconstant` 新增了本表未覆盖的 `CREDIT_` 常量，测试会红——新类型是可见的缺口，而不是静默透传。

## 测试

新增 20 个，覆盖两套编号的一致段与分叉段、买卖方向归类、现金还款无方向、普通委托不受影响、未知类型仍按原样报错。

`699 passed`，55/55 测试文件全部收集。

## 未验证 —— 需要你

**这会下真实的融资融券委托，我这边没有信用账户。** @fengzhizialex 说过"您来改、我实盘来验"，麻烦你验这几条：

1. `order_stock(acc, code, 27, ...)` 融资买入能否成交
2. `order_stock(acc, code, 28, ...)` 融券卖出
3. 若你有专项额度：`order_type=40`，确认券商收到的是**专项融资买入**而不是期货组合开多

建议先用小额、或用远离现价的限价单先看委托是否被受理。
