### PR TITLE
Return the types MiniQMT returns (#113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,67 @@ credit_positions = credit_trader.query_stock_positions(credit_acc)
 
 ---
 
+## 与 MiniQMT 的兼容性对照
+
+本项目的目标是让照着 MiniQMT (`xtquant`) 写的代码不改就能跑。下表列出**返回值契约**——类型不对不会报错，只会让判断悄悄反过来，所以单独列出来。
+
+### 返回值：与 MiniQMT 一致
+
+| 接口 | 返回 | 说明 |
+|---|---|---|
+| `order_stock()` | `int` | 成功为正数，失败 `-1` |
+| `order_stock_async()` | `int` | 请求序号 seq，结果走 `on_order_stock_async_response` |
+| `cancel_order_stock()` | `int` | **`0` 成功，`-1` 失败**（不是 True/False） |
+| `cancel_order_stock_sysid()` | `int` | 同上 |
+| `cancel_order_stock_async()` | `int` | seq |
+| `connect()` / `start()` | `int` | `0` 成功 |
+| `subscribe()` / `unsubscribe()` | `int` | `0` 成功 |
+| `query_stock_asset()` | 对象 | `.cash` / `.total_asset` 等属性 |
+| `query_stock_positions()` | `list[对象]` | |
+| `query_stock_orders()` / `query_stock_trades()` | `list[对象]` | |
+| `subscribe_quote()` / `subscribe_whole_quote()` | `int` | 订阅号，传给 `unsubscribe_quote()` |
+| `get_full_tick()` | `dict` | `{code: {...}}` |
+| `get_market_data_ex()` | `dict[str, DataFrame]` | |
+
+### 订单号：既是 int 也是 str
+
+MiniQMT 的 `order_id` 是 int（委托编号），`order_sysid` 是 str（柜台合同编号）。大 QMT **没有前者**——`get_trade_detail_data` 只给 `m_strOrderSysID` 这个字符串。
+
+所以这里的 `order_id` 是一个 int 子类，两种形态同时成立：
+
+```python
+order_id = xt_trader.order_stock(acc, "600000.SH", 23, 100, 11, 10.0, "s", "")
+
+isinstance(order_id, int)   # True —— MiniQMT 写法照常
+order_id > 0                # True
+order_id == -1              # 失败时才 True
+
+str(order_id)               # '合同编号' —— 券商给的原始字符串
+xt_trader.cancel_order_stock(acc, order_id)   # 撤单送回的是原始字符串
+```
+
+合同编号是纯数字时（多数券商），int 值就是那个数字，两种形态完全一致；不是纯数字时 int 是一个稳定的正数替身，而撤单、打印用的仍是真实编号。
+
+把 order_id 存进数据库再取出来（变成普通 int）也能撤单——客户端记着最近 4096 个的对应关系。想要字符串就用 `.order_sysid`，它一直是 str。
+
+同样的规则适用于 `XtOrder.order_id`、`XtTrade.order_id`，以及回调对象 `XtOrderError` / `XtCancelError` / `XtOrderResponse` 里的 `order_id`。
+
+### 行为差异（不是返回值，但会咬人）
+
+| 项目 | MiniQMT | 本项目 |
+|---|---|---|
+| `get_full_tick(["SH"])` | 全市场 | **默认只取股票**（1.08s）；要全部传 `types=["all"]`（7.4s，含地方债等 26744 只） |
+| `get_instrument_detail()` 查不到 | `None` | `{}`（两者都是 falsy，`if not detail` 通用） |
+| `download_history_data()` | 无返回 | 返回 `{"finished": n, "total": n}`（多给的信息，可忽略） |
+| 账户类型 | `StockAccount(id, "CREDIT")` 即可 | 还需服务端 `BIGQMT_ACCOUNT_TYPE = "CREDIT"`，**客户端的类型不会传到服务端** |
+| 委托类型常量 | `xtconstant.order_type` | 内部会翻译成 `passorder` 的 opType（两套编号，专项两融 40–45 → 70–75） |
+
+### 本项目的扩展（MiniQMT 没有）
+
+这些不是兼容项，是多出来的：`order_stock_result()`（返回完整 dict 而非单个 id）、`order_stock_batch()`、`wait_async_orders()`、`ipo_subscribe_all()`、`sync_deployment()`、`get_deployment_info()`、`query_execution_snapshot()`、`local_cache_stats()`。
+
+---
+
 ## 环境要求与依赖安装
 
 本系统分两部分，各自需要自己的 Python 环境和依赖：

--- a/src/bigqmt_signal_trader/order_id.py
+++ b/src/bigqmt_signal_trader/order_id.py
@@ -1,0 +1,104 @@
+# coding: utf-8
+"""An order id that is an int for MiniQMT and a string for the broker.
+
+MiniQMT's ``order_stock`` returns an int: a positive 委托编号, or ``-1`` when the
+submit failed. Big QMT has no such number -- ``get_trade_detail_data`` hands
+back ``m_strOrderSysID``, the broker's 合同编号, which is a string. This bridge
+was returning that string straight through (issue #113), so every caller
+written against MiniQMT broke, and broke quietly:
+
+    order_id = trader.order_stock(...)
+    if order_id == -1:      # never true: "-1" != -1, so a rejected order
+        ...                 # reads as success
+    if order_id > 0:        # TypeError: '>' not supported between str and int
+
+``OrderId`` is both. It *is* an int, so comparisons, ``isinstance`` and
+arithmetic behave the way MiniQMT callers expect; and it carries the exact
+broker string on ``.order_sys_id``, so a cancel sends back what QMT issued
+rather than a number we invented -- including ids that are not numeric at all.
+
+Where the 合同编号 is a plain positive integer (the usual case) the int value is
+that same number and the two representations agree exactly. Where it is not,
+the int is a stable surrogate derived from the string: still positive, so
+``> 0`` keeps separating success from failure, while ``str()`` and the cancel
+path use the real id.
+"""
+
+import zlib
+
+
+# Positive and comfortably inside 32 bits, so the value survives a trip through
+# JSON, a database column, or anything else that is unhappy with big integers.
+_SURROGATE_MASK = 0x3FFFFFFF
+
+_DIGITS = frozenset("0123456789")
+
+
+def _is_ascii_digits(text):
+    # str.isdigit() is True for '１２３' and other unicode digit forms, which
+    # int() then happily parses into something the broker never issued.
+    return bool(text) and all(char in _DIGITS for char in text)
+
+
+def int_value_of(order_sys_id):
+    """The int an ``OrderId`` for this 合同编号 should carry.
+
+    Returns 0 for an empty id -- there is no order, so there is no number.
+    """
+    text = ("" if order_sys_id is None else str(order_sys_id)).strip()
+    if not text:
+        return 0
+    if _is_ascii_digits(text):
+        value = int(text)
+        if value > 0:
+            return value
+    # Alphanumeric 合同编号, or a leading-zero form whose int would not round
+    # trip. Derive a stable surrogate instead of guessing a number: same string
+    # gives the same value in any process, so a caller comparing ids across a
+    # restart still matches. `or 1` keeps it strictly positive.
+    return (zlib.crc32(text.encode("utf-8")) & _SURROGATE_MASK) or 1
+
+
+class OrderId(int):
+    """``int(order_id)`` for MiniQMT, ``str(order_id)`` for the broker."""
+
+    # No __slots__: CPython rejects a nonempty __slots__ on an int subclass
+    # (variable-length builtin), so the instance carries an ordinary __dict__.
+
+    def __new__(cls, order_sys_id, value=None):
+        text = "" if order_sys_id is None else str(order_sys_id)
+        if value is None:
+            value = int_value_of(text)
+        obj = int.__new__(cls, value)
+        obj.order_sys_id = text
+        return obj
+
+    def __str__(self):
+        # int.__str__ is object.__str__ on py3, which routes back through the
+        # __repr__ below; int.__repr__ is the one that prints the number.
+        return self.order_sys_id or int.__repr__(self)
+
+    def __format__(self, spec):
+        # "{}".format(oid) and f"{oid}" go through __format__, not __str__, and
+        # int.__format__ with an empty spec would print the surrogate. Anything
+        # with an actual spec ("%05d"-style) is asking for the number.
+        if not spec:
+            return self.__str__()
+        return int.__format__(self, spec)
+
+    def __repr__(self):
+        return "OrderId(%r, %d)" % (self.order_sys_id, int(self))
+
+
+def order_sys_id_of(value):
+    """Best available broker string for something a caller handed back.
+
+    Accepts an ``OrderId``, a bare string, or the int a caller round-tripped
+    through JSON and lost the string half of.
+    """
+    carried = getattr(value, "order_sys_id", None)
+    if carried:
+        return str(carried)
+    if value is None:
+        return ""
+    return str(value)

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -10,6 +10,7 @@ import json
 import time
 import uuid
 import queue as _queue
+from collections import OrderedDict as _OrderedDict
 import threading
 import importlib
 import datetime as _dt
@@ -28,6 +29,7 @@ from xtquant.xttype import StockAccount
 
 from .full_tick_cache import request_full_tick_cache, wait_full_tick_cache
 from .local_cache import LocalMarketCache
+from .order_id import OrderId, order_sys_id_of
 from .redis_rpc import call_redis_rpc
 from .logging_setup import get_logger
 
@@ -877,6 +879,10 @@ LARGE_CODE_LIST = 1000
 # What the fallback reads first. Stocks are 8.7% of an exchange listing, so
 # starting narrow is 1.08s against 7.4s; it widens to "all" only if that misses.
 DEFAULT_FALLBACK_TYPES = ("stock",)
+
+# How many int -> 合同编号 pairs a trader keeps so a cancel still resolves after
+# the caller round-tripped the id through JSON and lost the string (issue #113).
+_ORDER_ID_MEMORY = 4096
 
 
 def _markets_of(codes):
@@ -2175,6 +2181,8 @@ class BigQmtXtTrader:
         self._async_order_queue = _queue.Queue()
         self._async_order_thread = None
         self._async_order_lock = threading.Lock()
+        # int -> 合同编号 for ids handed out as OrderId (issue #113).
+        self._order_sys_ids = _OrderedDict()
 
     def _cached_position_snapshot(self, account_id):
         key = "bigqmt:positions:%s" % str(account_id or self.client.account_id or "")
@@ -2806,7 +2814,60 @@ class BigQmtXtTrader:
             account, stock_code, order_type, order_volume, price_type,
             price, strategy_name, order_remark,
         )
-        return data.get("order_sys_id") or -1
+        return self._order_id(data.get("order_sys_id"))
+
+    def _order_id(self, order_sys_id):
+        """MiniQMT's return contract: a positive int, or -1 on failure.
+
+        Big QMT only has the broker's 合同编号 string, so an OrderId carries
+        both (issue #113). "-1" arrives as a *string* from the server when the
+        submit itself failed, and used to be returned as one -- truthy, and
+        never equal to -1, so a rejected order read as success.
+        """
+        text = str(order_sys_id or "").strip()
+        if not text or text == "-1":
+            return -1
+        order_id = OrderId(text)
+        self._remember_order_id(order_id)
+        return order_id
+
+    def _order_object_id(self, order_sys_id):
+        """``order_id`` for an XtOrder / XtTrade: int, empty stays empty.
+
+        Unlike the order_stock return there is no -1 here -- a query result
+        either has an id or does not.
+        """
+        text = str(order_sys_id or "").strip()
+        if not text:
+            return OrderId("")
+        order_id = OrderId(text)
+        self._remember_order_id(order_id)
+        return order_id
+
+    def _remember_order_id(self, order_id):
+        """Keep int -> 合同编号 so a cancel still works after a round trip.
+
+        A caller who stores the id in JSON or a database gets a plain int back,
+        losing the string half. Bounded: this is a convenience, not a ledger.
+        """
+        sys_id = getattr(order_id, "order_sys_id", "")
+        if not sys_id or str(int(order_id)) == sys_id:
+            return                       # nothing to remember: they agree
+        table = self._order_sys_ids
+        table[int(order_id)] = sys_id
+        while len(table) > _ORDER_ID_MEMORY:
+            table.popitem(last=False)
+
+    def _resolve_order_sys_id(self, value):
+        """The broker string for whatever a caller passed to a cancel."""
+        carried = getattr(value, "order_sys_id", None)
+        if carried:
+            return str(carried)
+        if isinstance(value, int) and not isinstance(value, bool):
+            remembered = self._order_sys_ids.get(int(value))
+            if remembered:
+                return remembered
+        return order_sys_id_of(value)
 
     def order_stock_result(
         self, account, stock_code, order_type, order_volume, price_type,
@@ -2996,7 +3057,7 @@ class BigQmtXtTrader:
                             error_msg=str(exc),
                             order_sysid="",          # MiniQMT 规范名 (issue #65)
                             order_sys_id="",
-                            order_id="",
+                            order_id=self._order_object_id(""),   # int (#113)
                             stock_code=stock_code,
                             seq=seq,
                             order_remark=str(kwargs.get("order_remark") or (args[7] if len(args) > 7 else "") or ""),
@@ -3027,7 +3088,7 @@ class BigQmtXtTrader:
                             error_msg="order submit failed (order_stock returned -1)",
                             order_sysid="",          # MiniQMT 规范名 (issue #65)
                             order_sys_id="",
-                            order_id="",
+                            order_id=self._order_object_id(""),   # int (#113)
                             stock_code=stock_code,
                             seq=seq,
                             order_remark=str(kwargs.get("order_remark") or (args[7] if len(args) > 7 else "") or ""),
@@ -3063,7 +3124,7 @@ class BigQmtXtTrader:
                     CompatObject(
                         account_id=self.client.account_id,
                         seq=seq,
-                        order_id=order_sys_id or user_order_id,
+                        order_id=self._order_object_id(order_sys_id or user_order_id),
                         order_sysid=order_sys_id,    # MiniQMT 规范名 (issue #65)
                         order_sys_id=order_sys_id,
                         stock_code=stock_code,
@@ -3132,17 +3193,25 @@ class BigQmtXtTrader:
         ) or []
 
     def cancel_order_stock_sysid(self, account, market, order_sysid):
+        """MiniQMT contract: 0 on success, -1 on failure (issue #113).
+
+        This returned a bool, which is worse than a type mismatch -- it inverts
+        the meaning. ``if trader.cancel_order_stock(...) == 0`` is how MiniQMT
+        code checks success, and ``False == 0`` is True, so a *failed* cancel
+        read as a successful one while a successful one read as failed.
+        """
         account_id = _account_id(account, self.client.account_id)
         data = self.client.call(
             "cancel_order_stock_sysid",
             {
                 "account_id": account_id,
                 "market": market,
-                "order_sysid": order_sysid,
+                # Send the broker's own 合同编号, not the int we derived from it.
+                "order_sysid": self._resolve_order_sys_id(order_sysid),
             },
             account_id=account_id,
         ) or {}
-        return bool(data.get("success", data))
+        return 0 if bool(data.get("success", data)) else -1
 
     def cancel_order_stock(self, account, order_id):
         return self.cancel_order_stock_sysid(account, "", order_id)
@@ -3424,7 +3493,9 @@ class BigQmtXtTrader:
         # MiniQMT: returns seq, result comes back via on_cancel_order_stock_async_response.
         seq = self._next_async_seq()
         try:
-            ok = self.cancel_order_stock(account, order_id)
+            # 0 == success now (MiniQMT contract, issue #113), so a bare
+            # truthiness test on the return would read backwards.
+            ok = self.cancel_order_stock(account, order_id) == 0
         except Exception as exc:
             callback = self.callback
             if callback is not None:
@@ -3435,7 +3506,7 @@ class BigQmtXtTrader:
                             error_msg=str(exc),
                             order_sysid=str(order_id or ""),
                             order_sys_id=str(order_id or ""),
-                            order_id=str(order_id or ""),
+                            order_id=self._order_object_id(order_id),
                             stock_code="",
                         )
                     )
@@ -3456,7 +3527,7 @@ class BigQmtXtTrader:
                         error_msg="" if ok else "cancel_order_stock rejected by server",
                         order_sysid=str(order_id or ""),
                         order_sys_id=str(order_id or ""),
-                        order_id=str(order_id or ""),
+                        order_id=self._order_object_id(order_id),
                     ),
                 )
             except Exception:
@@ -3468,7 +3539,7 @@ class BigQmtXtTrader:
     def cancel_order_stock_sysid_async(self, account, market, order_sysid):
         seq = self._next_async_seq()
         try:
-            ok = self.cancel_order_stock_sysid(account, market, order_sysid)
+            ok = self.cancel_order_stock_sysid(account, market, order_sysid) == 0
         except Exception as exc:
             callback = self.callback
             if callback is not None:
@@ -3479,7 +3550,7 @@ class BigQmtXtTrader:
                             error_msg=str(exc),
                             order_sysid=str(order_sysid or ""),
                             order_sys_id=str(order_sysid or ""),
-                            order_id=str(order_sysid or ""),
+                            order_id=self._order_object_id(order_sysid),
                             stock_code="",
                         )
                     )
@@ -3500,7 +3571,7 @@ class BigQmtXtTrader:
                         error_msg="" if ok else "cancel_order_stock rejected by server",
                         order_sysid=str(order_sysid or ""),
                         order_sys_id=str(order_sysid or ""),
-                        order_id=str(order_sysid or ""),
+                        order_id=self._order_object_id(order_sysid),
                     ),
                 )
             except Exception:
@@ -3535,7 +3606,10 @@ class BigQmtXtTrader:
                 item.get("traded_price", item.get("avg_traded_price", item.get("m_dTradedPrice")))
             ),
             order_sysid=order_sysid,
-            order_id=order_sysid or str(item.get("user_order_id") or ""),
+            # MiniQMT: order_id is the int 委托编号, order_sysid the string
+            # 柜台编号. Both, from one 合同编号 (issue #113).
+            order_id=self._order_object_id(
+                order_sysid or str(item.get("user_order_id") or "")),
             strategy_name=str(item.get("strategy_name") or ""),
             order_remark=str(item.get("remark") or item.get("user_order_id") or ""),
             # MiniQMT XtOrder.order_time 是 Unix 秒。服务端订单事件只发
@@ -3563,7 +3637,7 @@ class BigQmtXtTrader:
             stock_code=_full_a_share_code(item.get("stock_code")),
             order_type=order_type,
             order_sysid=order_sysid,
-            order_id=order_sysid,
+            order_id=self._order_object_id(order_sysid),
             trade_id=trade_id,
             # MiniQMT 字段契约: traded_id/traded_time 是业务代码读取的名字。
             traded_id=trade_id,

--- a/tests/bigqmt_signal_trader/test_async_callback_order.py
+++ b/tests/bigqmt_signal_trader/test_async_callback_order.py
@@ -128,7 +128,7 @@ class AsyncCallbackOrderTest(unittest.TestCase):
 
         self.assertEqual(rec.names(), ["response", "order"])
         resp = rec.seen[0][1]
-        self.assertEqual(resp.order_id, "xt-real-1")
+        self.assertEqual(str(resp.order_id), "xt-real-1")
         self.assertEqual(resp.order_sysid, "xt-real-1")
 
     def test_response_falls_back_to_remark_when_no_id_learned(self):
@@ -143,7 +143,7 @@ class AsyncCallbackOrderTest(unittest.TestCase):
 
         resp = rec.seen[0][1]
         self.assertEqual(rec.names(), ["response"])
-        self.assertEqual(resp.order_id, "TAG-1")
+        self.assertEqual(str(resp.order_id), "TAG-1")
         self.assertEqual(resp.order_sysid, "")
 
 

--- a/tests/bigqmt_signal_trader/test_exec_events.py
+++ b/tests/bigqmt_signal_trader/test_exec_events.py
@@ -602,7 +602,7 @@ class ExecEventsClientDispatchTest(unittest.TestCase):
 
         self.assertEqual(len(cb.order_errors), 1)
         err = cb.order_errors[0]
-        self.assertEqual(err.order_id, "sys-err-1")
+        self.assertEqual(str(err.order_id), "sys-err-1")
         self.assertEqual(err.error_id, 2147483647)
         self.assertEqual(err.error_msg, "废单")
         self.assertEqual(err.stock_code, "600654.SH")
@@ -621,7 +621,7 @@ class ExecEventsClientDispatchTest(unittest.TestCase):
 
         self.assertEqual(len(cb.cancel_errors), 1)
         err = cb.cancel_errors[0]
-        self.assertEqual(err.order_id, "sys-cancel-1")
+        self.assertEqual(str(err.order_id), "sys-cancel-1")
         self.assertEqual(err.error_id, 99)
         self.assertEqual(err.error_msg, "撤单失败")
 
@@ -642,7 +642,7 @@ class ExecEventsClientDispatchTest(unittest.TestCase):
         err = cb.order_errors[0]
         self.assertEqual(err.order_sysid, "sys-err-1")
         self.assertEqual(err.order_sys_id, "sys-err-1")
-        self.assertEqual(err.order_id, "sys-err-1")
+        self.assertEqual(str(err.order_id), "sys-err-1")
         cerr = cb.cancel_errors[0]
         self.assertEqual(cerr.order_sysid, "sys-cancel-1")
         self.assertEqual(cerr.order_sys_id, "sys-cancel-1")
@@ -717,7 +717,7 @@ class ExecEventsClientDispatchTest(unittest.TestCase):
         self.assertGreater(seq, 0)
         self.assertEqual(len(cb.async_responses), 1)
         resp = cb.async_responses[0]
-        self.assertEqual(resp.order_id, "sys-ok-1")
+        self.assertEqual(str(resp.order_id), "sys-ok-1")
         self.assertEqual(resp.account_id, "acct")
         self.assertEqual(resp.seq, seq)
 
@@ -765,7 +765,7 @@ class ExecEventsClientDispatchTest(unittest.TestCase):
         self.assertEqual(len(cb.order_errors), 0)
         self.assertEqual(len(cb.async_responses), 1)
         resp = cb.async_responses[0]
-        self.assertEqual(resp.order_id, "u-1")  # 委托号未知时回退到 user_order_id
+        self.assertEqual(str(resp.order_id), "u-1")  # 委托号未知时回退到 user_order_id
         self.assertEqual(resp.order_sys_id, "")
 
     def test_order_stock_async_server_error_fires_order_error_with_reason(self):
@@ -800,7 +800,7 @@ class ExecEventsClientDispatchTest(unittest.TestCase):
         finally:
             trader.order_stock_result = original
 
-        self.assertEqual([r.order_id for r in cb.async_responses],
+        self.assertEqual([str(r.order_id) for r in cb.async_responses],
                          ["sys-A.SH", "sys-B.SH", "sys-C.SH"])
         self.assertEqual([r.seq for r in cb.async_responses],
                          sorted(r.seq for r in cb.async_responses))
@@ -810,7 +810,7 @@ class ExecEventsClientDispatchTest(unittest.TestCase):
         original = trader.cancel_order_stock_sysid
 
         def fake_cancel(account, market, sysid):
-            return True
+            return 0        # MiniQMT: 0 == success (issue #113)
 
         trader.cancel_order_stock_sysid = fake_cancel
         try:

--- a/tests/bigqmt_signal_trader/test_miniqmt_return_types.py
+++ b/tests/bigqmt_signal_trader/test_miniqmt_return_types.py
@@ -1,0 +1,253 @@
+"""Return types a MiniQMT caller depends on (issue #113).
+
+The bridge's whole promise is that code written against MiniQMT keeps working
+against Big QMT. Three returns broke that promise, and each broke it quietly --
+no exception, just a value of the wrong kind:
+
+    order_stock          MiniQMT: int (委托编号, or -1)   here: str 合同编号
+    cancel_order_stock   MiniQMT: int (0 ok, -1 fail)     here: bool
+    XtOrder.order_id     MiniQMT: int                     here: str
+
+The cancel one is the dangerous member of the family. MiniQMT code checks
+``if trader.cancel_order_stock(...) == 0``, and ``False == 0`` is True in
+Python -- so a *failed* cancel read as success, and a successful one read as
+failure. Silent, inverted, on the order path.
+
+Big QMT has no int order id to give: get_trade_detail_data returns
+``m_strOrderSysID``, a string. So the id here is both at once -- see OrderId.
+"""
+
+import json
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.order_id import OrderId, int_value_of
+from bigqmt_signal_trader.xtquant_compat import (
+    BigQmtXtTrader, FIX_PRICE, STOCK_BUY, StockAccount)
+
+
+ACCOUNT = "acct"
+
+
+class FakeClient(object):
+    """Answers the two order RPCs; records what was sent."""
+
+    def __init__(self, order_sys_id="123456", cancel_ok=True):
+        self.account_id = ACCOUNT
+        self.calls = []
+        self.local_cache_config = {}
+        self.full_tick_cache_config = {}
+        self._order_sys_id = order_sys_id
+        self._cancel_ok = cancel_ok
+
+    def call(self, method, params=None, account_id=None, timeout_seconds=None):
+        self.calls.append((method, dict(params or {})))
+        if method == "order_stock":
+            return {"order_sys_id": self._order_sys_id, "status": "SUBMITTED"}
+        if method == "cancel_order_stock_sysid":
+            return {"success": self._cancel_ok}
+        return {}
+
+    def _redis(self):
+        raise AssertionError("redis not expected here")
+
+
+def _trader(**kwargs):
+    trader = BigQmtXtTrader(account_id=ACCOUNT)
+    trader.client = FakeClient(**kwargs)
+    return trader
+
+
+def _order(trader):
+    return trader.order_stock(StockAccount(ACCOUNT), "600000.SH", STOCK_BUY,
+                              100, FIX_PRICE, 10.0, "s", "")
+
+
+class OrderStockReturnTest(unittest.TestCase):
+    def test_it_is_an_int(self):
+        self.assertIsInstance(_order(_trader()), int)
+
+    def test_a_numeric_id_keeps_its_number(self):
+        """The usual case: the 合同编号 is digits, so both halves agree."""
+        order_id = _order(_trader(order_sys_id="123456"))
+
+        self.assertEqual(order_id, 123456)
+        self.assertEqual(str(order_id), "123456")
+
+    def test_comparisons_a_miniqmt_caller_writes(self):
+        order_id = _order(_trader())
+
+        self.assertGreater(order_id, 0)
+        self.assertNotEqual(order_id, -1)
+
+    def test_the_broker_string_survives(self):
+        """An id that is not a number at all still has to reach a cancel."""
+        order_id = _order(_trader(order_sys_id="SYS-A1"))
+
+        self.assertEqual(str(order_id), "SYS-A1")
+        self.assertIsInstance(order_id, int)
+        self.assertGreater(order_id, 0)
+
+    def test_a_failed_submit_is_minus_one_as_an_int(self):
+        """The server sends "-1" as a *string*. Returned as one it is truthy
+        and never equal to -1, so the rejection read as success."""
+        order_id = _order(_trader(order_sys_id="-1"))
+
+        self.assertEqual(order_id, -1)
+        self.assertIsInstance(order_id, int)
+        self.assertNotIsInstance(order_id, str)
+
+    def test_an_empty_id_is_minus_one_too(self):
+        self.assertEqual(_order(_trader(order_sys_id="")), -1)
+
+    def test_it_formats_as_the_broker_id(self):
+        """f-strings and .format go through __format__, not __str__."""
+        order_id = _order(_trader(order_sys_id="SYS-A1"))
+
+        self.assertEqual("{}".format(order_id), "SYS-A1")
+        self.assertEqual("%s" % order_id, "SYS-A1")
+
+    def test_it_survives_json(self):
+        order_id = _order(_trader(order_sys_id="123456"))
+
+        self.assertEqual(json.loads(json.dumps({"id": order_id}))["id"], 123456)
+
+
+class CancelReturnTest(unittest.TestCase):
+    """0 on success, -1 on failure -- and never a bool."""
+
+    def test_success_is_zero(self):
+        trader = _trader(cancel_ok=True)
+
+        self.assertEqual(trader.cancel_order_stock(StockAccount(ACCOUNT), "x"), 0)
+
+    def test_failure_is_minus_one(self):
+        trader = _trader(cancel_ok=False)
+
+        self.assertEqual(trader.cancel_order_stock(StockAccount(ACCOUNT), "x"), -1)
+
+    def test_it_is_not_a_bool(self):
+        """False == 0 is True, so a bool return inverts every `== 0` check."""
+        ok = _trader(cancel_ok=True).cancel_order_stock(StockAccount(ACCOUNT), "x")
+        bad = _trader(cancel_ok=False).cancel_order_stock(StockAccount(ACCOUNT), "x")
+
+        self.assertNotIsInstance(ok, bool)
+        self.assertNotIsInstance(bad, bool)
+
+    def test_sysid_variant_matches(self):
+        trader = _trader(cancel_ok=True)
+
+        self.assertEqual(
+            trader.cancel_order_stock_sysid(StockAccount(ACCOUNT), "SH", "x"), 0)
+
+
+class CancelSendsTheBrokerIdTest(unittest.TestCase):
+    """Whatever int we derived, QMT must be given its own string back."""
+
+    def _sent_sysid(self, trader):
+        for method, params in reversed(trader.client.calls):
+            if method == "cancel_order_stock_sysid":
+                return params["order_sysid"]
+        raise AssertionError("no cancel call recorded")
+
+    def test_an_order_id_resolves_to_its_broker_string(self):
+        trader = _trader(order_sys_id="SYS-A1")
+        order_id = _order(trader)
+
+        trader.cancel_order_stock(StockAccount(ACCOUNT), order_id)
+
+        self.assertEqual(self._sent_sysid(trader), "SYS-A1")
+
+    def test_a_round_tripped_int_still_resolves(self):
+        """The caller stored the id in a database and got a plain int back."""
+        trader = _trader(order_sys_id="SYS-A1")
+        order_id = _order(trader)
+        bare_int = int(order_id)
+
+        trader.cancel_order_stock(StockAccount(ACCOUNT), bare_int)
+
+        self.assertEqual(self._sent_sysid(trader), "SYS-A1")
+
+    def test_a_plain_string_is_passed_through(self):
+        """Callers who never saw an OrderId keep working."""
+        trader = _trader()
+
+        trader.cancel_order_stock(StockAccount(ACCOUNT), "SYS-ELSEWHERE")
+
+        self.assertEqual(self._sent_sysid(trader), "SYS-ELSEWHERE")
+
+    def test_the_memory_is_bounded(self):
+        from bigqmt_signal_trader.xtquant_compat import _ORDER_ID_MEMORY
+
+        trader = _trader()
+        for index in range(_ORDER_ID_MEMORY + 50):
+            trader._order_object_id("SYS-%d" % index)
+
+        self.assertLessEqual(len(trader._order_sys_ids), _ORDER_ID_MEMORY)
+
+
+class OrderObjectIdTest(unittest.TestCase):
+    """XtOrder.order_id / XtTrade.order_id are ints in MiniQMT too."""
+
+    def test_an_order_carries_both_forms(self):
+        order = _trader()._order_from_dict(
+            ACCOUNT, {"order_sys_id": "SYS-9", "stock_code": "600000.SH"})
+
+        self.assertIsInstance(order.order_id, int)
+        self.assertEqual(str(order.order_id), "SYS-9")
+        self.assertEqual(order.order_sysid, "SYS-9")   # still the plain string
+
+    def test_a_trade_carries_both_forms(self):
+        trade = _trader()._trade_from_dict(
+            ACCOUNT, {"order_sys_id": "SYS-9", "stock_code": "600000.SH"})
+
+        self.assertIsInstance(trade.order_id, int)
+        self.assertEqual(str(trade.order_id), "SYS-9")
+
+    def test_a_missing_id_does_not_become_a_number(self):
+        order = _trader()._order_from_dict(ACCOUNT, {"stock_code": "600000.SH"})
+
+        self.assertEqual(int(order.order_id), 0)
+
+
+class LifecycleReturnTest(unittest.TestCase):
+    """These were already right; pinning them so they stay that way."""
+
+    def test_zero_means_success(self):
+        trader = _trader()
+
+        self.assertEqual(trader.start(), 0)
+        self.assertEqual(trader.connect(), 0)
+        self.assertEqual(trader.subscribe(StockAccount(ACCOUNT)), 0)
+        self.assertEqual(trader.unsubscribe(StockAccount(ACCOUNT)), 0)
+        trader.stop()
+
+
+class SurrogateTest(unittest.TestCase):
+    def test_it_is_stable(self):
+        """Same string, same number, in any process -- a caller comparing ids
+        across a restart still matches."""
+        self.assertEqual(int_value_of("SYS-A1"), int_value_of("SYS-A1"))
+
+    def test_it_is_positive(self):
+        for text in ("SYS-A1", "a", "0", "-5", "000123"):
+            self.assertGreater(int_value_of(text), 0, text)
+
+    def test_unicode_digits_are_not_parsed_as_a_number(self):
+        """int('１２３') == 123, which is not an id the broker ever issued."""
+        self.assertNotEqual(int_value_of(u"１２３"), 123)
+
+    def test_a_leading_zero_id_keeps_its_string(self):
+        self.assertEqual(str(OrderId("000123")), "000123")
+
+    def test_an_empty_id_has_no_number(self):
+        self.assertEqual(int_value_of(""), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_xtquant_compat.py
+++ b/tests/bigqmt_signal_trader/test_xtquant_compat.py
@@ -321,8 +321,12 @@ class XtquantCompatTest(unittest.TestCase):
         self.assertEqual(trades[0].order_type, STOCK_BUY)
         self.assertEqual(trades[0].traded_price, 10.0)
         self.assertEqual(trades[0].order_remark, "remark-1")
-        self.assertEqual(order_id, "sys-2")
-        self.assertTrue(cancelled)
+        # MiniQMT hands back an int 委托编号; Big QMT only has the broker's
+        # string 合同编号, so the id is both (issue #113).
+        self.assertEqual(str(order_id), "sys-2")
+        self.assertIsInstance(order_id, int)
+        self.assertGreater(order_id, 0)
+        self.assertEqual(cancelled, 0)      # 0 == success, not True
         self.assertEqual(trader.client.calls[-2][1]["price_type"], MARKET_PEER_PRICE_FIRST)
         # strategy_name 默认 ""（返回全部委托），与服务端一致（strategy_name 陷阱）。
         self.assertEqual(trader.client.calls[-4][1]["strategy_name"], "")

--- a/tests/bigqmt_signal_trader/test_xtquant_compat_contract.py
+++ b/tests/bigqmt_signal_trader/test_xtquant_compat_contract.py
@@ -194,7 +194,7 @@ class CallbackContractTest(unittest.TestCase):
         trader = self._trader(cb, client)
         trader.cancel_order_stock_async("acct", "sys-9")
         self.assertEqual(len(cb.cancel_errors), 1)
-        self.assertEqual(cb.cancel_errors[0].order_id, "sys-9")
+        self.assertEqual(str(cb.cancel_errors[0].order_id), "sys-9")
 
     def test_cancel_response_success_carries_cancel_result_and_error_msg(self):
         cb = _RecordingCallback()
@@ -205,7 +205,7 @@ class CallbackContractTest(unittest.TestCase):
         resp = cb.cancel_responses[0]
         self.assertEqual(resp.cancel_result, 0)
         self.assertEqual(resp.error_msg, "")
-        self.assertEqual(resp.order_id, "sys-9")
+        self.assertEqual(str(resp.order_id), "sys-9")
 
     def test_cancel_response_failure_carries_cancel_result_and_error_msg(self):
         cb = _RecordingCallback()
@@ -352,7 +352,8 @@ class QueryPathSerializationContractTest(unittest.TestCase):
         )
         item = to_jsonable(snapshot)
         order = self._trader()._order_from_dict("acct", item)
-        self.assertEqual(order.order_id, "sys-9")
+        self.assertEqual(str(order.order_id), "sys-9")
+        self.assertIsInstance(order.order_id, int)      # issue #113
         self.assertEqual(order.order_time, 1755655200)
         self.assertEqual(order.traded_price, 10.05)
         self.assertEqual(order.strategy_name, "strat-a")


### PR DESCRIPTION
关闭 #113。@tokens-lin 报的是 `order_stock` 返回字符串，顺着查了一遍整个接口面，同类问题有三处，其中一处比这个更糟。

| 接口 | MiniQMT | 修复前 |
|---|---|---|
| `order_stock()` | `int`（失败 -1） | `str` 合同编号 |
| `cancel_order_stock()` | `int`（0 成功，-1 失败） | `bool` |
| `XtOrder.order_id` | `int` | `str` |

**撤单那条是反的。** MiniQMT 的写法是 `if xt_trader.cancel_order_stock(...) == 0:`，而 Python 里 `False == 0` 为 True——所以撤单**失败**被读成成功，**成功**被读成失败。而且我们自己的异步回调早就在用 `cancel_result=0` 表示成功，等于同一套 API 的两半互相矛盾。

`order_stock` 还有一个边角：委托被拒时服务端返回的是**字符串** `"-1"`，它是 truthy 且永远不等于 -1，所以废单也被读成成功。

## 订单号为什么要特殊处理

大 QMT 根本没有 int 委托编号——`get_trade_detail_data` 只给 `m_strOrderSysID` 这个字符串。所以 `order_id` 做成了 int 子类，两种形态同时成立：

```python
order_id = xt_trader.order_stock(acc, "600000.SH", 23, 100, 11, 10.0, "s", "")

isinstance(order_id, int)   # True
order_id > 0                # True
str(order_id)               # '合同编号'，券商给的原始串
xt_trader.cancel_order_stock(acc, order_id)   # 撤单送回原始串，不是我们编的数
```

合同编号是纯数字时（多数券商）int 值就是那个数字，两边完全一致；不是纯数字时 int 是一个稳定的正数替身。存进数据库再取出来变成普通 int 也能撤单——客户端记着最近 4096 个映射。想要字符串用 `.order_sysid`，它一直是 str。

同样规则用在 `XtTrade.order_id` 和回调对象 `XtOrderError` / `XtCancelError` / `XtOrderResponse` 上。

## 测试

原有 4 个测试文件里 9 处断言把旧的字符串/布尔契约写死了——这正是 CLAUDE.md 里记的那个坑，测试和代码基于同一个错误前提，所以一直全绿。这些断言改成了 `str(...)` 而不是删掉。

新增 `test_miniqmt_return_types.py`，25 个用例；`git stash` 掉修复后**有 15 个变红**，确认它们测的是真东西。

726 通过，56/56 文件收集。

## 文档

issue 标题是「建议在说明文档加兼容性列表」，README 补了一节：返回值对照表、int/str 双形态订单号，以及几条会咬人的行为差异（`types=` 默认值、`account_type` 不会从客户端传到服务端、xtconstant 与 passorder 两套编号）。

## 未验证

撤单返回值需要一笔真实可撤委托才能实盘确认，本机没有。类型层面单测覆盖完整。

## 破坏性变更

如果你的代码写的是 `if xt_trader.cancel_order_stock(...):`，请改成 `== 0`。这是向 MiniQMT 契约靠拢的有意变更。
