### PR TITLE
Serialize a pandas Panel instead of reducing it to is_copy (#115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,10 +426,15 @@ python -m bigqmt_signal_trader.qmt_launcher restart --dir "D:\国金证券QMT交
 | `exe` | 直接起 `XtItClient.exe`，靠终端自身恢复会话 | 否 |
 | `login` | 起 exe 后向登录框输入账号密码 | 是，需 pywin32 |
 
-**关于「pywinauto/pyautogui 要求 Windows 处于登录状态」**：`login` 模式用的是
-`win32api.SendMessage` 直接投递到窗口句柄，不是 pyautogui 那种按屏幕坐标重放物理输入。
-前者不要求窗口置于前台，锁屏下也能工作（会话还在即可，完全注销则不行）。密码从
-环境变量 `BIGQMT_LOGIN_USER` / `BIGQMT_LOGIN_PASSWORD` 读，不走命令行参数——argv
+**`login` 模式需要未锁屏的交互式桌面。** 它用的是 `keybd_event` / `mouse_event`
+物理输入（经 ctypes），不是 `SendMessage`——消息式输入投不到 Qt 对话框的焦点控件上，
+当别的窗口在前台时会静默失败，什么也不输入。物理输入要求对话框在最前，所以启动前会
+先把它置顶并核验；锁屏或 RDP 注销的会话直接抛 `QmtLauncherError` 而不是打一半密码。
+
+> 需要**无人值守定时重启**的话，用 `linkmini` / `bat` / `exe` 三种模式，它们不碰登录框，
+> 锁屏也能跑。只有 `login` 受这条限制。
+
+密码从环境变量 `BIGQMT_LOGIN_USER` / `BIGQMT_LOGIN_PASSWORD` 读，不走命令行参数——argv
 对同机任何进程可见。
 
 两个设计要点：

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -341,6 +341,29 @@ def to_jsonable(value):
             }
         except Exception:
             return str(value)
+    # pandas Panel (3-D). QMT ships pandas 0.22, where get_financial_data with
+    # several stocks AND several dates still returns one. A Panel has no
+    # .columns and no .index, so it falls past the DataFrame and Series
+    # branches all the way to the __dict__ fallback -- and vars(panel) is
+    # {'_data': ..., 'is_copy': None}, which the underscore filter reduces to
+    # {'is_copy': None}. That is exactly what callers got back (issue #115):
+    # not an error, just the one public attribute the object happened to have.
+    #
+    # pandas removed Panel in 1.0, so the client cannot rebuild one even if we
+    # sent the axes. Send a DataFrame per item instead; it arrives as a dict.
+    if (hasattr(value, "major_axis") and hasattr(value, "minor_axis")
+            and hasattr(value, "items") and not isinstance(value, dict)):
+        try:
+            labels = [str(item) for item in value.items]
+            return {
+                "__bigqmt_type__": "Panel",
+                "items": labels,
+                "major_axis": [str(item) for item in value.major_axis],
+                "minor_axis": [str(item) for item in value.minor_axis],
+                "data": {str(item): to_jsonable(value[item]) for item in value.items},
+            }
+        except Exception:
+            return str(value)
     if hasattr(value, "tolist") and not isinstance(value, (str, bytes, bytearray)):
         try:
             return to_jsonable(value.tolist())

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -364,6 +364,13 @@ def _restore_jsonable(value):
                 return pd.DataFrame(value.get("records") or [], columns=value.get("columns") or None)
             except Exception:
                 return value.get("records") or []
+        if marker == "Panel":
+            # pandas dropped Panel in 1.0, so a 3-D object cannot be rebuilt on
+            # a modern client. It comes back as what a caller can actually use:
+            # {item: DataFrame} (issue #115). The axis labels ride along for
+            # anyone who needs to know how the cube was sliced.
+            return {key: _restore_jsonable(item)
+                    for key, item in (value.get("data") or {}).items()}
         if marker == "Series":
             try:
                 import pandas as pd

--- a/tests/bigqmt_signal_trader/test_panel_serialization.py
+++ b/tests/bigqmt_signal_trader/test_panel_serialization.py
@@ -1,0 +1,152 @@
+"""A pandas Panel must survive the RPC (issue #115).
+
+QMT ships pandas 0.22, where ``get_financial_data`` with several stocks AND
+several dates returns a Panel -- the 3-D container pandas removed in 1.0. A
+Panel has no ``.columns`` and no ``.index``, so it fell past to_jsonable's
+DataFrame and Series branches to the ``__dict__`` fallback, and
+``vars(panel)`` is ``{'_data': ..., 'is_copy': None}``. After the
+underscore filter that leaves ``{'is_copy': None}``.
+
+So the caller got no error and no data -- just the one public attribute the
+object happened to have. One stock, or one date, returns a DataFrame and
+worked fine, which is why this hid for so long.
+
+The client runs modern pandas and cannot rebuild a Panel, so it comes back as
+``{item: DataFrame}``.
+"""
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.redis_rpc import to_jsonable
+from bigqmt_signal_trader.xtquant_compat import _restore_jsonable
+
+
+class FakePanel(object):
+    """pandas 0.22's Panel, to the extent to_jsonable can see it.
+
+    Written by hand because pandas >= 1.0 has no Panel to import, and this test
+    has to run on the client's pandas as well as QMT's.
+    """
+
+    def __init__(self, frames, major_axis, minor_axis):
+        self._frames = frames                      # {item: FakeFrame}
+        self.items = list(frames.keys())
+        self.major_axis = list(major_axis)
+        self.minor_axis = list(minor_axis)
+        self.is_copy = None                        # the attribute that leaked
+
+    def __getitem__(self, item):
+        return self._frames[item]
+
+
+class FakeFrame(object):
+    """Enough of a DataFrame for to_jsonable's duck-typed branch."""
+
+    def __init__(self, records, columns):
+        self._records = records
+        self.columns = columns
+        self.index = list(range(len(records)))
+
+    def reset_index(self):
+        return self
+
+    def to_dict(self, orient=None):
+        return list(self._records)
+
+
+def _panel():
+    columns = ["total_capital", "circulating_capital"]
+    return FakePanel(
+        {
+            "000001.SZ": FakeFrame(
+                [{"total_capital": 1.0, "circulating_capital": 2.0}], columns),
+            "000017.SZ": FakeFrame(
+                [{"total_capital": 3.0, "circulating_capital": 4.0}], columns),
+        },
+        major_axis=["20260101", "20260830"],
+        minor_axis=columns,
+    )
+
+
+class ServerSideTest(unittest.TestCase):
+    def test_a_panel_is_no_longer_reduced_to_is_copy(self):
+        payload = to_jsonable(_panel())
+
+        self.assertNotEqual(payload, {"is_copy": None})
+        self.assertEqual(payload["__bigqmt_type__"], "Panel")
+
+    def test_every_item_is_carried(self):
+        payload = to_jsonable(_panel())
+
+        self.assertEqual(sorted(payload["data"]), ["000001.SZ", "000017.SZ"])
+
+    def test_each_item_is_a_dataframe_payload(self):
+        payload = to_jsonable(_panel())
+        first = payload["data"]["000001.SZ"]
+
+        self.assertEqual(first["__bigqmt_type__"], "DataFrame")
+        self.assertEqual(first["records"],
+                         [{"total_capital": 1.0, "circulating_capital": 2.0}])
+
+    def test_the_axes_ride_along(self):
+        """So a caller can tell how the cube was sliced."""
+        payload = to_jsonable(_panel())
+
+        self.assertEqual(payload["major_axis"], ["20260101", "20260830"])
+        self.assertEqual(payload["minor_axis"],
+                         ["total_capital", "circulating_capital"])
+
+    def test_a_dict_is_not_mistaken_for_a_panel(self):
+        """dict has .items too -- only the axes tell them apart."""
+        payload = to_jsonable({"items": 1, "a": 2})
+
+        self.assertEqual(payload, {"items": 1, "a": 2})
+
+    def test_a_broken_panel_does_not_take_the_rpc_down(self):
+        class Exploding(FakePanel):
+            def __getitem__(self, item):
+                raise RuntimeError("no data")
+
+        payload = to_jsonable(Exploding({"a": None}, [], []))
+
+        self.assertIsInstance(payload, str)
+
+
+class RoundTripTest(unittest.TestCase):
+    """What the caller actually ends up with."""
+
+    def _restored(self):
+        return _restore_jsonable(to_jsonable(_panel()))
+
+    def test_it_is_a_dict_keyed_by_item(self):
+        restored = self._restored()
+
+        self.assertEqual(sorted(restored), ["000001.SZ", "000017.SZ"])
+
+    def test_the_values_are_dataframes(self):
+        try:
+            import pandas as pd
+        except ImportError:
+            self.skipTest("pandas not installed")
+
+        restored = self._restored()
+
+        self.assertIsInstance(restored["000001.SZ"], pd.DataFrame)
+        self.assertEqual(list(restored["000001.SZ"]["total_capital"]), [1.0])
+
+    def test_a_dataframe_still_round_trips_unchanged(self):
+        """The new branch sits above the DataFrame one; make sure it did not
+        swallow the two-dimensional case."""
+        payload = to_jsonable(FakeFrame([{"a": 1}], ["a"]))
+
+        self.assertEqual(payload["__bigqmt_type__"], "DataFrame")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
关闭 #115。@jerry87n 的诊断完全正确，包括根因和建议的落点。

## 确认

`to_jsonable` 里没有 Panel 分支。Panel 既没有 `.columns` 也没有 `.index`，所以它一路穿过 DataFrame 分支、Series 分支，落到最后的 `__dict__` 兜底——而 `vars(panel)` 是 `{'_data': ..., 'is_copy': None}`，下划线过滤之后正好剩 `{'is_copy': None}`。

不报错、没数据，只剩这个对象恰好有的那一个公开属性。单股或单日期返回的是 DataFrame，走得通，所以这个坑藏了很久。

## 怎么修的

加了 Panel 分支，放在 `tolist` 分支之前。**pandas 1.0 已经删掉了 Panel**，所以客户端就算拿到三个轴也重建不出来——现在返回的是客户端真正能用的形态：

```python
{"000001.SZ": DataFrame, "000017.SZ": DataFrame}
```

轴标签（`items` / `major_axis` / `minor_axis`）也一并带回，需要知道立方体是怎么切的可以看。

`dict` 也有 `.items`，所以判定用的是 `major_axis` + `minor_axis` 两个轴属性，普通 dict 不会被误判——有测试钉住。

## 测试

新增 9 个用例，`git stash` 掉修复后**红 6 个**。

Panel 的测试替身是手写的：pandas ≥ 1.0 根本 import 不到 Panel，而这个测试既要在客户端的 pandas 上跑，也要在 QMT 的 pandas 上跑。

735 通过。

## 顺带修的文档

README 里 `qmt_launcher` 那节说 `login` 模式用 `win32api.SendMessage`、锁屏下也能工作。**代码从 #45 起就是反的**——它用的是 `keybd_event` 物理输入，要求对话框在前台，并且 `session_is_locked()` 为真时直接抛异常拒绝执行。这条对想做无人值守定时重启的人有实际影响（见 #116），所以一起改了：要无人值守就用 `linkmini` / `bat` / `exe`，只有 `login` 受限。

## 未验证

这个修复跑在 QMT 里，需要部署 + 重启策略之后，用一次多股多日期的真实调用才能确认。@jerry87n 你那边方便的话，升级并重启后跑一下你原来那行：

```python
xtdata.get_financial_data(stock_list=['000017.SZ', '000001.SZ'],
                          table_list=['CAPITALSTRUCTURE'],
                          start_time="20260101", end_time="20260830")
```

应该返回一个以股票代码为键、值是 DataFrame 的 dict。

> 注意这次改的是**服务端**（`redis_rpc.py` 跑在 QMT 里），只 `pip install --upgrade` 不够，要把包拷进 QMT 的 python 目录并**重启策略**。`xt_trader.sync_deployment()` 可以自动拷（不碰 config）。
