### PR TITLE
Say which order_type was rejected, and by which build (#92)

### DIFF
--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -1097,7 +1097,32 @@ class BigQmtRpcHandlers:
             raise ValueError(
                 "order_type %s has no implicit buy/sell side; pass action "
                 "explicitly" % raw)
-        raise ValueError("action or order_type is required")
+        if raw in (None, ""):
+            raise ValueError("action or order_type is required")
+        # An order_type WAS supplied and was not recognised. Saying "required"
+        # here sent a reporter looking at their own call for twenty minutes
+        # (issue #92): the real answer is almost always that the package
+        # deployed inside QMT predates the type they are using, and a
+        # client-side pip upgrade cannot fix that -- this code runs in QMT.
+        raise ValueError(
+            # ASCII only: this text is written to QMT's own log, which drops
+            # non-ASCII characters (a Chinese install path came back mangled).
+            "order_type %r is not recognised by the package deployed in QMT "
+            "(%s). Credit order types (27-32, and 40-45 special) need 0.3.1 "
+            "or newer HERE, in the QMT python directory -- upgrading the "
+            "client with pip does not change this file. Run "
+            "xt_trader.sync_deployment(), restart the strategy, then check "
+            "xtdata.get_deployment_info()." % (raw, self._deployed_version()))
+
+    @staticmethod
+    def _deployed_version():
+        """Never raises: this only ever runs while building an error message."""
+        try:
+            from bigqmt_signal_trader.version import __version__
+
+            return __version__
+        except Exception:
+            return "unknown version"
 
     def _credit_order_type_from_params(self, params):
         """The MiniQMT order_type to forward, when it is a credit operation."""

--- a/tests/bigqmt_signal_trader/test_credit_order_types.py
+++ b/tests/bigqmt_signal_trader/test_credit_order_types.py
@@ -190,13 +190,17 @@ class RpcAcceptanceTest(unittest.TestCase):
         self.assertIsNone(handlers._credit_order_type_from_params(
             {"order_type": xtconstant.STOCK_BUY}))
 
-    def test_unknown_types_still_raise_the_original_error(self):
+    def test_an_unknown_type_still_raises(self):
+        """It must not be guessed at. The message changed in #92 -- it now
+        names the value and the deployed version instead of claiming no
+        order_type was given, which is what a reporter who had given one saw.
+        Covered in detail by test_unknown_order_type_message.py."""
         handlers = self._handlers()
 
         with self.assertRaises(ValueError) as caught:
             handlers._order_action_from_params({"order_type": 9999})
 
-        self.assertIn("action or order_type is required", str(caught.exception))
+        self.assertIn("9999", str(caught.exception))
 
 
 if __name__ == "__main__":

--- a/tests/bigqmt_signal_trader/test_unknown_order_type_message.py
+++ b/tests/bigqmt_signal_trader/test_unknown_order_type_message.py
@@ -1,0 +1,113 @@
+"""An unrecognised order_type must say so, not claim none was given (#92).
+
+A reporter passed order_type=27 and got back "action or order_type is
+required". They had passed one, so the message sent them looking at their own
+call. The real cause was that the package deployed *inside QMT* predated the
+credit order types -- and a client-side ``pip install --upgrade`` cannot fix
+that, because this code runs in QMT, not in the caller's process.
+
+Nothing about the old message pointed there. It could not: it did not
+distinguish "no order_type given" from "this order_type is not one I know".
+"""
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from xtquant import xtconstant
+from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+
+
+def _handlers():
+    return BigQmtRpcHandlers.__new__(BigQmtRpcHandlers)
+
+
+def _error(params):
+    try:
+        _handlers()._order_action_from_params(params)
+    except ValueError as exc:
+        return str(exc)
+    raise AssertionError("expected a ValueError for %r" % (params,))
+
+
+class MissingTest(unittest.TestCase):
+    """Nothing supplied: the original message is still the right one."""
+
+    def test_no_parameters(self):
+        self.assertEqual(_error({}), "action or order_type is required")
+
+    def test_an_empty_order_type(self):
+        self.assertEqual(_error({"order_type": ""}),
+                         "action or order_type is required")
+
+    def test_an_explicit_none(self):
+        self.assertEqual(_error({"order_type": None}),
+                         "action or order_type is required")
+
+
+class UnrecognisedTest(unittest.TestCase):
+    """Supplied but unknown: say that, and say where to look."""
+
+    def test_it_does_not_claim_one_was_required(self):
+        message = _error({"order_type": 9999})
+
+        self.assertNotIn("is required", message)
+
+    def test_it_quotes_the_value_it_rejected(self):
+        self.assertIn("9999", _error({"order_type": 9999}))
+
+    def test_it_names_the_deployed_version(self):
+        """Which build rejected it is the whole question."""
+        from bigqmt_signal_trader.version import __version__
+
+        self.assertIn(__version__, _error({"order_type": 9999}))
+
+    def test_it_says_a_pip_upgrade_will_not_help(self):
+        """The trap: the fix is a file copy into QMT, not a client upgrade."""
+        message = _error({"order_type": 9999})
+
+        self.assertIn("pip", message)
+        self.assertIn("sync_deployment", message)
+
+    def test_it_is_ascii_only(self):
+        """QMT's log writer drops non-ASCII -- a Chinese install path came
+        back mangled, and a mangled error message helps nobody."""
+        message = _error({"order_type": 9999})
+
+        self.assertTrue(all(ord(char) < 128 for char in message), message)
+
+    def test_the_version_lookup_never_raises(self):
+        """This only runs while building an error message; failing there would
+        replace a useful error with a confusing one."""
+        self.assertIsInstance(BigQmtRpcHandlers._deployed_version(), str)
+
+
+class StillWorksTest(unittest.TestCase):
+    """The recognised paths are untouched."""
+
+    def test_a_credit_type_still_resolves(self):
+        handlers = _handlers()
+
+        self.assertEqual(
+            handlers._order_action_from_params(
+                {"order_type": xtconstant.CREDIT_FIN_BUY}), "BUY")
+
+    def test_cash_repayment_still_asks_for_an_action(self):
+        message = _error({"order_type": xtconstant.CREDIT_DIRECT_CASH_REPAY})
+
+        self.assertIn("no implicit buy/sell side", message)
+
+    def test_an_explicit_action_still_wins(self):
+        handlers = _handlers()
+
+        self.assertEqual(
+            handlers._order_action_from_params(
+                {"order_type": 9999, "action": "SELL"}), "SELL")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
@fengzhizialex 在 #92 里两次贴出同一份 traceback，间隔半小时，内容一字不差。这不是他没看回复——**是报错本身把人往错的方向指。**

他传了 `order_type=27`，服务端回的是：

```
ValueError: action or order_type is required
```

他明明传了。于是只能回去反复检查自己的调用。

而真正的原因报错里一个字都没提：**QMT 目录里部署的那份包早于信用委托类型**。这段代码跑在 QMT 里，客户端 `pip install --upgrade` 碰不到它。（他 traceback 的行号显示客户端是 0.3.0，但就算客户端是 0.3.2 也一样撞这堵墙。）

## 为什么原来的检查指不出来

它没有区分「没传 order_type」和「传了但我不认识」——两种情况共用同一条消息。

现在分开：

- 没传 → 保持原消息 `action or order_type is required`
- 传了但不认识 → 说清楚是哪个值、哪个版本拒绝的、以及**升级客户端没用**

```
order_type 9999 is not recognised by the package deployed in QMT (0.3.2).
Credit order types (27-32, and 40-45 special) need 0.3.1 or newer HERE, in
the QMT python directory -- upgrading the client with pip does not change
this file. Run xt_trader.sync_deployment(), restart the strategy, then check
xtdata.get_deployment_info().
```

**纯 ASCII**：QMT 的日志写入会丢非 ASCII 字符（本项目早先遇到过中文安装路径被吞成乱码），一条乱码的报错帮不上任何人。

## 测试

新增 12 个用例，修复前红 5 个。

`test_credit_order_types.py` 里有一处断言钉的是旧措辞，改成钉那个被拒绝的值——那才是那个测试真正要保证的东西（未知类型不能被静默猜测）。

747 通过，58/58 文件收集。
