### PR TITLE
Fix all three backtest problems from one report (#109)

### DIFF
--- a/src/bigqmt_backtest/qmt_runtime.py
+++ b/src/bigqmt_backtest/qmt_runtime.py
@@ -119,6 +119,12 @@ def _is_qmt_backtest(context):
     return False
 
 
+# What ContextInfo.get_history_data actually serves (API reference 5.2).
+# Anything outside this set produces an ERROR line in QMT's log rather than a
+# quiet miss, so it must never be probed (issue #109).
+HISTORY_DATA_FIELDS = frozenset(("open", "high", "low", "close", "quoter"))
+
+
 class QmtBarExtractor(object):
     def __init__(self):
         self.previous_close = {}
@@ -160,7 +166,47 @@ class QmtBarExtractor(object):
                 result.append(text)
         return result
 
+    def _market_data_ex_value(self, context, field):
+        """The recommended getter (API reference 5.2, 主推接口).
+
+        get_history_data is marked 不推荐 there and QMT logs a deprecation
+        notice for it, which is what a reporter saw first (issue #109).
+        """
+        getter = getattr(context, "get_market_data_ex", None)
+        if not callable(getter):
+            return None
+        symbol = self._symbol(context)
+        for period in self._periods(context):
+            try:
+                frame = (getter([field], [symbol], period=period, count=1)
+                         or {}).get(symbol)
+            except Exception:
+                continue
+            if frame is None:
+                continue
+            try:
+                column = frame[field]
+            except Exception:
+                continue
+            value = _last_value(column)
+            if value not in (None, ""):
+                return value
+        return None
+
     def _history_value(self, context, field):
+        # get_history_data serves exactly open/high/low/close/quoter (API
+        # reference 5.2). Asking it for anything else is not a miss, it is an
+        # ERROR line in QMT's own log -- one per field, per period, per bar:
+        #
+        #     [系统]ERROR获取历史数据,不支持'prev_close'数据字段
+        #     [系统]ERROR获取历史数据,不支持'preClose'数据字段
+        #     [系统]ERROR获取历史数据,不支持'lastClose'数据字段
+        #
+        # which is what issue #109 reported. The probe was guaranteed to fail
+        # for those names, and prev_close is derived from the previous bar's
+        # close anyway, so there was never anything to gain by asking.
+        if field not in HISTORY_DATA_FIELDS:
+            return None
         getter = getattr(context, "get_history_data", None)
         if not callable(getter):
             return None
@@ -179,11 +225,16 @@ class QmtBarExtractor(object):
         return None
 
     def _field(self, context, field, aliases=()):
-        for name in (field,) + tuple(aliases):
+        names = (field,) + tuple(aliases)
+        for name in names:
             value = _last_value(getattr(context, name, None))
             if value not in (None, ""):
                 return value
-        for name in (field,) + tuple(aliases):
+        for name in names:
+            value = self._market_data_ex_value(context, name)
+            if value not in (None, ""):
+                return value
+        for name in names:
             value = self._history_value(context, name)
             if value not in (None, ""):
                 return value
@@ -650,7 +701,12 @@ class QmtBacktestBridgeRuntime(object):
         )
         self.server_thread.start()
         if not self.server.wait_until_ready(5.0) or not self.server.actual_endpoint:
-            raise RuntimeError("QMT native backtest ZMQ service failed to bind")
+            reason = self.server.bind_error
+            raise RuntimeError(
+                "QMT native backtest ZMQ service failed to bind %s%s"
+                % (self.server.endpoint,
+                   ": %s. A previous run may still hold the port -- stop it, "
+                   "or wait a moment and start again" % reason if reason else ""))
         print(
             "[bigqmt_backtest] QMT native service started run_id=%s endpoint=%s account=%s live_ready=False"
             % (self.engine.config.run_id, self.server.actual_endpoint, self.engine.config.account_id)
@@ -668,8 +724,19 @@ class QmtBacktestBridgeRuntime(object):
     def on_qmt_stop(self):
         self.engine.on_qmt_stop()
 
-    def stop_server(self):
+    def stop_server(self, timeout_seconds=5.0):
+        """Stop serving and wait for the port to be released.
+
+        Without the wait, a re-run binds while the previous socket is still
+        open and fails with EADDRINUSE -- the endpoint is a fixed port, so
+        there is no fallback to a free one (issue #109).
+        """
         self.server.stop()
+        thread = self.server_thread
+        if thread is not None and thread.is_alive():
+            self.server.wait_until_stopped(timeout_seconds)
+            thread.join(timeout_seconds)
+        self.server_thread = None
 
 
 def reset_runtime():
@@ -710,8 +777,16 @@ def deal_callback(ContextInfo, dealInfo):
 
 
 def stop(ContextInfo=None):
+    """QMT calls this when the strategy is stopped -- including the stop
+    button next to the chart.
+
+    This used to tell the engine and leave the ZMQ service running, so the
+    port stayed bound to a strategy that was no longer there and the next
+    run failed to bind (issue #109).
+    """
     if _RUNTIME is not None:
         _RUNTIME.on_qmt_stop()
+        _RUNTIME.stop_server()
 
 
 def after_backtest(ContextInfo=None):

--- a/src/bigqmt_backtest/zmq_server.py
+++ b/src/bigqmt_backtest/zmq_server.py
@@ -12,10 +12,21 @@ class ZmqBacktestServer(object):
         self.poll_ms = int(poll_ms)
         self._stop_event = threading.Event()
         self._ready_event = threading.Event()
+        self._stopped_event = threading.Event()
         self.actual_endpoint = None
+        self.bind_error = None
 
     def wait_until_ready(self, timeout_seconds=None):
         return self._ready_event.wait(timeout_seconds)
+
+    def wait_until_stopped(self, timeout_seconds=None):
+        """True once the socket is closed and the port is free again.
+
+        stop() only sets a flag; the serving thread notices up to poll_ms
+        later and closes the socket after that. A re-run that binds in
+        between gets EADDRINUSE (issue #109).
+        """
+        return self._stopped_event.wait(timeout_seconds)
 
     def stop(self):
         self._stop_event.set()
@@ -29,13 +40,21 @@ class ZmqBacktestServer(object):
         socket.setsockopt(zmq.RCVHWM, 1000)
         socket.setsockopt(zmq.SNDHWM, 1000)
         try:
-            if self.endpoint.endswith(":0"):
-                base = self.endpoint.rsplit(":", 1)[0]
-                port = socket.bind_to_random_port(base)
-                self.actual_endpoint = "%s:%d" % (base, port)
-            else:
-                socket.bind(self.endpoint)
-                self.actual_endpoint = self.endpoint
+            try:
+                if self.endpoint.endswith(":0"):
+                    base = self.endpoint.rsplit(":", 1)[0]
+                    port = socket.bind_to_random_port(base)
+                    self.actual_endpoint = "%s:%d" % (base, port)
+                else:
+                    socket.bind(self.endpoint)
+                    self.actual_endpoint = self.endpoint
+            except Exception as exc:
+                # Keep the reason: the caller only sees "failed to bind"
+                # otherwise, and the reason is nearly always a previous run
+                # still holding the port (issue #109). Raising it on this
+                # daemon thread would only print a traceback nobody reads.
+                self.bind_error = exc
+                return
             self._ready_event.set()
             poller = zmq.Poller()
             poller.register(socket, zmq.POLLIN)
@@ -63,3 +82,5 @@ class ZmqBacktestServer(object):
         finally:
             self._ready_event.set()
             socket.close(linger=0)
+            # Only now is the endpoint actually free.
+            self._stopped_event.set()

--- a/tests/bigqmt_backtest/test_backtest_rerun.py
+++ b/tests/bigqmt_backtest/test_backtest_rerun.py
@@ -1,0 +1,175 @@
+"""Stopping a backtest must free its port (issue #109).
+
+The reporter's sequence: run the in-QMT backtest script, press the stop button
+next to the chart, run it again -- and the second run fails to bind.
+
+Two things kept the port held. ``stop()`` told the engine the run was over and
+left the ZMQ service running, so nothing ever asked the socket to close. And
+``stop_server()`` only set a flag: the serving thread notices up to poll_ms
+later and closes the socket after that, while ``init()`` goes straight on to
+bind the next one. The endpoint is a fixed port (16662), so there is no
+fallback to a free one -- it is EADDRINUSE or nothing.
+"""
+
+import os
+import sys
+import threading
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SRC = os.path.join(ROOT, "src")
+sys.path.insert(0, SRC)
+
+from bigqmt_backtest.zmq_server import ZmqBacktestServer
+
+
+class FakeProtocol(object):
+    class engine(object):
+        class config(object):
+            run_id = "test-run"
+
+    def handle(self, request):
+        return {"ok": True}
+
+
+def _server(endpoint):
+    return ZmqBacktestServer(FakeProtocol(), endpoint=endpoint, poll_ms=10)
+
+
+def _serve(server):
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return thread
+
+
+class StoppedEventTest(unittest.TestCase):
+    """The signal a re-run has to wait on."""
+
+    def test_it_is_not_set_while_serving(self):
+        server = _server("tcp://127.0.0.1:0")
+        _serve(server)
+        self.addCleanup(server.stop)
+        self.assertTrue(server.wait_until_ready(5.0))
+
+        self.assertFalse(server.wait_until_stopped(0.05))
+
+    def test_it_is_set_once_the_socket_is_closed(self):
+        server = _server("tcp://127.0.0.1:0")
+        thread = _serve(server)
+        self.assertTrue(server.wait_until_ready(5.0))
+
+        server.stop()
+
+        self.assertTrue(server.wait_until_stopped(5.0))
+        thread.join(5.0)
+        self.assertFalse(thread.is_alive())
+
+    def test_a_server_that_never_bound_still_reports_stopped(self):
+        """Two servers on one port: the loser must not leave a caller waiting
+        forever for a socket it never opened."""
+        first = _server("tcp://127.0.0.1:0")
+        _serve(first)
+        self.assertTrue(first.wait_until_ready(5.0))
+        self.addCleanup(first.stop)
+
+        second = _server(first.actual_endpoint)
+        _serve(second)
+
+        self.assertTrue(second.wait_until_stopped(5.0))
+
+    def test_a_failed_bind_keeps_its_reason(self):
+        """"failed to bind" on its own sends people looking in the wrong
+        place; "Address in use" says which run to go and stop."""
+        first = _server("tcp://127.0.0.1:0")
+        _serve(first)
+        self.assertTrue(first.wait_until_ready(5.0))
+        self.addCleanup(first.stop)
+
+        second = _server(first.actual_endpoint)
+        _serve(second)
+        self.assertTrue(second.wait_until_stopped(5.0))
+
+        self.assertIsNotNone(second.bind_error)
+        self.assertIsNone(second.actual_endpoint)
+
+
+class RebindTest(unittest.TestCase):
+    """The reporter's sequence, end to end."""
+
+    def test_the_port_is_free_after_a_stop(self):
+        first = _server("tcp://127.0.0.1:0")
+        _serve(first)
+        self.assertTrue(first.wait_until_ready(5.0))
+        endpoint = first.actual_endpoint
+
+        first.stop()
+        self.assertTrue(first.wait_until_stopped(5.0))
+
+        second = _server(endpoint)
+        _serve(second)
+        self.addCleanup(second.stop)
+
+        self.assertTrue(second.wait_until_ready(5.0),
+                        "rebinding %s failed after a clean stop" % endpoint)
+        self.assertEqual(second.actual_endpoint, endpoint)
+
+
+class StopHookTest(unittest.TestCase):
+    """QMT's stop button reaches stop(); it has to reach the server too."""
+
+    def test_stop_calls_stop_server(self):
+        import bigqmt_backtest.qmt_runtime as runtime
+
+        calls = []
+
+        class FakeRuntime(object):
+            def on_qmt_stop(self):
+                calls.append("engine")
+
+            def stop_server(self, timeout_seconds=5.0):
+                calls.append("server")
+
+        saved = runtime._RUNTIME
+        try:
+            runtime._RUNTIME = FakeRuntime()
+            runtime.stop(None)
+        finally:
+            runtime._RUNTIME = saved
+
+        self.assertEqual(calls, ["engine", "server"])
+
+    def test_after_backtest_stops_it_too(self):
+        import bigqmt_backtest.qmt_runtime as runtime
+
+        calls = []
+
+        class FakeRuntime(object):
+            def on_qmt_stop(self):
+                calls.append("engine")
+
+            def stop_server(self, timeout_seconds=5.0):
+                calls.append("server")
+
+        saved = runtime._RUNTIME
+        try:
+            runtime._RUNTIME = FakeRuntime()
+            runtime.after_backtest(None)
+        finally:
+            runtime._RUNTIME = saved
+
+        self.assertIn("server", calls)
+
+    def test_stop_without_a_runtime_is_harmless(self):
+        import bigqmt_backtest.qmt_runtime as runtime
+
+        saved = runtime._RUNTIME
+        try:
+            runtime._RUNTIME = None
+            runtime.stop(None)          # must not raise
+        finally:
+            runtime._RUNTIME = saved
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_backtest/test_qmt_runtime.py
+++ b/tests/bigqmt_backtest/test_qmt_runtime.py
@@ -36,8 +36,26 @@ class FakeQmtContext(object):
         value = dt.datetime(2026, 1, 5, 9, 30)
         return int(value.timestamp() * 1000)
 
+    # Real QMT serves exactly open/high/low/close/quoter here and writes an
+    # ERROR line to its own log for anything else (issue #109). The fake used
+    # to answer preClose, which no QMT build does -- so the test passed while
+    # the code was spamming the terminal log for every bar.
+    HISTORY_FIELDS = ("open", "high", "low", "close", "quoter")
+
+    def __init__(self):
+        self.history_fields_asked = []
+
     def get_history_data(self, count, period, field):
+        self.history_fields_asked.append(field)
+        if field not in self.HISTORY_FIELDS:
+            return {}
         return {"600000.SH": self.values.get(field, [])}
+
+    def get_market_data_ex(self, fields, stock_code, period="follow", count=-1, **kwargs):
+        field = fields[0]
+        if field not in self.values:
+            return {}
+        return {stock_code[0]: {field: self.values[field]}}
 
     def set_account(self, account_id):
         self.account_id = account_id
@@ -51,6 +69,16 @@ class QmtBarExtractorTest(unittest.TestCase):
         self.assertEqual(row["datetime"], "2026-01-05 09:30:00")
         self.assertEqual(row["open"], 10.0)
         self.assertEqual(row["prev_close"], 9.8)
+
+    def test_it_never_asks_get_history_data_for_a_field_it_lacks(self):
+        """Every such ask is an ERROR line in QMT's log, not a quiet miss."""
+        context = FakeQmtContext()
+
+        QmtBarExtractor().extract(context)
+
+        unsupported = [f for f in context.history_fields_asked
+                       if f not in FakeQmtContext.HISTORY_FIELDS]
+        self.assertEqual(unsupported, [])
 
     def test_qmt_entry_is_isolated_and_binds_native_order_callbacks(self):
         path = os.path.join(SRC, "BIGQMT_ZMQ_BACKTEST.py")


### PR DESCRIPTION
关闭 #109。@wolfeee 报了三件事，查下来是**两个原因**。

## 一、弃用提示 + `不支持'prev_close'数据字段` 是同一个 bug

`ContextInfo.get_history_data` 只提供 **`open` / `high` / `low` / `close` / `quoter`** 五个字段（API 参考 5.2），并且在文档里标着**【不推荐】**。

而 bar 提取器把它想要的**每个**字段都拿去问它——`prev_close`、`preClose`、`lastClose`、`volume`、`amount`。这些问必然失败，而且**每问一次 QMT 就往自己的日志里写一行 ERROR**，每字段 × 每周期 × 每根 K 线：

```
【系统】ERROR获取历史数据,不支持'prev_close'数据字段
【系统】ERROR获取历史数据,不支持'preClose'数据字段
【系统】ERROR获取历史数据,不支持'lastClose'数据字段
```

更没道理的是：提取器**本来就会用上一根 K 线的收盘价**来填 `prev_close`。所以这些问从头到尾就没有可能有收益。

改法：先用主推接口 `get_market_data_ex`；`get_history_data` 只问它真正有的字段。

## 二、停止后重启 bind 失败 —— 真的端口泄漏

两处：

**`stop()` 根本没停 ZMQ 服务。** 它只调用 `_RUNTIME.on_qmt_stop()` 告诉引擎回测结束了，服务线程继续跑，端口继续被一个已经不存在的策略占着。你按的那个停止按钮走的正是这条路径。

**`stop_server()` 只设了个标志就返回。** 服务线程最多 `poll_ms` 之后才发现，再关 socket；而 `init()` 紧接着就去 bind 下一个。端点是固定端口，没有退到随机端口的余地——这个竞态的结果只能是 EADDRINUSE。

改法：`stop()` 现在会停服务；`stop_server()` 会等 socket 真的关闭再返回。

**顺带**：bind 失败现在会保留原因。光一句 `failed to bind` 会让人往错的方向查；带上 `Address in use` 才知道是有一个跑着的回测要先停掉。

## 测试

原来那个假 ContextInfo 会响应 `get_history_data("preClose")`——**没有任何 QMT 版本会这么做**。所以测试一直是绿的，而代码一直在刷屏。现在它像真 QMT 一样拒绝不支持的字段，并且新增一条测试断言我们**从不**问它没有的字段。

新增 8 个用例；连同改过的 2 个，修复前共 **9 个变红**。

756 通过，59/59 文件收集。

## 未验证

这些代码跑在 QMT 的回测进程里，需要部署后走一遍「启动 → 停止 → 再启动」才能实证。@wolfeee 方便的话麻烦帮忙跑一下，尤其是第二条——你原来那个复现路径。
