### PR TITLE
fix: 可转债的最小申报量、市场推断与报价精度

### DIFF
--- a/src/bigqmt_signal_trader/code_utils.py
+++ b/src/bigqmt_signal_trader/code_utils.py
@@ -35,6 +35,43 @@ _QMT_SUFFIXES = (
 _CASE_SENSITIVE_SUFFIXES = frozenset({".SF", ".DF", ".IF", ".ZF", ".INE", ".GF"})
 
 
+# 可转债 / 可交换债的代码段。两件事都要靠它：
+#   1. 裸 6 位码推断市场 —— 沪市转债 110/111/113 是 "1" 开头，落不进 ("5","6")
+#      那条规则，会被判到深市；
+#   2. 最小申报量 —— 债券论「张」，10 张起，不是 100。
+#
+#   SH  110/111/113 可转债、118 科创转债、132 可交换债
+#   SZ  12x 可转债与可交换债
+_BOND_SH_PREFIXES = ("110", "111", "113", "118", "132")
+_BOND_SZ_PREFIXES = ("12",)
+BOND_LOT = 10          # 债券最小申报数量（张）
+DEFAULT_LOT = 100      # 股票/基金最小申报数量（股/份）
+STAR_LOT = 200         # 科创板（688/689）
+
+
+def is_bond_code(stock_code):
+    """是不是可转债/可交换债。只看代码段，不需要联网。"""
+    text = str(stock_code or "").strip().upper()
+    if not text:
+        return False
+    if "." in text:
+        pure, _, suffix = text.partition(".")
+    elif text[:2] in ("SH", "SZ") and text[2:].isdigit():
+        pure, suffix = text[2:], text[:2]
+    else:
+        pure, suffix = text, ""
+    if not pure.isdigit():
+        return False
+    if suffix == "SH":
+        return pure.startswith(_BOND_SH_PREFIXES)
+    if suffix == "SZ":
+        return pure.startswith(_BOND_SZ_PREFIXES)
+    if suffix:
+        return False
+    # 裸码：两个市场的债券段互不重叠，直接一起判
+    return pure.startswith(_BOND_SH_PREFIXES) or pure.startswith(_BOND_SZ_PREFIXES)
+
+
 def normalize_stock_code(code):
     raw = str(code or "").strip()
     if not raw:
@@ -60,15 +97,26 @@ def normalize_stock_code(code):
         if _DIGIT_CODE_RE.match(prefix):
             return text
     if _DIGIT_CODE_RE.match(text):
-        market = "SH" if text.startswith(("5", "6")) else "SZ"
+        # 沪市转债 110/111/113/118/132 是 "1" 开头，不加这一条会被判到深市
+        if text.startswith(_BOND_SH_PREFIXES) or text.startswith(("5", "6")):
+            market = "SH"
+        else:
+            market = "SZ"
         return f"{text}.{market}"
     raise ValueError(f"invalid stock code: {code}")
 
 
 def min_lot(stock_code):
+    """最小申报数量。
+
+    债券论「张」，10 张起 —— 之前一律按 100 算，于是 round_buy_volume 会把
+    一手转债 (10 张) 变成 `(10 // 100) * 100 == 0`，单子直接废掉。
+    """
     normalized = normalize_stock_code(stock_code)
+    if is_bond_code(normalized):
+        return BOND_LOT
     pure = normalized.split(".")[0]
-    return 200 if pure.startswith("688") else 100
+    return STAR_LOT if pure.startswith("688") else DEFAULT_LOT
 
 
 def round_buy_volume(stock_code, amount):

--- a/src/bigqmt_signal_trader/price_engine.py
+++ b/src/bigqmt_signal_trader/price_engine.py
@@ -1,10 +1,18 @@
 """订单价格生成逻辑。"""
 
-from .code_utils import normalize_stock_code
+from .code_utils import is_bond_code, normalize_stock_code
 
 
 def _price_precision(stock_code):
-    pure = normalize_stock_code(stock_code).split(".")[0]
+    """报价小数位。基金和债券都是 3 位，股票 2 位。
+
+    债券这一条原来漏了：转债报价精度是 0.001，按 2 位取整会把 128.456 变成
+    128.46，交易所直接拒单。
+    """
+    code = normalize_stock_code(stock_code)
+    if is_bond_code(code):
+        return 3
+    pure = code.split(".")[0]
     return 3 if pure.startswith(("15", "16", "51", "52")) else 2
 
 

--- a/tests/bigqmt_signal_trader/test_code_utils.py
+++ b/tests/bigqmt_signal_trader/test_code_utils.py
@@ -7,10 +7,13 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(ROOT, "src"))
 
 from bigqmt_signal_trader.code_utils import (
+    is_bond_code,
+    min_lot,
     normalize_stock_code,
     round_buy_volume,
     round_sell_volume,
 )
+from bigqmt_signal_trader.price_engine import _price_precision
 
 
 class CodeUtilsTest(unittest.TestCase):
@@ -32,6 +35,68 @@ class CodeUtilsTest(unittest.TestCase):
     def test_round_sell_volume_keeps_all_when_sell_all(self):
         self.assertEqual(round_sell_volume("000001.SZ", 1234, sell_all=False), 1200)
         self.assertEqual(round_sell_volume("000001.SZ", 1234, sell_all=True), 1234)
+
+
+class ConvertibleBondTest(unittest.TestCase):
+    """可转债 / 可交换债：10 张起、0.001 报价，沪市转债不能判到深市。"""
+
+    SH_BONDS = ("110043", "111000", "113050", "118076", "132018")
+    SZ_BONDS = ("123281", "127045", "128136")
+
+    def test_shanghai_bonds_are_not_misfiled_to_shenzhen(self):
+        # 沪市转债是 "1" 开头，落不进 ("5","6") 那条规则
+        for code in self.SH_BONDS:
+            self.assertEqual(normalize_stock_code(code), code + ".SH", code)
+
+    def test_shenzhen_bonds_stay_in_shenzhen(self):
+        for code in self.SZ_BONDS:
+            self.assertEqual(normalize_stock_code(code), code + ".SZ", code)
+
+    def test_bond_codes_are_recognised_in_every_form(self):
+        for raw in ("113050", "113050.SH", "SH113050", "sh113050"):
+            self.assertTrue(is_bond_code(raw), raw)
+        for raw in ("600000.SH", "000001.SZ", "688981.SH", "510300.SH", "159915.SZ"):
+            self.assertFalse(is_bond_code(raw), raw)
+
+    def test_min_lot_is_ten_for_bonds(self):
+        for code in self.SH_BONDS + self.SZ_BONDS:
+            self.assertEqual(min_lot(code), 10, code)
+
+    def test_one_lot_of_bonds_survives_rounding(self):
+        # 这是修复的根本原因：(10 // 100) * 100 == 0，一手转债的单子直接废掉
+        self.assertEqual(round_buy_volume("113050.SH", 10), 10)
+        self.assertEqual(round_buy_volume("113050.SH", 37), 30)
+        self.assertEqual(round_buy_volume("113050.SH", 9), 0)
+
+    def test_bond_sell_rounds_by_ten_and_keeps_odd_lots_on_sell_all(self):
+        self.assertEqual(round_sell_volume("113050.SH", 37), 30)
+        self.assertEqual(round_sell_volume("113050.SH", 7, sell_all=True), 7)
+
+    def test_bond_price_precision_is_three_decimals(self):
+        for code in self.SH_BONDS + self.SZ_BONDS:
+            self.assertEqual(_price_precision(code), 3, code)
+
+    def test_existing_instruments_keep_their_precision(self):
+        self.assertEqual(_price_precision("600000.SH"), 2)
+        self.assertEqual(_price_precision("688981.SH"), 2)
+        self.assertEqual(_price_precision("510300.SH"), 3)
+        self.assertEqual(_price_precision("159915.SZ"), 3)
+
+
+class UnchangedBehaviourTest(unittest.TestCase):
+    """非债券品种的行为一个字都不能变。"""
+
+    def test_stock_and_star_lots_are_untouched(self):
+        self.assertEqual(min_lot("000001.SZ"), 100)
+        self.assertEqual(min_lot("600000.SH"), 100)
+        self.assertEqual(min_lot("688001.SH"), 200)
+        self.assertEqual(min_lot("510300.SH"), 100)
+
+    def test_ordinary_code_market_inference_is_untouched(self):
+        self.assertEqual(normalize_stock_code("600000"), "600000.SH")
+        self.assertEqual(normalize_stock_code("000001"), "000001.SZ")
+        self.assertEqual(normalize_stock_code("510300"), "510300.SH")
+        self.assertEqual(normalize_stock_code("159915"), "159915.SZ")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 问题

三处都是同一个原因：代码里没有「债券」这个概念，一律按股票处理。是在给 [bigqmt-dashboard](https://github.com/litaolemo/bigqmt_dashboard) 接可转债交易时踩出来的。

| # | 位置 | 现状 | 后果 |
|---|---|---|---|
| 1 | `code_utils.min_lot()` | 可转债返回 100 | `round_buy_volume` 把一手转债算成 `(10 // 100) * 100 == 0`，**单子直接废掉** |
| 2 | `code_utils.normalize_stock_code()` | 裸 6 位码按「5/6 开头 = 沪市」 | 沪市转债 110/111/113/118/132 都是 `1` 开头，**被判到深市**，拿去下单是另一只票 |
| 3 | `price_engine._price_precision()` | 只把 15/16/51/52 当 3 位小数 | 转债报价精度同样是 0.001，按 2 位取整会把 `128.456` 变成 `128.46`，**交易所拒单** |

复现（修复前）：

```python
>>> normalize_stock_code("110043")
'110043.SZ'          # 应为 110043.SH
>>> round_buy_volume("113050.SH", 10)
0                    # 一手转债 = 10 张，被规整没了
>>> _price_precision("113050.SH")
2                    # 应为 3
```

## 改动

新增 `is_bond_code()`，覆盖 SH `110/111/113/118/132` 与 SZ `12x`（可转债 + 可交换债），纯代码段判断，不需要联网。三处分别接上它。

**非债券品种行为一个字没动**：股票 100、科创板 200、ETF 100 且 3 位小数，原有断言（含 `round_buy_volume("688001.SH", 234) == 200`）全部保持。新增了一组 `UnchangedBehaviourTest` 专门钉住这一点。

## 验证

- 新增 12 个用例，`tests/bigqmt_signal_trader/test_code_utils.py` 14 项全过
- `python run_all_tests.py` → **737 项全过，0 失败**
- 品种规则拿大QMT 自己的合约数据交叉验证过：`get_instrument_detail()` 返回的 `PriceTick`，浦发/平安/中芯国际 `0.01`，立讯转债/中仑转债/派克转债/先锋转债 `0.001`，沪深300ETF/创业板ETF `0.001` —— 9 个品种全部吻合

## 一个没动、留给你判断的

科创板目前是 `min_lot=200` 且按 200 整手规整，`round_buy_volume("688001.SH", 234) == 200`。按交易所规则应该是「200 股起，之后按 1 股递增」，250 股是合法委托。但现有测试明确断言了 200，说明这是接受的行为，我没动它 —— 改的话 5 万元买中芯国际会从 300 股变成 397 股，资金利用率差一截，但也确实改变了老用户的下单量。要不要改你定。