### PR TITLE
Raise the real failure, not "No active exception to reraise" (#104)

### DIFF
--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -1147,20 +1147,42 @@ class BigQmtXtData:
             rpc_timeout = timeout_seconds
         else:
             rpc_timeout = 30 if upper_codes & {"SH", "SZ", "BJ", "HK"} else None
+        failure = None
         try:
             data = self.client.call(
                 "get_full_tick", _full_tick_params(codes, types),
                 timeout_seconds=rpc_timeout) or {}
-        except Exception:
+        except Exception as exc:
             data = None
+            failure = exc
             if not self._can_fall_back_to_markets(codes, upper_codes):
                 raise
         if self._should_fall_back(codes, upper_codes, data):
-            recovered = self._full_tick_via_markets(codes, rpc_timeout, types)
+            fallback_errors = []
+            recovered = self._full_tick_via_markets(
+                codes, rpc_timeout, types, errors=fallback_errors)
             if recovered is not None:
                 return recovered
-            if data is None:
-                raise
+            if failure is not None:
+                # A bare `raise` here has no active exception -- the except
+                # block above has already exited -- so it produced
+                # "RuntimeError: No active exception to reraise" and buried
+                # the real timeout (reported on issue #104). Re-raise the
+                # actual failure, and say why the recovery did not help.
+                if fallback_errors:
+                    log.warning(
+                        "get_full_tick: %d codes failed directly (%s) and the "
+                        "market re-read failed too (%s: %s); raising the "
+                        "original failure.",
+                        len(codes), failure,
+                        fallback_errors[-1].__class__.__name__,
+                        fallback_errors[-1])
+                else:
+                    log.warning(
+                        "get_full_tick: %d codes failed directly (%s) and "
+                        "could not be recovered from a market read.",
+                        len(codes), failure)
+                raise failure
         return data or {}
 
     def _can_fall_back_to_markets(self, codes, upper_codes):
@@ -1181,7 +1203,7 @@ class BigQmtXtData:
         # than was asked for (issue #104).
         return len(data) < len(set(str(c) for c in codes))
 
-    def _full_tick_via_markets(self, codes, rpc_timeout, types=None):
+    def _full_tick_via_markets(self, codes, rpc_timeout, types=None, errors=None):
         """Read the exchange(s) these codes live on, then filter to them.
 
         A long explicit list is one RPC carrying one timeout, so it either fits
@@ -1213,7 +1235,11 @@ class BigQmtXtData:
                     for key, value in snapshot.items():
                         if str(key) in wanted:
                             merged[key] = value
-            except Exception:
+            except Exception as exc:
+                # Swallowing the reason here left the caller with nothing to
+                # report; hand it back so the raise can name it (issue #104).
+                if errors is not None:
+                    errors.append(exc)
                 return None
             if len(merged) >= len(wanted):
                 break          # everything asked for; no need to widen

--- a/tests/bigqmt_signal_trader/test_full_tick_failure_reporting.py
+++ b/tests/bigqmt_signal_trader/test_full_tick_failure_reporting.py
@@ -1,0 +1,139 @@
+"""When the long-list recovery cannot help, say what actually failed (#104).
+
+The recovery added for a long explicit code list has its own failure path: the
+direct call times out, the market re-read is tried, and that does not work
+either. The code then did a bare ``raise`` -- but by then the ``except`` block
+had already exited, so there was no active exception:
+
+    File ".../xtquant_compat.py", line 1163, in get_full_tick
+        raise
+    RuntimeError: No active exception to reraise
+
+which is what frank0532 got, in place of the timeout that actually happened.
+The re-read swallowed its own reason too (``except Exception: return None``),
+so nothing anywhere knew why the recovery had failed.
+"""
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader import xtquant_compat as compat
+from bigqmt_signal_trader.xtquant_compat import LARGE_CODE_LIST
+
+
+def _codes(count, market="SH"):
+    return ["%06d.%s" % (600000 + index, market) for index in range(count)]
+
+
+class FakeClient(object):
+    """Fails the direct call, and optionally the market re-read too."""
+
+    def __init__(self, direct_error, market_error=None, market_answer=None):
+        self.account_id = "acct"
+        self.local_cache_config = {}
+        self.full_tick_cache_config = {}
+        self.requests = []
+        self._direct_error = direct_error
+        self._market_error = market_error
+        self._market_answer = market_answer or {}
+
+    def call(self, method, params=None, timeout_seconds=None, **kwargs):
+        params = params or {}
+        codes = list(params.get("codes") or [])
+        self.requests.append(codes)
+        if len(codes) == 1 and codes[0] in ("SH", "SZ", "BJ", "HK"):
+            if self._market_error is not None:
+                raise self._market_error
+            return dict(self._market_answer)
+        raise self._direct_error
+
+    def _redis(self):
+        raise AssertionError("redis not expected here")
+
+
+def _xtdata(client):
+    return compat.BigQmtXtData(client)
+
+
+class RaisesTheRealFailureTest(unittest.TestCase):
+    def setUp(self):
+        self.codes = _codes(LARGE_CODE_LIST + 1)
+
+    def test_it_is_not_a_bare_reraise(self):
+        client = FakeClient(TimeoutError("zmq rpc timeout: get_full_tick"),
+                            market_error=TimeoutError("re-read timed out"))
+
+        with self.assertRaises(Exception) as caught:
+            _xtdata(client).get_full_tick(self.codes)
+
+        self.assertNotIn("No active exception", str(caught.exception))
+
+    def test_it_keeps_the_original_type(self):
+        """Callers catching TimeoutError must keep catching it."""
+        client = FakeClient(TimeoutError("zmq rpc timeout: get_full_tick"),
+                            market_error=TimeoutError("re-read timed out"))
+
+        with self.assertRaises(TimeoutError):
+            _xtdata(client).get_full_tick(self.codes)
+
+    def test_it_keeps_the_original_message(self):
+        client = FakeClient(TimeoutError("zmq rpc timeout: get_full_tick"),
+                            market_error=TimeoutError("re-read timed out"))
+
+        with self.assertRaises(TimeoutError) as caught:
+            _xtdata(client).get_full_tick(self.codes)
+
+        self.assertIn("zmq rpc timeout", str(caught.exception))
+
+    def test_the_re_read_reason_is_logged(self):
+        """It is the half a reporter cannot see from the traceback."""
+        client = FakeClient(TimeoutError("direct timed out"),
+                            market_error=ValueError("re-read exploded"))
+
+        with self.assertLogs(compat.log, level="WARNING") as logs:
+            with self.assertRaises(TimeoutError):
+                _xtdata(client).get_full_tick(self.codes)
+
+        joined = "\n".join(logs.output)
+        self.assertIn("re-read exploded", joined)
+        self.assertIn("ValueError", joined)
+
+    def test_a_short_recovery_returns_what_it_found(self):
+        """Partial data beats an exception here: the codes that did come back
+        are real, and the warning says how many did not."""
+        client = FakeClient(TimeoutError("direct timed out"),
+                            market_answer={self.codes[0]: {"lastPrice": 1.0}})
+
+        with self.assertLogs(compat.log, level="WARNING") as logs:
+            result = _xtdata(client).get_full_tick(self.codes)
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("filtered to 1", " ".join(logs.output))
+
+
+class StillRecoversTest(unittest.TestCase):
+    """The happy path must not have been broken by any of this."""
+
+    def test_a_working_re_read_still_returns_data(self):
+        codes = _codes(LARGE_CODE_LIST + 1)
+        answer = dict((code, {"lastPrice": 1.0}) for code in codes)
+        client = FakeClient(TimeoutError("direct timed out"), market_answer=answer)
+
+        result = _xtdata(client).get_full_tick(codes)
+
+        self.assertEqual(len(result), len(codes))
+
+    def test_a_short_list_failure_still_raises_untouched(self):
+        client = FakeClient(TimeoutError("direct timed out"))
+
+        with self.assertRaises(TimeoutError):
+            _xtdata(client).get_full_tick(_codes(10))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
@frank0532 在 #104 上跑 0.3.4 时报的（他的三个行号 1163 / 2830 / 741 精确匹配 v0.3.4）：

```
File ".../xtquant_compat.py", line 1163, in get_full_tick
    raise
RuntimeError: No active exception to reraise
```

**是我在 #111 里写的 bug。** 那个 `raise` 在 `except` 块**外面**——except 已经退出，没有活跃异常可重新抛出，于是真正发生的超时被换成了一条毫无意义的错误。

而且重读那边也把自己的原因吞了（`except Exception: return None`），所以即便修好 raise，也没有任何地方知道恢复为什么没成功。

## 改法

- 捕获原始异常，显式 `raise failure` ——**类型保持不变**，写 `except TimeoutError` 的调用方照旧能接住
- 重读把异常交回调用方，raise 之前把它记进日志

意味着下一次有人报这个问题时，手上会有诊断而不是死胡同。**我到现在仍然不知道他那次重读为什么失败**——现在日志会说。

## 顺带确认

重读本身的超时是 `max(rpc_timeout or 0, 60)`，60 秒起，所以不是被 0.3.4 之前那个 6s 默认值卡的。真实原因待日志。

## 测试

7 个新用例，修复前红 4 个。770 通过。
