### PR TITLE
Refuse a field FormulaServer answers with NaN (#104)

### DIFF
--- a/src/bigqmt_signal_trader/formula_server.py
+++ b/src/bigqmt_signal_trader/formula_server.py
@@ -486,11 +486,38 @@ def _weight_in_index_params(params):
     return {"indexCode": str(index_code), "stockCode": str(stock_code)}
 
 
+# What FormulaServer actually answers with data, measured against a live
+# terminal. It accepts ANY field name and returns a column either way -- the
+# ones outside this set come back as all-NaN, which looks like an answer and
+# is not:
+#
+#     field_list=[...11 names...]  0.015s  preClose=nan   suspendFlag=nan
+#     field_list=[]                (RPC)   preClose=9.0   suspendFlag=0
+#
+# Same shape, same column count, twelve times faster, silently wrong. The four
+# it cannot serve are daily metadata (settelementPrice, openInterest, preClose,
+# suspendFlag) rather than bar data, which is why they are missing here.
+#
+# A whitelist, not a blacklist: an unfamiliar field name goes to RPC and is
+# merely slow. Guessing that it might be served risks being quietly wrong,
+# which is the failure this guard exists to remove.
+SERVED_FIELDS = frozenset((
+    "open", "high", "low", "close", "volume", "amount", "time", "stime",
+))
+
+
 def _market_data_params(params):
     fields = _as_list(_first(params, ("field_list", "fields"), None))
     codes = _as_list(_first(params, ("stock_list", "stock_code", "stockCodes"), None))
     if not fields or not codes:
         raise ValueError("field_list and stock_list are required")
+    unservable = sorted(set(str(field) for field in fields) - SERVED_FIELDS)
+    if unservable:
+        # Same rule as the dividend_type guard below: a request this path
+        # cannot answer honestly goes to RPC instead of coming back as NaN.
+        raise ValueError(
+            "field(s) %s come back as NaN here; RPC has the real values"
+            % ", ".join(unservable))
     dividend_type = str(params.get("dividend_type") or "none").lower()
     # FormulaServer returns byte-identical bars for dividendType none/front, so
     # adjustment is not applied here. Serving an adjusted request from this path

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -933,8 +933,9 @@ def _notice_field_list_cost(field_list):
     """Say once that naming fields is what enables the fast path.
 
     Not a warning about a mistake: an empty field_list correctly returns all 11
-    columns and only RPC can do that. But the 30x is invisible unless someone
-    tells you it exists (issue #104)."""
+    columns and only RPC can do that. But the speedup is invisible unless
+    someone tells you it exists (issue #104). Asking for a field the direct
+    path lacks is safe -- it falls back to RPC rather than returning NaN."""
     if field_list or _FIELD_LIST_NOTICE["shown"]:
         return
     _FIELD_LIST_NOTICE["shown"] = True
@@ -942,8 +943,10 @@ def _notice_field_list_cost(field_list):
         log.info(
             "get_market_data_ex with an empty field_list returns all 11 columns "
             "and must go over RPC. If the six OHLCV columns %s are enough, pass "
-            "them as field_list -- that path is served by FormulaServer, ~30x "
-            "faster (0.03s vs 0.97s measured).", ", ".join(DIRECT_PATH_FIELDS))
+            "them as field_list -- that path is served by FormulaServer, 0.015s "
+            "against 5.8s measured. Naming preClose / suspendFlag / "
+            "settelementPrice / openInterest falls back to RPC, so a wider "
+            "field_list is safe, just not faster.", ", ".join(DIRECT_PATH_FIELDS))
     except Exception:
         pass
 
@@ -1347,11 +1350,15 @@ class BigQmtXtData:
         ``chunk_size=0`` restores the old single-request behaviour.
 
         An empty ``field_list`` means "every field", which only the RPC path can
-        answer -- FormulaServer serves the six OHLCV columns and returns NaN for
-        settelementPrice / openInterest / preClose / suspendFlag, where RPC has
-        real values (preClose 9.07 against nan, measured). So the default stays
-        on RPC rather than quietly handing back NaN; naming the six fields you
-        actually want is what unlocks the ~30x direct path (issue #104).
+        answer: FormulaServer has the six bar columns plus time, and not the
+        four daily ones (settelementPrice, openInterest, preClose,
+        suspendFlag). Naming the fields you actually want is what unlocks the
+        direct path -- 0.015s against 5.8s, measured (issue #104).
+
+        Asking it for a field it lacks is now refused at the router and served
+        by RPC instead. It used to answer with a column of NaN, so naming all
+        eleven columns looked like a free speedup and quietly cost four of them
+        (see formula_server.SERVED_FIELDS).
         """
         _notice_field_list_cost(field_list)
         codes = list(stock_list or [])

--- a/tests/bigqmt_signal_trader/test_formula_server_fields.py
+++ b/tests/bigqmt_signal_trader/test_formula_server_fields.py
@@ -1,0 +1,142 @@
+"""FormulaServer must not answer with NaN where RPC has the data (#104).
+
+The direct path accepts any field name. For the four it does not have it
+returns a column of NaN rather than an error, so a request looked answered and
+was not. Measured against a live terminal:
+
+    field_list=[...all 11 names...]   0.015s   preClose=nan  suspendFlag=nan
+    field_list=[]                     (RPC)    preClose=9.0  suspendFlag=0
+
+Same columns, same shape, twelve times faster, silently wrong -- and reaching
+for it is exactly what someone does after being told that naming fields is what
+unlocks the fast path.
+
+The four are daily metadata (settelementPrice, openInterest, preClose,
+suspendFlag), not bar data, which is why this path lacks them. preClose cannot
+be reconstructed from close either: on an ex-dividend day it is the *adjusted*
+previous close, measured at 8.89 against a previous close of 9.31 on
+600000.SH -- a 4.5% gap on precisely the day a wrong value matters most.
+
+The rule here is the one the dividend_type guard already followed: a request
+this path cannot answer honestly goes to RPC.
+"""
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.formula_server import (
+    SERVED_FIELDS, _market_data_params)
+
+
+SIX = ["open", "high", "low", "close", "volume", "amount"]
+NAN_FIELDS = ("settelementPrice", "openInterest", "preClose", "suspendFlag")
+
+
+def _params(fields, **extra):
+    base = {"field_list": list(fields), "stock_list": ["600000.SH"],
+            "period": "1d", "count": 2}
+    base.update(extra)
+    return base
+
+
+def _refusal(fields, **extra):
+    try:
+        _market_data_params(_params(fields, **extra))
+    except ValueError as exc:
+        return str(exc)
+    raise AssertionError("expected a refusal for %r" % (fields,))
+
+
+class ServedTest(unittest.TestCase):
+    """What the direct path answers with real numbers, measured live."""
+
+    def test_the_six_bar_columns_route(self):
+        wire = _market_data_params(_params(SIX))
+
+        self.assertEqual(wire["fields"], SIX)
+
+    def test_time_routes_alongside_them(self):
+        """Measured: ['time','close'] came back with time=1788105600000."""
+        wire = _market_data_params(_params(SIX + ["time"]))
+
+        self.assertIn("time", wire["fields"])
+
+    def test_stime_routes_too(self):
+        wire = _market_data_params(_params(["stime", "close"]))
+
+        self.assertIn("stime", wire["fields"])
+
+    def test_the_served_set_is_exactly_what_was_measured(self):
+        self.assertEqual(
+            set(SERVED_FIELDS),
+            {"open", "high", "low", "close", "volume", "amount", "time", "stime"})
+
+
+class RefusedTest(unittest.TestCase):
+    """The four that come back as NaN."""
+
+    def test_each_one_is_refused_on_its_own(self):
+        for field in NAN_FIELDS:
+            message = _refusal(SIX + [field])
+            self.assertIn(field, message, field)
+
+    def test_naming_all_eleven_is_refused(self):
+        """The tempting move: write every column name and keep the fast path.
+        It used to work, at the cost of four NaN columns."""
+        all_eleven = ["time"] + SIX + list(NAN_FIELDS)
+
+        message = _refusal(all_eleven)
+
+        self.assertIn("preClose", message)
+
+    def test_the_refusal_says_where_the_data_is(self):
+        message = _refusal(SIX + ["preClose"])
+
+        self.assertIn("NaN", message)
+        self.assertIn("RPC", message)
+
+    def test_one_bad_field_refuses_the_whole_request(self):
+        """Serving the rest and dropping the one would be the same silent
+        hole in a different shape."""
+        _refusal(SIX + ["preClose"])
+
+
+class WhitelistTest(unittest.TestCase):
+    """Unknown names go to RPC: slow is recoverable, wrong is not."""
+
+    def test_an_unfamiliar_field_is_refused(self):
+        _refusal(["close", "someFutureFieldName"])
+
+    def test_it_is_not_a_blacklist_of_the_known_four(self):
+        """A blacklist would let a newly added NaN field slip straight
+        through -- exactly how this one got here."""
+        message = _refusal(["close", "turnoverRate"])
+
+        self.assertIn("turnoverRate", message)
+
+
+class ExistingGuardsTest(unittest.TestCase):
+    """The rule this one follows was already here; keep it working."""
+
+    def test_adjusted_bars_are_still_refused(self):
+        message = _refusal(SIX, dividend_type="front")
+
+        self.assertIn("dividend_type", message)
+
+    def test_tick_period_is_still_refused(self):
+        message = _refusal(SIX, period="tick")
+
+        self.assertIn("tick", message)
+
+    def test_an_empty_field_list_is_still_refused(self):
+        """"every field" is exactly what this path cannot do."""
+        _refusal([])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
第一步：**堵住直连路径静默返回 NaN 的洞**（第二步的日频字段缓存另开）。

## 问题

FormulaServer 直连**接受任何字段名**。对它没有的四个字段，它不报错，而是返回一整列 `NaN`。实盘量的：

```
field_list=[...11 个字段名...]   0.015s   preClose=nan   suspendFlag=nan
field_list=[]                    (RPC)    preClose=9.0   suspendFlag=0
```

**同样的列、同样的形状、快 12 倍、数据静默错了。**

而且这正是有人在被告知「写明字段名能走快路径」之后会做的事——客户端自己还打印了这条提示。

## 为什么这四个字段没有

`settelementPrice` / `openInterest` / `preClose` / `suspendFlag` 是**日频元数据**，不是 K 线数据。直连供的是日内会变的 OHLCV，所以缺的正好是这四个。

**`preClose` 也不能从 `close` 推出来**，我验过：除权除息日它是**除权后的昨收**。

| 股票 | 前一日 close | 实际 preClose | 差 |
|---|---|---|---|
| 600000.SH | 9.31 | **8.89** | **-4.51%** |
| 000001.SZ | 11.57 | 11.33 | -2.07% |
| 000001.SZ | 11.30 | 10.94 | -3.19% |
| 600519.SH | 1431.00 | 1407.04 | -1.67% |
| 600519.SH | 1212.10 | 1184.08 | -2.31% |

250 个交易日里每只 1–2 天——正好是算涨跌幅最要紧的那一两天，推导会凭空造出 2~4.5% 的假跳空。

## 改法

沿用 `dividend_type` 和 `period=tick` 已有的规矩：**这条路径答不诚实的请求，交给 RPC**。

用**白名单**不用黑名单：

```python
SERVED_FIELDS = frozenset((
    "open", "high", "low", "close", "volume", "amount", "time", "stime",
))
```

不认识的字段名走 RPC，只是慢；猜它「大概能供」则可能静默出错——而这个 bug 正是这么来的。

（`time` 和 `stime` 是实测能返回真值的，`['time','close']` 拿到 `time=1788105600000`。）

## 实盘验证

| 请求 | 修复前 | 修复后 |
|---|---|---|
| 六列 | 0.016s | 0.016s（不变） |
| 六列 + `preClose` | 0.015s，`preClose=nan` | 0.258s，**`preClose=9.0`** |
| 显式写全 11 列 | 0.015s，四列 nan | 0.195s，**四列全是真值** |

快路径原样保留，静默错误没了。

13 个新测试。783 通过，62/62 文件收集。

## 下一步

日频四列对 `(代码, 日期)` 是定值，可以缓存——缓存之后 `field_list=[]` 能走「OHLCV 直连 + 四列查缓存」，既完整又快。那是独立的一步，等这个合了再做。
