### PR TITLE
Say the file is not Python, instead of a bare NameError (#102)

### DIFF
--- a/src/BIGQMT_REDIS_DRYRUN.py
+++ b/src/BIGQMT_REDIS_DRYRUN.py
@@ -107,6 +107,45 @@ def _set_parent_attribute(name, module):
     setattr(parent, child_name, module)
 
 
+# A strategy file that arrived corrupted fails with a bare NameError naming a
+# 200-character token, which says nothing about the file being broken (issue
+# #102). Real symptom, from a reporter's terminal:
+#
+#     File "...\bigqmt_signal_trader_strategy.py", line 1, in <module>
+#         MiFBOecYoHXT4UUBBOIr3m5aTVbA5Rbt6OnG52cfBT5EAtPG9kA7kQnEsKuDUOORy...
+#     NameError: name 'MiFBOecYoHXT4UUB...' is not defined
+#
+# Python read line 1 as a variable name because that is all it was: the file
+# had been saved from something other than the source -- a download page, a
+# proxy that served a token instead of the file. Every version behaves the
+# same way, so "try a different version" sends people in the wrong direction.
+_TOKEN_CHARS = set(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=+/")
+
+
+def _looks_like_a_token_not_python(source):
+    """True when the first real line cannot be Python at all.
+
+    Deliberately narrow. A Python line this long with no whitespace and
+    nothing outside the base64 alphabet would have to be a bare identifier,
+    which is already broken -- so a false positive costs a clearer message on
+    code that was going to fail anyway.
+    """
+    try:
+        if isinstance(source, bytes):
+            source = source.decode("utf-8", "replace")
+        for line in source.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            return (len(line) >= 40
+                    and not any(char.isspace() for char in line)
+                    and all(char in _TOKEN_CHARS for char in line))
+    except Exception:
+        pass
+    return False
+
+
 def _load_local_module(name):
     existing = sys.modules.get(name)
     if existing is not None:
@@ -133,6 +172,15 @@ def _load_local_module(name):
         exec(compile(source, source_path, "exec"), module.__dict__)
     except Exception:
         sys.modules.pop(name, None)
+        if _looks_like_a_token_not_python(source):
+            raise RuntimeError(
+                "%s is not Python source -- its first line is one long token, "
+                "so the file was saved from something other than the code "
+                "(a download page, a mirror that served a token). Fetch it "
+                "again: pip install --upgrade xtquant-big-convert then "
+                "xt_trader.sync_deployment(), or copy src/ from the release. "
+                "A different version will not help; every version fails the "
+                "same way on this file." % source_path)
         raise
     _set_parent_attribute(name, module)
     return module

--- a/src/BIGQMT_ZMQ_BACKTEST.py
+++ b/src/BIGQMT_ZMQ_BACKTEST.py
@@ -78,6 +78,39 @@ def _find_source(name):
     raise ModuleNotFoundError("local source not found: %s" % name, name=name)
 
 
+# A file that arrived corrupted fails with a bare NameError naming a long
+# token, which says nothing about the file being broken (issue #102). Python
+# read line 1 as a variable name because that is all it was: the file had been
+# saved from something other than the source -- a download page, or a mirror
+# that served a token instead of the file. Every version behaves the same way,
+# so "try a different version" sends people in the wrong direction.
+_TOKEN_CHARS = set(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_=+/")
+
+
+def _looks_like_a_token_not_python(source):
+    """True when the first real line cannot be Python at all.
+
+    Deliberately narrow. A Python line this long with no whitespace and
+    nothing outside the base64 alphabet would have to be a bare identifier,
+    which is already broken -- so a false positive costs a clearer message on
+    code that was going to fail anyway.
+    """
+    try:
+        if isinstance(source, bytes):
+            source = source.decode("utf-8", "replace")
+        for line in source.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            return (len(line) >= 40
+                    and not any(char.isspace() for char in line)
+                    and all(char in _TOKEN_CHARS for char in line))
+    except Exception:
+        pass
+    return False
+
+
 def _load_local_module(name):
     existing = sys.modules.get(name)
     if existing is not None:
@@ -102,6 +135,13 @@ def _load_local_module(name):
         exec(compile(source, source_path, "exec"), module.__dict__)
     except Exception:
         sys.modules.pop(name, None)
+        if _looks_like_a_token_not_python(source):
+            raise RuntimeError(
+                "%s is not Python source -- its first line is one long token, "
+                "so the file was saved from something other than the code (a "
+                "download page, or a mirror that served a token). Fetch the "
+                "file again. A different version will not help; every version "
+                "fails the same way on this file." % source_path)
         raise
     if "." in name:
         parent_name, child_name = name.rsplit(".", 1)

--- a/tests/bigqmt_signal_trader/test_corrupt_source_message.py
+++ b/tests/bigqmt_signal_trader/test_corrupt_source_message.py
@@ -1,0 +1,135 @@
+"""A file that is not Python must say so (issue #102).
+
+huliangyu's strategy file had arrived corrupted -- line 1 was a 200-character
+token, not code -- and the loader reported it as:
+
+    File "...\\bigqmt_signal_trader_strategy.py", line 1, in <module>
+        MiFBOecYoHXT4UUBBOIr3m5aTVbA5Rbt6OnG52cfBT5EAtPG9kA7kQnEsKuDUOORy...
+    NameError: name 'MiFBOecYoHXT4UUB...' is not defined
+
+Python read line 1 as a variable name because that is all it was. Nothing in
+that message says the file is broken, so the first answer they got was "maybe
+a version problem, redeploy" -- which cannot help: every version fails the same
+way on that file.
+
+The check is deliberately narrow. A Python line 40+ characters long with no
+whitespace and nothing outside the base64 alphabet would have to be a bare
+identifier, which is already broken, so a false positive only means a clearer
+message on code that was going to fail anyway.
+"""
+
+import io
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SRC = os.path.join(ROOT, "src")
+sys.path.insert(0, SRC)
+
+ENTRIES = ("BIGQMT_REDIS_DRYRUN.py", "BIGQMT_ZMQ_BACKTEST.py")
+
+# The real one, from the reporter's screenshot.
+REAL_TOKEN = ("MiFBOecYoHXT4UUBBOIr3m5aTVbA5Rbt6OnG52cfBT5EAtPG9kA7kQnEsKuDUOO"
+              "RyAIDLm4V4QJ66slR3f9yxa78SEyEn4MHPBmB_yap_dtN-dqis9Wx_VkUyEt8f")
+
+
+def _detector(entry):
+    """Pull the check out of a standalone entry script.
+
+    These files bootstrap the package, so they cannot import from it and the
+    helper is inlined in each. Exec'ing just that function keeps the test
+    honest about what actually ships.
+    """
+    path = os.path.join(SRC, entry)
+    encoding = "gbk" if entry.endswith("BACKTEST.py") else "utf-8"
+    with io.open(path, encoding=encoding) as handle:
+        source = handle.read()
+    start = source.index("_TOKEN_CHARS = set(")
+    end = source.index("def _load_local_module(name):", start)
+    namespace = {}
+    exec(compile(source[start:end], path, "exec"), namespace)
+    return namespace["_looks_like_a_token_not_python"]
+
+
+class DetectsTest(unittest.TestCase):
+    def test_the_reporters_actual_file(self):
+        for entry in ENTRIES:
+            self.assertTrue(_detector(entry)(REAL_TOKEN), entry)
+
+    def test_a_leading_blank_line_does_not_hide_it(self):
+        self.assertTrue(_detector(ENTRIES[0])("\n\n   \n" + REAL_TOKEN))
+
+    def test_bytes_are_handled(self):
+        """The loader reads the file in binary."""
+        self.assertTrue(_detector(ENTRIES[0])(REAL_TOKEN.encode("utf-8")))
+
+
+class LeavesRealPythonAloneTest(unittest.TestCase):
+    """A false positive here would replace a real traceback with a wrong story."""
+
+    def _check(self, source):
+        return _detector(ENTRIES[0])(source)
+
+    def test_the_real_strategy_file(self):
+        path = os.path.join(SRC, "bigqmt_signal_trader_strategy.py")
+        with io.open(path, encoding="utf-8") as handle:
+            self.assertFalse(self._check(handle.read()))
+
+    def test_every_shipped_entry_script(self):
+        for entry in ENTRIES:
+            encoding = "gbk" if entry.endswith("BACKTEST.py") else "utf-8"
+            with io.open(os.path.join(SRC, entry), encoding=encoding) as handle:
+                self.assertFalse(self._check(handle.read()), entry)
+
+    def test_a_module_that_opens_with_a_long_import(self):
+        source = ("from bigqmt_signal_trader.adapters.market_bigqmt import "
+                  "BigQmtMarketDataProvider\n")
+        self.assertFalse(self._check(source))
+
+    def test_a_module_that_opens_with_a_long_dotted_expression(self):
+        """Long, but it has dots -- outside the alphabet."""
+        self.assertFalse(self._check("a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u\n"))
+
+    def test_a_long_comment(self):
+        self.assertFalse(self._check("# " + "x" * 200))
+
+    def test_an_empty_file(self):
+        self.assertFalse(self._check(""))
+
+    def test_a_short_identifier_alone(self):
+        """Broken code, but not this kind of broken -- let the NameError
+        speak for itself."""
+        self.assertFalse(self._check("undefined_name\n"))
+
+    def test_it_never_raises(self):
+        for value in (None, 12345, object()):
+            self.assertFalse(self._check(value))
+
+
+class MessageTest(unittest.TestCase):
+    def _entry_source(self, entry):
+        encoding = "gbk" if entry.endswith("BACKTEST.py") else "utf-8"
+        with io.open(os.path.join(SRC, entry), encoding=encoding) as handle:
+            return handle.read()
+
+    def test_it_names_the_file(self):
+        for entry in ENTRIES:
+            self.assertIn("% source_path", self._entry_source(entry), entry)
+
+    def test_it_says_a_different_version_will_not_help(self):
+        """The answer the reporter was given first."""
+        for entry in ENTRIES:
+            self.assertIn("A different version will not help",
+                          self._entry_source(entry), entry)
+
+    def test_the_backtest_entry_stays_isolated(self):
+        """It must not mention the live bridge -- pinned by
+        test_qmt_runtime.py, and easy to break when adding shared wording."""
+        self.assertNotIn("bigqmt_signal_trader",
+                         self._entry_source("BIGQMT_ZMQ_BACKTEST.py"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
@huliangyu 在 #102 报的：脚本跑不起来，截图里是

```
File "...\bigqmt_signal_trader_strategy.py", line 1, in <module>
    MiFBOecYoHXT4UUBBOIr3m5aTVbA5Rbt6OnG52cfBT5EAtPG9kA7kQnEsKuDUOORy...
NameError: name 'MiFBOecYoHXT4UUB...' is not defined
```

**他那个文件的第一行是一串 token，不是代码。** Python 把它当变量名求值，所以报 `NameError`。

问题是这条报错**看不出文件坏了**——所以第一反应的答复是「可能是版本问题，重新部署一下」，而那对这个文件无效：**换任何版本都一样报错**。

## 改法

加载器 exec 失败时，看一眼第一行像不像 Python。像 token 就直说：

```
...\bigqmt_signal_trader_strategy.py is not Python source -- its first line
is one long token, so the file was saved from something other than the code
(a download page, a mirror that served a token). Fetch it again: pip install
--upgrade xtquant-big-convert then xt_trader.sync_deployment(), or copy src/
from the release. A different version will not help; every version fails the
same way on this file.
```

判定**故意做窄**：40 字符以上、无空白、字符全在 base64 字母表内。满足这三条的 Python 行只可能是一个裸标识符——那本来就是坏代码，所以误判的代价只是给一段反正要失败的代码一条更清楚的消息。

## 端到端验证

用 fixture 跑了真实加载器（不是只测判定函数）：

| 输入 | 结果 |
|---|---|
| 正常模块 | 加载成功，`VALUE=42` |
| `undefined_name_here` | `NameError: name 'undefined_name_here' is not defined`（原样，守卫够窄） |
| 第一行是 token 的文件 | 新的 `RuntimeError`，指名文件 |

> 探测过程本身踩了两个坑，值得记一下：加载器优先用 `_SOURCE_ROOT` 而不是 `sys.path`，所以第一次 fixture 根本没被读到；而且它开头就 `sys.modules.get(name)` 返回缓存，所以第二次读到的是已加载的干净模块。两次都表现为「没报错」，看起来像修好了。这正是「部署后不重启不生效」的同一个机制。

## 两个入口各有一份

`BIGQMT_REDIS_DRYRUN.py` 和 `BIGQMT_ZMQ_BACKTEST.py` 都定义了加载器。它们是引导包的入口，不能反过来 import 包里的工具，所以判定函数在两边各内联一份。

回测入口用的是**不同措辞**：那个文件**不允许出现 `bigqmt_signal_trader` 字样**（它与实盘桥的隔离由 `test_qmt_runtime.py` 钉着），我第一版共用文案时正好撞了这条，被测试拦下来了。新增测试里也加了一条守着它。

14 个新测试。797 通过，63/63 文件收集。
