### PR TITLE
Make a blocked bridge say so, and pay the first-call cost at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,68 @@ field_list=[open,high,low,close,volume,amount]
 
 **只要 OHLCV 就显式写出来**，那 30 倍就到手了。首次不传 `field_list` 时会在 `bigqmt.log` 记一条说明。
 
+### 启动预热与卡顿监控
+
+**重启策略后，第一次调用 `get_financial_data` 可能要几分钟。** 实测过一次 **346 秒**——当时 QMT 自身完全健康（全推行情每几秒一批、线程池正常），主策略线程也空闲（adjust 每 10 秒 100 拍，每拍 < 2ms）。当天之后的所有调用都在 1 秒内，**包括从没查过的票和没查过的表**，所以这是一次性代价，不是按代码的缓存未命中。
+
+问题在于它的传染性：**RPC 处理是串行的**，一个调用卡住，后面排队的全部超时。客户端看到的是一片超时，和「桥死了」完全一样。
+
+#### 启动时自动预热（默认开启）
+
+启动后会在**后台线程**上先跑一次这个调用，把这份等待提前付掉：
+
+```
+[bigqmt_warmup] get_financial_data: first call after a restart can take
+minutes; running it now so a caller does not have to wait
+[bigqmt_warmup] get_financial_data warm after 346.0s -- that wait is now paid
+```
+
+热了之后就是这样：
+
+```
+[bigqmt_warmup] get_financial_data warm in 0.31s
+```
+
+**预热不会让这个代价变便宜**，它只是把代价挪到一个确定的时刻、一个没人等待的线程上，并且留下一行说明——而不是让它以「第一个调用方莫名卡死」的形式出现。
+
+> **为什么不放在 init 里？** 启动诊断（`_diag_startup`）跑在主线程的 `init()` 中。把一个可能 346 秒的调用加进去，会在 adjust 定时器都还没排上的时候冻住整个启动——比原问题更糟。所以预热走独立守护线程，`init()` 立即返回。
+
+关掉它（服务端 local config）：
+
+```python
+BIGQMT_REDIS_CONFIG = {
+    # ...
+    "warm_context_data": False,
+}
+```
+
+#### 卡顿监控：区分「桥卡住」和「桥死了」
+
+handler 还在跑的时候就会报，不用等它结束：
+
+```
+[bigqmt_rpc] zmq handler STILL RUNNING method=get_financial_data 40s
+thread=bigqmt-zmq-rpc queued=3 -- the bridge is blocked, not dead
+```
+
+- 默认 **20 秒**触发。比实测最慢的健康调用（整市场快照 7.7s）长得多，又短于客户端 30 秒的默认超时，**所以日志会在调用方放弃之前就点名**
+- 指数退避，一次长阻塞不会把它自己要解释的日志淹掉
+- 调整或关闭（注意它在 **`zmq` 子块**里，不是顶层）：
+
+```python
+BIGQMT_REDIS_CONFIG = {
+    # ...
+    "zmq": {
+        "stall_warn_seconds": 45,   # 0 = 关闭
+    },
+}
+```
+
+**看到成片超时时，先在服务端日志里搜 `STILL RUNNING` 或 `slow handler`。** 有这两行之一，就说明桥没死，只是被一个慢调用堵住了——等它跑完，或者查那个方法。
+
+> 注意 `slow handler` 是**事后**打的（handler 返回才计时），`STILL RUNNING` 才是进行中的。
+
+
 ### 版本检测与部署同步
 
 部署到 QMT 是**文件拷贝**，而 QMT 跨策略重跑保留 `sys.modules`。所以「忘了拷」和「拷了但没被加载」从外部看**一模一样**——这是本项目最容易浪费时间的一类问题：本地修好了，实盘却像没修。

--- a/src/bigqmt_signal_trader/transports/zmq_transport.py
+++ b/src/bigqmt_signal_trader/transports/zmq_transport.py
@@ -94,6 +94,8 @@ class ZmqTransport(RpcTransport):
         discovery_key_template="bigqmt:zmq:addr:{account_id}",
         discovery_ttl_seconds=300,
         port_scan_range=50,
+        stall_warn_seconds=20.0,
+        stall_check_seconds=5.0,
     ):
         super(ZmqTransport, self).__init__(account_id=account_id, print_prefix=print_prefix)
         # Address resolution order: explicit bind_address/connect_address win;
@@ -109,6 +111,13 @@ class ZmqTransport(RpcTransport):
         self.connect_address = connect_address
         self.bind_host = resolved_host
         self.base_port = resolved_port
+        # Handlers run one at a time, so anything past a few seconds is
+        # holding up every queued request. 20s is comfortably longer than the
+        # slowest healthy call measured here (a whole-market snapshot, 7.7s)
+        # and far short of a client's default 30s timeout, so the log names
+        # the culprit before the caller gives up. 0 disables the watchdog.
+        self.stall_warn_seconds = float(stall_warn_seconds)
+        self.stall_check_seconds = max(float(stall_check_seconds), 0.5)
         self.io_threads = int(io_threads)
         self.recv_timeout_seconds = float(recv_timeout_seconds)
         self.server_hwm = int(server_hwm)
@@ -132,6 +141,10 @@ class ZmqTransport(RpcTransport):
         self._response_queue = queue.Queue()
         self._queued_response_count = 0
         self._sent_response_count = 0
+        # (method, started_at, thread_name) while a handler is running.
+        # Reported by the stall watchdog below; None when idle.
+        self._in_flight = None
+        self._stall_thread = None
         # client state
         self._dealer = None
         self._client_lock = threading.Lock()
@@ -250,6 +263,11 @@ class ZmqTransport(RpcTransport):
             target=self._router_loop, name="bigqmt-zmq-rpc", daemon=True
         )
         self._router_thread.start()
+        if self.stall_warn_seconds > 0:
+            self._stall_thread = threading.Thread(
+                target=self._stall_watchdog_loop, name="bigqmt-zmq-stall",
+                daemon=True)
+            self._stall_thread.start()
         print(
             "%s zmq started bound=%s" % (self.print_prefix, self.bind_address)
         )
@@ -298,14 +316,55 @@ class ZmqTransport(RpcTransport):
 
     def _deliver_request(self, request):
         started = time.perf_counter()
+        method = request.get("method")
+        # Published for the watchdog. Handlers run one at a time on this
+        # thread, so a single slot is enough.
+        self._in_flight = (method, started, threading.current_thread().name)
         try:
             self.deliver(request)
         except Exception as exc:
             print("%s zmq deliver failed: %s" % (self.print_prefix, exc))
+        finally:
+            self._in_flight = None
         elapsed_ms = (time.perf_counter() - started) * 1000.0
         if elapsed_ms > 50.0:
             print("%s zmq slow handler method=%s %.0fms"
-                  % (self.print_prefix, request.get("method"), elapsed_ms))
+                  % (self.print_prefix, method, elapsed_ms))
+
+    def _stall_watchdog_loop(self):
+        """Report a handler that is STILL running, while it still is.
+
+        The slow-handler line above is measured after deliver() returns, so a
+        handler that blocks says nothing until it finishes. One did, for 346
+        seconds: get_financial_data on the first call after a restart, while
+        QMT itself was healthy and the main strategy thread idle. Every
+        request queued behind it timed out, and the only clue in the log
+        arrived once it was already over.
+
+        A stalled bridge and a dead one look identical from the client. This
+        is what tells them apart, at the time it matters.
+        """
+        reported_at = 0.0
+        while self._running:
+            time.sleep(self.stall_check_seconds)
+            snapshot = self._in_flight
+            if snapshot is None:
+                reported_at = 0.0
+                continue
+            method, started, thread_name = snapshot
+            elapsed = time.perf_counter() - started
+            if elapsed < self.stall_warn_seconds:
+                continue
+            # Back off: every interval at first, then less often, so a very
+            # long stall does not bury the log it is meant to explain.
+            interval = self.stall_warn_seconds * (2 ** min(reported_at, 6))
+            if reported_at and elapsed < interval:
+                continue
+            reported_at += 1
+            print("%s zmq handler STILL RUNNING method=%s %.0fs thread=%s "
+                  "queued=%d -- the bridge is blocked, not dead"
+                  % (self.print_prefix, method, elapsed, thread_name,
+                     self._response_queue.qsize()))
 
     def _drain_response_queue(self):
         while True:

--- a/src/bigqmt_signal_trader/transports/zmq_transport.py
+++ b/src/bigqmt_signal_trader/transports/zmq_transport.py
@@ -170,6 +170,8 @@ class ZmqTransport(RpcTransport):
             ),
             discovery_ttl_seconds=int(config.get("discovery_ttl_seconds", 300)),
             port_scan_range=int(config.get("port_scan_range", 50)),
+            stall_warn_seconds=float(config.get("stall_warn_seconds", 20.0)),
+            stall_check_seconds=float(config.get("stall_check_seconds", 5.0)),
         )
 
     # -- shared zmq context -----------------------------------------------

--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -805,6 +805,10 @@ def init(ContextInfo):
 
     # 启动时自动诊断：检测服务状态 + 关键函数绑定，方便发现问题
     _diag_startup(ContextInfo, config)
+    try:
+        _start_context_warmup(ContextInfo, config)
+    except Exception as exc:
+        _log_startup_error("context warmup failed to start: %s" % exc)
     return app
 
 
@@ -918,6 +922,66 @@ def _diag_startup(ContextInfo, config):
 
     print("[bigqmt_diag] diagnostics complete")
     print("=" * 60)
+
+
+# ContextInfo families whose FIRST call after a restart can cost minutes.
+#
+# get_full_tick is already exercised by _diag_startup, on the main thread, and
+# comes back in milliseconds. get_financial_data is not, and it was measured at
+# 346 SECONDS on its first call after a restart -- while QMT itself was healthy
+# (whole-quote data flowing, threadpool alive) and the main strategy thread was
+# idle. Every later call that day took under a second, including codes and
+# tables never asked for before, so it is a one-time cost and not a per-code
+# cache miss.
+#
+# That block lands on the RPC listener thread, which serves one request at a
+# time, so it takes the whole bridge down with it: every queued request times
+# out and the client sees a dead bridge.
+#
+# Warming does not make the cost cheaper. It moves it to a known moment, onto a
+# thread nobody is waiting on, with a log line saying what is happening --
+# instead of arriving as an unexplained freeze the first time a caller asks.
+#
+# Deliberately NOT on the main thread: _diag_startup runs there during init, and
+# a 346-second call in init would freeze startup before the adjust timer is even
+# scheduled -- worse than the problem.
+CONTEXT_WARMUP_PROBES = (
+    ("get_financial_data",
+     lambda ctx: ctx.get_financial_data(
+         ["CAPITALSTRUCTURE.total_capital"], ["000001.SZ"], "", "", "report_time")),
+)
+
+
+def _context_warmup_loop(context_info):
+    for name, probe in CONTEXT_WARMUP_PROBES:
+        started = time.time()
+        print("[bigqmt_warmup] %s: first call after a restart can take "
+              "minutes; running it now so a caller does not have to wait" % name)
+        try:
+            probe(context_info)
+            elapsed = time.time() - started
+        except Exception as exc:
+            print("[bigqmt_warmup] %s failed after %.1fs: %s"
+                  % (name, time.time() - started, str(exc)[:120]))
+            continue
+        if elapsed > 10.0:
+            print("[bigqmt_warmup] %s warm after %.1fs -- that wait is now "
+                  "paid; callers should see sub-second responses" % (name, elapsed))
+        else:
+            print("[bigqmt_warmup] %s warm in %.2fs" % (name, elapsed))
+
+
+def _start_context_warmup(context_info, config):
+    """Kick the warmup onto a daemon thread. Never blocks init."""
+    flag = dict(config.get("rpc") or {}).get("warm_context_data", True)
+    if isinstance(flag, str):
+        flag = flag.strip().lower() not in ("0", "false", "no", "off", "")
+    if not flag:
+        return
+    thread = threading.Thread(
+        target=_context_warmup_loop, args=(context_info,),
+        name="bigqmt-context-warmup", daemon=True)
+    thread.start()
 
 
 def _pump_download_jobs(context_info, config):

--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -945,11 +945,40 @@ def _diag_startup(ContextInfo, config):
 # Deliberately NOT on the main thread: _diag_startup runs there during init, and
 # a 346-second call in init would freeze startup before the adjust timer is even
 # scheduled -- worse than the problem.
+def _warm_financial_data(context_info):
+    """Fetch a real slice, not an empty one.
+
+    An EMPTY date range is accepted and returns None instantly. The first
+    version of this warmup passed "" for both and reported "warm in 0.00s"
+    while exercising nothing at all -- a warmup that silently no-ops is worse
+    than none, because the log says it worked. Measured against the live
+    terminal, same code and stock:
+
+        dotted field + real range   0.75s  DataFrame rows=159
+        dotted field + empty range  0.17s  None
+        whole table  + real range   0.41s  DataFrame rows=159
+        whole table  + empty range  0.20s  Series rows=6
+    """
+    end = datetime.date.today()
+    start = end - datetime.timedelta(days=365)
+    return context_info.get_financial_data(
+        ["CAPITALSTRUCTURE.total_capital"], ["000001.SZ"],
+        start.strftime("%Y%m%d"), end.strftime("%Y%m%d"), "report_time")
+
+
 CONTEXT_WARMUP_PROBES = (
-    ("get_financial_data",
-     lambda ctx: ctx.get_financial_data(
-         ["CAPITALSTRUCTURE.total_capital"], ["000001.SZ"], "", "", "report_time")),
+    ("get_financial_data", _warm_financial_data),
 )
+
+
+def _warmup_row_count(result):
+    """How much a probe brought back, or -1 when that cannot be told."""
+    if result is None:
+        return 0
+    try:
+        return len(result)
+    except Exception:
+        return -1
 
 
 def _context_warmup_loop(context_info):
@@ -958,17 +987,26 @@ def _context_warmup_loop(context_info):
         print("[bigqmt_warmup] %s: first call after a restart can take "
               "minutes; running it now so a caller does not have to wait" % name)
         try:
-            probe(context_info)
+            result = probe(context_info)
             elapsed = time.time() - started
         except Exception as exc:
             print("[bigqmt_warmup] %s failed after %.1fs: %s"
                   % (name, time.time() - started, str(exc)[:120]))
             continue
-        if elapsed > 10.0:
-            print("[bigqmt_warmup] %s warm after %.1fs -- that wait is now "
-                  "paid; callers should see sub-second responses" % (name, elapsed))
+        rows = _warmup_row_count(result)
+        if rows == 0:
+            # Warming nothing while reporting success is the failure mode this
+            # check exists to catch; it already happened once.
+            print("[bigqmt_warmup] %s returned NOTHING in %.2fs -- the probe "
+                  "did not exercise the path it is meant to warm, so the "
+                  "first real caller will still pay the wait" % (name, elapsed))
+        elif elapsed > 10.0:
+            print("[bigqmt_warmup] %s warm after %.1fs (%s rows) -- that wait "
+                  "is now paid; callers should see sub-second responses"
+                  % (name, elapsed, rows))
         else:
-            print("[bigqmt_warmup] %s warm in %.2fs" % (name, elapsed))
+            print("[bigqmt_warmup] %s warm in %.2fs (%s rows)"
+                  % (name, elapsed, rows))
 
 
 def _start_context_warmup(context_info, config):

--- a/tests/bigqmt_signal_trader/test_context_warmup.py
+++ b/tests/bigqmt_signal_trader/test_context_warmup.py
@@ -15,6 +15,7 @@ must NOT be on the main thread: _diag_startup runs there during init, and a
 scheduled -- worse than the problem it set out to fix.
 """
 
+import datetime
 import io
 import os
 import re
@@ -39,26 +40,111 @@ def _strategy_namespace():
     """
     with io.open(STRATEGY, encoding="utf-8") as handle:
         source = handle.read()
-    start = source.index("CONTEXT_WARMUP_PROBES = (")
+    start = source.index("def _warm_financial_data(")
     end = source.index("def _pump_download_jobs(", start)
-    namespace = {"time": time, "threading": threading}
+    namespace = {"time": time, "threading": threading, "datetime": datetime}
     exec(compile(source[start:end], STRATEGY, "exec"), namespace)
     return namespace
 
 
 class FakeContext(object):
-    def __init__(self, delay=0.0, blow_up=False):
+    """Mirrors what the live terminal does: an empty date range returns None."""
+
+    def __init__(self, delay=0.0, blow_up=False, rows=159):
         self.calls = []
         self._delay = delay
         self._blow_up = blow_up
+        self._rows = rows
 
-    def get_financial_data(self, *args, **kwargs):
-        self.calls.append(args)
+    def get_financial_data(self, fields, codes, start_time, end_time, report_type):
+        self.calls.append((fields, codes, start_time, end_time, report_type))
         if self._delay:
             time.sleep(self._delay)
         if self._blow_up:
             raise RuntimeError("QMT said no")
-        return {}
+        if not start_time or not end_time:
+            return None            # measured: empty range fetches nothing
+        return list(range(self._rows))
+
+
+class RealRangeTest(unittest.TestCase):
+    """The first version passed "" for both dates and warmed nothing."""
+
+    def test_the_probe_asks_for_a_real_date_range(self):
+        namespace = _strategy_namespace()
+        context = FakeContext()
+
+        namespace["_warm_financial_data"](context)
+
+        _fields, _codes, start, end, _report = context.calls[0]
+        self.assertTrue(start, "start_time was empty -- fetches nothing")
+        self.assertTrue(end, "end_time was empty -- fetches nothing")
+
+    def test_the_range_is_eight_digit_dates(self):
+        namespace = _strategy_namespace()
+        context = FakeContext()
+
+        namespace["_warm_financial_data"](context)
+
+        _fields, _codes, start, end, _report = context.calls[0]
+        self.assertRegex(start, r"^\d{8}$")
+        self.assertRegex(end, r"^\d{8}$")
+
+    def test_the_range_is_not_empty(self):
+        namespace = _strategy_namespace()
+        context = FakeContext()
+
+        namespace["_warm_financial_data"](context)
+
+        _fields, _codes, start, end, _report = context.calls[0]
+        self.assertLess(start, end)
+
+    def test_it_actually_brings_rows_back(self):
+        namespace = _strategy_namespace()
+        context = FakeContext()
+
+        result = namespace["_warm_financial_data"](context)
+
+        self.assertEqual(namespace["_warmup_row_count"](result), 159)
+
+
+class EmptyResultIsReportedTest(unittest.TestCase):
+    """A warmup that warms nothing must not report success."""
+
+    def _run(self, context):
+        namespace = _strategy_namespace()
+        recorder = []
+        import builtins
+        saved = builtins.print
+        try:
+            builtins.print = lambda *a: recorder.append(" ".join(str(x) for x in a))
+            namespace["_context_warmup_loop"](context)
+        finally:
+            builtins.print = saved
+        return recorder
+
+    def test_nothing_fetched_says_so(self):
+        class Empty(FakeContext):
+            def get_financial_data(self, *args):
+                self.calls.append(args)
+                return None
+
+        lines = self._run(Empty())
+
+        self.assertTrue([l for l in lines if "returned NOTHING" in l], lines)
+
+    def test_a_real_fetch_reports_the_row_count(self):
+        lines = self._run(FakeContext())
+
+        warm = [l for l in lines if "warm in" in l or "warm after" in l]
+        self.assertTrue(warm, lines)
+        self.assertIn("159", warm[0])
+
+    def test_row_count_survives_an_object_without_len(self):
+        namespace = _strategy_namespace()
+
+        self.assertEqual(namespace["_warmup_row_count"](object()), -1)
+        self.assertEqual(namespace["_warmup_row_count"](None), 0)
 
 
 class ProbeTest(unittest.TestCase):

--- a/tests/bigqmt_signal_trader/test_context_warmup.py
+++ b/tests/bigqmt_signal_trader/test_context_warmup.py
@@ -1,0 +1,175 @@
+"""The first ContextInfo call after a restart is paid at startup, not by a caller.
+
+get_financial_data was measured at 346 seconds on its first call after a
+restart -- while QMT itself was healthy and the main strategy thread idle.
+Every later call that day took under a second, including codes and tables
+never asked for before, so it is a one-time cost rather than a per-code miss.
+
+That block lands on the RPC listener thread, which serves one request at a
+time, so it takes the whole bridge down with it.
+
+Warming does not make the cost cheaper. It moves it to a known moment, onto a
+thread nobody is waiting on, with a log line saying what is happening. And it
+must NOT be on the main thread: _diag_startup runs there during init, and a
+346-second call in init would freeze startup before the adjust timer is even
+scheduled -- worse than the problem it set out to fix.
+"""
+
+import io
+import os
+import re
+import sys
+import threading
+import time
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SRC = os.path.join(ROOT, "src")
+sys.path.insert(0, SRC)
+
+STRATEGY = os.path.join(SRC, "bigqmt_signal_trader_strategy.py")
+
+
+def _strategy_namespace():
+    """Exec just the warmup helpers out of the strategy entry.
+
+    The module as a whole expects QMT globals; the pieces under test are
+    self-contained.
+    """
+    with io.open(STRATEGY, encoding="utf-8") as handle:
+        source = handle.read()
+    start = source.index("CONTEXT_WARMUP_PROBES = (")
+    end = source.index("def _pump_download_jobs(", start)
+    namespace = {"time": time, "threading": threading}
+    exec(compile(source[start:end], STRATEGY, "exec"), namespace)
+    return namespace
+
+
+class FakeContext(object):
+    def __init__(self, delay=0.0, blow_up=False):
+        self.calls = []
+        self._delay = delay
+        self._blow_up = blow_up
+
+    def get_financial_data(self, *args, **kwargs):
+        self.calls.append(args)
+        if self._delay:
+            time.sleep(self._delay)
+        if self._blow_up:
+            raise RuntimeError("QMT said no")
+        return {}
+
+
+class ProbeTest(unittest.TestCase):
+    def test_it_warms_get_financial_data(self):
+        namespace = _strategy_namespace()
+        names = [name for name, _ in namespace["CONTEXT_WARMUP_PROBES"]]
+
+        self.assertIn("get_financial_data", names)
+
+    def test_the_probe_actually_calls_it(self):
+        namespace = _strategy_namespace()
+        context = FakeContext()
+
+        namespace["_context_warmup_loop"](context)
+
+        self.assertEqual(len(context.calls), 1)
+
+    def test_a_probe_failure_does_not_stop_the_rest(self):
+        namespace = _strategy_namespace()
+        context = FakeContext(blow_up=True)
+
+        namespace["_context_warmup_loop"](context)   # must not raise
+
+        self.assertEqual(len(context.calls), 1)
+
+
+class OffTheMainThreadTest(unittest.TestCase):
+    """The point of the whole thing: init must return immediately."""
+
+    def test_starting_it_does_not_block(self):
+        namespace = _strategy_namespace()
+        context = FakeContext(delay=1.5)
+
+        started = time.time()
+        namespace["_start_context_warmup"](context, {})
+        elapsed = time.time() - started
+
+        self.assertLess(elapsed, 0.5, "warmup blocked the caller for %.2fs" % elapsed)
+
+    def test_it_runs_on_a_daemon_thread(self):
+        """A strategy stop must not wait on it."""
+        namespace = _strategy_namespace()
+        before = set(t.name for t in threading.enumerate())
+
+        namespace["_start_context_warmup"](FakeContext(delay=0.5), {})
+        time.sleep(0.1)
+        new = [t for t in threading.enumerate() if t.name not in before]
+
+        warmers = [t for t in new if "warmup" in t.name]
+        self.assertTrue(warmers, [t.name for t in new])
+        self.assertTrue(warmers[0].daemon)
+
+    def test_it_can_be_turned_off(self):
+        namespace = _strategy_namespace()
+        context = FakeContext()
+
+        namespace["_start_context_warmup"](
+            context, {"rpc": {"warm_context_data": False}})
+        time.sleep(0.2)
+
+        self.assertEqual(context.calls, [])
+
+    def test_a_string_false_turns_it_off_too(self):
+        """Config files hand these through as text often enough."""
+        namespace = _strategy_namespace()
+        context = FakeContext()
+
+        namespace["_start_context_warmup"](
+            context, {"rpc": {"warm_context_data": "false"}})
+        time.sleep(0.2)
+
+        self.assertEqual(context.calls, [])
+
+    def test_it_is_on_by_default(self):
+        namespace = _strategy_namespace()
+        context = FakeContext()
+
+        namespace["_start_context_warmup"](context, {})
+        time.sleep(0.3)
+
+        self.assertEqual(len(context.calls), 1)
+
+
+class WiringTest(unittest.TestCase):
+    def test_init_starts_it_after_the_diagnostics(self):
+        with io.open(STRATEGY, encoding="utf-8") as handle:
+            source = handle.read()
+
+        self.assertIn("_start_context_warmup(ContextInfo, config)", source)
+        self.assertLess(source.index("_diag_startup(ContextInfo, config)"),
+                        source.index("_start_context_warmup(ContextInfo, config)"))
+
+    def test_a_start_failure_cannot_kill_init(self):
+        with io.open(STRATEGY, encoding="utf-8") as handle:
+            source = handle.read()
+        start = source.index("_start_context_warmup(ContextInfo, config)")
+
+        self.assertIn("except Exception", source[start:start + 260])
+
+    def test_the_diagnostics_still_do_not_call_it_on_the_main_thread(self):
+        """_diag_startup runs in init; a 346s probe there would freeze
+        startup before the adjust timer is scheduled."""
+        with io.open(STRATEGY, encoding="utf-8") as handle:
+            source = handle.read()
+        start = source.index("def _diag_startup(")
+        # The next top-level thing after it is the warmup block, not a def.
+        end = min(source.index("\ndef ", start + 1),
+                  source.index("\n# ContextInfo families", start + 1))
+
+        self.assertNotIn("get_financial_data", source[start:end])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_stall_watchdog.py
+++ b/tests/bigqmt_signal_trader/test_stall_watchdog.py
@@ -1,0 +1,188 @@
+"""A blocked handler has to be visible while it is blocked.
+
+The slow-handler line the transport already printed is measured after
+deliver() returns, so a handler that blocks says nothing at all until it
+finishes. One did, for 346 seconds -- get_financial_data on the first call
+after a restart -- and every request queued behind it timed out. The only clue
+in the log arrived once it was already over.
+
+From the client, a stalled bridge and a dead one are the same thing: a
+timeout. This is what tells them apart, at the time it matters.
+
+Handlers are served one at a time, so a single in-flight slot is enough.
+"""
+
+import os
+import sys
+import threading
+import time
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.transports.zmq_transport import ZmqTransport
+
+
+class Recorder(object):
+    def __init__(self):
+        self.lines = []
+
+    def __call__(self, text):
+        self.lines.append(str(text))
+
+    def matching(self, needle):
+        return [line for line in self.lines if needle in line]
+
+
+def _transport(**kwargs):
+    settings = dict(account_id="acct", stall_warn_seconds=0.05,
+                    stall_check_seconds=0.5)
+    settings.update(kwargs)
+    return ZmqTransport(**settings)
+
+
+class InFlightTest(unittest.TestCase):
+    """What the watchdog reads."""
+
+    def test_it_is_empty_when_idle(self):
+        self.assertIsNone(_transport()._in_flight)
+
+    def test_a_handler_publishes_itself(self):
+        transport = _transport()
+        seen = {}
+
+        def deliver(request):
+            seen["slot"] = transport._in_flight
+
+        transport.deliver = deliver
+        transport._deliver_request({"method": "get_financial_data"})
+
+        method, started, thread_name = seen["slot"]
+        self.assertEqual(method, "get_financial_data")
+        self.assertIsInstance(started, float)
+        self.assertTrue(thread_name)
+
+    def test_the_slot_is_cleared_afterwards(self):
+        transport = _transport()
+        transport.deliver = lambda request: None
+
+        transport._deliver_request({"method": "ping"})
+
+        self.assertIsNone(transport._in_flight)
+
+    def test_it_is_cleared_even_when_the_handler_raises(self):
+        """A handler that blows up must not leave the bridge looking stuck."""
+        transport = _transport()
+
+        def deliver(request):
+            raise RuntimeError("boom")
+
+        transport.deliver = deliver
+        transport._deliver_request({"method": "ping"})
+
+        self.assertIsNone(transport._in_flight)
+
+
+class WatchdogTest(unittest.TestCase):
+    """What it prints, and when."""
+
+    def _run_watchdog(self, transport, seconds=1.2):
+        transport._running = True
+        thread = threading.Thread(target=transport._stall_watchdog_loop, daemon=True)
+        thread.start()
+        time.sleep(seconds)
+        transport._running = False
+        thread.join(2.0)
+
+    def test_it_says_nothing_while_idle(self):
+        transport = _transport()
+        recorder = Recorder()
+        transport.print_prefix = "[t]"
+
+        import builtins
+        saved = builtins.print
+        try:
+            builtins.print = recorder
+            self._run_watchdog(transport, seconds=0.8)
+        finally:
+            builtins.print = saved
+
+        self.assertEqual(recorder.matching("STILL RUNNING"), [])
+
+    def test_it_reports_a_handler_that_is_still_running(self):
+        transport = _transport()
+        transport._in_flight = ("get_financial_data", time.perf_counter() - 300.0,
+                                "bigqmt-zmq-rpc")
+        recorder = Recorder()
+
+        import builtins
+        saved = builtins.print
+        try:
+            builtins.print = recorder
+            self._run_watchdog(transport, seconds=0.8)
+        finally:
+            builtins.print = saved
+
+        reports = recorder.matching("STILL RUNNING")
+        self.assertTrue(reports, recorder.lines)
+        self.assertIn("get_financial_data", reports[0])
+
+    def test_the_report_says_blocked_not_dead(self):
+        """The distinction the client cannot make on its own."""
+        transport = _transport()
+        transport._in_flight = ("get_financial_data", time.perf_counter() - 300.0,
+                                "bigqmt-zmq-rpc")
+        recorder = Recorder()
+
+        import builtins
+        saved = builtins.print
+        try:
+            builtins.print = recorder
+            self._run_watchdog(transport, seconds=0.8)
+        finally:
+            builtins.print = saved
+
+        self.assertIn("blocked, not dead", recorder.matching("STILL RUNNING")[0])
+
+    def test_a_quick_handler_is_not_reported(self):
+        transport = _transport(stall_warn_seconds=30.0)
+        transport._in_flight = ("ping", time.perf_counter() - 0.01, "t")
+        recorder = Recorder()
+
+        import builtins
+        saved = builtins.print
+        try:
+            builtins.print = recorder
+            self._run_watchdog(transport, seconds=0.8)
+        finally:
+            builtins.print = saved
+
+        self.assertEqual(recorder.matching("STILL RUNNING"), [])
+
+
+class ConfigTest(unittest.TestCase):
+    def test_the_default_fires_before_a_client_gives_up(self):
+        """A client's default timeout is 30s; the log has to name the culprit
+        before the caller has already concluded the bridge is dead."""
+        from bigqmt_signal_trader.xtquant_compat import DEFAULT_RPC_TIMEOUT_SECONDS
+
+        self.assertLess(_transport(stall_warn_seconds=20.0).stall_warn_seconds,
+                        DEFAULT_RPC_TIMEOUT_SECONDS)
+
+    def test_it_clears_the_slowest_healthy_call(self):
+        """A whole-market snapshot measures 7.7s and is not a stall."""
+        self.assertGreater(ZmqTransport(account_id="a").stall_warn_seconds, 7.7)
+
+    def test_zero_disables_it(self):
+        self.assertEqual(_transport(stall_warn_seconds=0).stall_warn_seconds, 0.0)
+
+    def test_the_check_interval_has_a_floor(self):
+        """A tight loop would cost more than the problem it reports."""
+        self.assertGreaterEqual(_transport(stall_check_seconds=0.0).stall_check_seconds,
+                                0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
追查 0.3.6 验证时那个 346 秒的 `get_financial_data`，挖出两个**可见性**缺口（不是速度问题）。

## 1. 卡住的时候，日志一个字都不说

`zmq slow handler` 是在 `deliver()` **返回之后**计时的，所以一个阻塞住的 handler 在结束之前什么都不打印。那 346 秒里日志只有 adjust 心跳，每 10 秒 100 拍——**主线程全程空闲，看上去一切健康**。

而从客户端看，「桥卡住」和「桥死了」是同一件事：超时。

现在有一个 watchdog 线程，在 handler **还在跑的时候**就报：

```
[bigqmt_rpc] zmq handler STILL RUNNING method=get_financial_data 40s
thread=bigqmt-zmq-rpc queued=3 -- the bridge is blocked, not dead
```

- 默认 20 秒开始报——比实测最慢的健康调用（整市场快照 7.7s）长得多，又短于客户端 30 秒的默认超时，**所以日志会在调用方放弃之前就点名**
- 指数退避，免得一次长阻塞把它自己要解释的日志淹掉
- `stall_warn_seconds=0` 关闭

## 2. 重启后的第一次调用，让启动去付

`get_full_tick` 启动时已经被 `_diag_startup` 摸过一次（毫秒级返回），`get_financial_data` 没有——而卡住的正是它。

当天后续调用全部亚秒级，**包括从没查过的票和没查过的表**，所以这是一次性代价，不是按代码的缓存未命中。

预热**不会让这个代价变便宜**，它只是把代价挪到一个确定的时刻、一个没人等待的线程上，并且带一行说明：

```
[bigqmt_warmup] get_financial_data: first call after a restart can take
minutes; running it now so a caller does not have to wait
[bigqmt_warmup] get_financial_data warm after 346.0s -- that wait is now paid
```

**特意不放主线程。** `_diag_startup` 跑在 init 里，把一个可能 346 秒的调用加进去会在 adjust 定时器都还没排上的时候冻住启动——比原问题更糟。有一条测试钉着诊断里永远不出现这个调用。

`rpc.warm_context_data = False` 可关闭。

## 仍未查清

为什么一个 `ContextInfo` 调用会在后台 listener 线程上阻塞 346 秒，而 QMT 自身健康、主线程空闲。

**watchdog 就是用来回答它的**：下次再发生，日志会在事情进行中点名是哪个调用、跑了多久、后面排了几个。现在只能事后看到一个数字。

24 个新测试。830 通过，65/65 文件收集。
