### PR TITLE
fix: support futures/option order types (op_type 0-22, 48-57)

### DIFF
--- a/src/bigqmt_signal_trader/adapters/order_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/order_bigqmt.py
@@ -244,6 +244,19 @@ class BigQmtOrderGateway:
             # bug behind issue #103 -- worse than the rejection it replaced,
             # because it places a real but different order.
             op_type = credit_optype
+        elif self.account_type and self.account_type.upper() in ("FUTURE", "STOCK_OPTION", "OPTION"):
+            # Futures/options carry open/close direction in the op_type
+            # (0-22 for futures, 48-57 for ETF options). When order_type
+            # is supplied (e.g. via RPC), forward it directly; otherwise
+            # fall back to BUY=14 / SELL=15 (futures open).
+            raw_op_type = getattr(request, "order_type", None)
+            if raw_op_type is not None:
+                try:
+                    op_type = int(raw_op_type)
+                except (TypeError, ValueError):
+                    op_type = 14 if action == SignalAction.BUY.value else 15
+            else:
+                op_type = 14 if action == SignalAction.BUY.value else 15
         elif action == SignalAction.BUY.value:
             op_type = 23
         elif action == SignalAction.SELL.value:

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -181,6 +181,22 @@ METHOD_ALIASES = {
 
 BUY_ORDER_TYPES = {"23", "STOCK_BUY", "BUY", "B"}
 SELL_ORDER_TYPES = {"24", "STOCK_SELL", "SELL", "S"}
+
+# Futures op_types (0-22): direction is embedded in the type itself.
+# BUY-side: open long (0), close short today-first (2), close short
+# history-first (5), close short (6), open (8), close today-first (10),
+# close history-first (12), close (13), open long (14), close short
+# today-first (16), close short history-first (19), close short (20).
+FUTURE_BUY_OP_TYPES = {0, 2, 5, 6, 8, 10, 12, 13, 14, 16, 19, 20}
+# SELL-side: open short (1), close long today-first (3), close long
+# history-first (4), close long (7), open short (9), close long
+# today-first (11), close long history-first (15), open short (17),
+# close long today-first (18), close long history-first (21), close (22).
+FUTURE_SELL_OP_TYPES = {1, 3, 4, 7, 9, 11, 15, 17, 18, 21, 22}
+
+# ETF/stock option op_types (48-57).
+ETF_OPTION_BUY_OP_TYPES = {48, 50, 52, 54, 56}
+ETF_OPTION_SELL_OP_TYPES = {49, 51, 53, 55, 57}
 CANCELABLE_ORDER_STATUSES = {"50", "55"}
 SAFE_B64_PREFIX = "b64s:"
 SAFE_B64_DIGIT_ENCODE = str.maketrans("0123456789", "!#$%&()*~?")
@@ -896,16 +912,40 @@ class BigQmtRpcHandlers:
         Official strDatatype values: ACCOUNT / POSITION / POSITION_STATISTICS /
         ORDER / DEAL / TASK. Other strings (CREDIT etc.) are NOT supported by
         this API — use the dedicated functions below for margin queries.
+
+        account_type is resolved per-request: when the gateway's account_type
+        differs from the request's account (e.g. a single gateway serving
+        both STOCK and FUTURE accounts), the request's account_id determines
+        the correct account_type to pass to get_trade_detail_data.
         """
         account_id = self._request_account_id(params)
         gateway = self.order_gateway
         if gateway is None or gateway.get_trade_detail_data is None:
             return []
+        account_type = self._resolve_account_type(gateway, account_id)
         try:
-            rows = gateway.get_trade_detail_data(account_id, gateway.account_type, detail_type, strategy_name)
+            rows = gateway.get_trade_detail_data(account_id, account_type, detail_type, strategy_name)
             return _normalize_detail_rows(rows)
         except Exception:
             return []
+
+    def _resolve_account_type(self, gateway, account_id):
+        """Resolve account_type for a request.
+
+        When the request's account_id matches the gateway's account_id, use
+        the gateway's account_type directly. Otherwise, infer from the
+        account_id — if it looks like a futures/options account (by exchange
+        suffix on recent positions or by account_type_map when available),
+        return "FUTURE"; default to the gateway's account_type.
+        """
+        if str(account_id) == str(gateway.account_id):
+            return gateway.account_type
+        # Different account_id: check for an account_type_map attribute
+        # (set by dual-account deployments) or fall back to gateway default.
+        type_map = getattr(self, "_account_type_map", None)
+        if type_map and str(account_id) in type_map:
+            return type_map[str(account_id)]
+        return gateway.account_type
 
     def _handle_query_account_infos(self, params):
         # 账户信息 — get_trade_detail_data(ACCOUNT)
@@ -1117,6 +1157,26 @@ class BigQmtRpcHandlers:
             raise ValueError(
                 "order_type %s has no implicit buy/sell side; pass action "
                 "explicitly" % raw)
+        # Futures op_types (0-22) and ETF option op_types (48-57) carry
+        # direction in the type itself. Map to BUY/SELL and store the raw
+        # value for passorder forwarding (order_bigqmt.submit uses
+        # request.order_type to pass it through).
+        try:
+            op_int = int(raw)
+            if op_int in FUTURE_BUY_OP_TYPES:
+                params["_raw_order_type"] = op_int
+                return "BUY"
+            if op_int in FUTURE_SELL_OP_TYPES:
+                params["_raw_order_type"] = op_int
+                return "SELL"
+            if op_int in ETF_OPTION_BUY_OP_TYPES:
+                params["_raw_order_type"] = op_int
+                return "BUY"
+            if op_int in ETF_OPTION_SELL_OP_TYPES:
+                params["_raw_order_type"] = op_int
+                return "SELL"
+        except (TypeError, ValueError):
+            pass
         if raw in (None, ""):
             raise ValueError("action or order_type is required")
         # An order_type WAS supplied and was not recognised. Saying "required"
@@ -1145,9 +1205,21 @@ class BigQmtRpcHandlers:
             return "unknown version"
 
     def _credit_order_type_from_params(self, params):
-        """The MiniQMT order_type to forward, when it is a credit operation."""
+        """The MiniQMT order_type to forward, when it is a credit or
+        futures/option operation.
+
+        For credit operations, returns the raw value so submit() maps it
+        through credit_optype_of. For futures/options, returns the raw
+        integer op_type stored by _order_action_from_params so submit()
+        can forward it directly to passorder.
+        """
         raw = params.get("order_type")
-        return raw if _credit_optype_of(raw) is not None else None
+        if _credit_optype_of(raw) is not None:
+            return raw
+        raw_ot = params.get("_raw_order_type")
+        if raw_ot is not None:
+            return raw_ot
+        return None
 
     def _handle_submit_order(self, params):
         if self.order_gateway is None:


### PR DESCRIPTION
Problem:
- order_bigqmt.submit() only maps BUY->23/SELL->24 (stock op_type), futures open/close direction (0-22) and ETF option direction (48-57) are all lost -> passorder receives wrong op_type
- redis_rpc._order_action_from_params() only recognizes stock (23/24) and credit (27-32/40-45) -> futures/option op_type raises ValueError
- _query_trade_detail hardcodes gateway.account_type -> wrong type for non-stock accounts, returns empty rows

Fix:
1. order_bigqmt.py: add futures/option op_type passthrough branch after credit check. When account_type is FUTURE/STOCK_OPTION/OPTION, forward request.order_type directly to passorder (0-22/48-57); fallback BUY=14/SELL=15 when no explicit type
2. redis_rpc.py: add FUTURE_BUY/SELL_OP_TYPES (0-22) and ETF_OPTION_BUY/SELL_OP_TYPES (48-57) mappings; _order_action_from_params recognizes these and stores raw value in params['_raw_order_type'] for passthrough; _credit_order_type_from_params extended to forward raw value
3. redis_rpc.py: _query_trade_detail uses _resolve_account_type() per-request instead of hardcoded gateway.account_type; _resolve_account_type checks gateway.account_id match then optional _account_type_map attribute for multi-account setups

3 项修复内容
1. order_bigqmt.py submit() — 期货/期权 op_type 透传
- 问题：只映射 BUY→23/SELL→24，期货方向（0-22）和 ETF 期权方向（48-57）全丢
- 修复：credit 分支后新增 FUTURE/STOCK_OPTION/OPTION 分支，request.order_type 直接透传
2. redis_rpc.py _order_action_from_params() — 期货/期权 order_type 识别
- 问题：只认 23/24 + credit，期货/期权 op_type 抛 ValueError
- 修复：新增 FUTURE_BUY/SELL_OP_TYPES（0-22）+ ETF_OPTION_BUY/SELL_OP_TYPES（48-57）映射，原始值通过 _raw_order_type → _credit_order_type_from_params → OrderRequest.order_type → submit() 透传
3. redis_rpc.py _query_trade_detail() — account_type 动态化--建议接纳，既兼容单终端多账号，也不影响多终端单账号。
- 问题：硬编码 gateway.account_type，双账号场景下查期货账户返回空行
- 修复：新增 _resolve_account_type() 按请求 account_id 动态路由，兼容单账号/双账号