### PR TITLE
fix: 期货 / ETF 期权 opType 直通（对着官方枚举，含股票账号拒绝）

### DIFF
--- a/src/bigqmt_signal_trader/adapters/order_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/order_bigqmt.py
@@ -67,6 +67,81 @@ _CREDIT_SELL_SIDE = frozenset({
 })
 
 
+# passorder 的 opType 直通表：期货和 ETF 期权把「开/平、今/昨」编码在 opType
+# 本身里。映射回 BUY/SELL 再重新拼一个 opType 会丢掉这些信息 —— 平今多会变成
+# 普通卖出，这跟 issue #103 里 融资买入 变普通买入 是同一类错误。所以原样透传。
+#
+# 依据：https://dict.thinktrader.net/innerApi/enum_constants.html?id=NF25nX
+#   期货/股指期权/商品期权   0-15   六键 0-5、四键 6-9、两键 10-15
+#   ETF 期权                50-59
+# 官方表里 16-22 没有定义，不要往里塞。
+FUTURE_OP_TYPES = frozenset(range(0, 16))
+ETF_OPTION_OP_TYPES = frozenset(range(50, 60))
+PASSTHROUGH_OP_TYPES = FUTURE_OP_TYPES | ETF_OPTION_OP_TYPES
+
+# 只用于记账的买卖方向。真正送进 passorder 的是上面的原始 opType。
+#   平多 / 平昨多 / 平今多 是卖出动作；平空 / 平昨空 / 平今空 是买入动作。
+_FUTURE_BUY_SIDE = frozenset({
+    0,   # 开多
+    4,   # 平昨空
+    5,   # 平今空
+    8,   # 平空，优先平今
+    9,   # 平空，优先平昨
+    12,  # 买入，如有空仓优先平今，余量开多
+    13,  # 买入，如有空仓优先平昨，余量开多
+    14,  # 买入，不优先平仓
+})
+_FUTURE_SELL_SIDE = frozenset({
+    1,   # 平昨多
+    2,   # 平今多
+    3,   # 开空
+    6,   # 平多，优先平今
+    7,   # 平多，优先平昨
+    10,  # 卖出，如有多仓优先平今，余量开空
+    11,  # 卖出，如有多仓优先平昨，余量开空
+    15,  # 卖出，不优先平仓
+})
+_ETF_OPTION_BUY_SIDE = frozenset({
+    50,  # 买入开仓
+    53,  # 买入平仓
+    55,  # 备兑平仓
+})
+_ETF_OPTION_SELL_SIDE = frozenset({
+    51,  # 卖出平仓
+    52,  # 卖出开仓
+    54,  # 备兑开仓
+})
+# 56 认购行权 / 57 认沽行权 / 58 证券锁定 / 59 证券解锁 没有买卖方向，
+# 和 直接还款(32) 一样必须由调用方显式传 action。
+
+# 能接受直通 opType 的账号类型（见 init_config.ACCOUNT_TYPES）。
+# 股票账号收到期货 opType 时必须拒绝，不能回落到 23/24 —— 那会真的发出
+# 一笔品种和方向都不对的股票单。
+PASSTHROUGH_ACCOUNT_TYPES = frozenset({"FUTURE", "STOCK_OPTION"})
+
+
+def passthrough_optype_of(order_type):
+    """原样送进 passorder 的期货/期权 opType，不是则 None。"""
+    try:
+        value = int(order_type)
+    except (TypeError, ValueError):
+        return None
+    return value if value in PASSTHROUGH_OP_TYPES else None
+
+
+def passthrough_action_of(order_type):
+    """期货/期权 opType 的买卖方向；没有方向（行权、锁定）则 None。"""
+    try:
+        value = int(order_type)
+    except (TypeError, ValueError):
+        return None
+    if value in _FUTURE_BUY_SIDE or value in _ETF_OPTION_BUY_SIDE:
+        return SignalAction.BUY.value
+    if value in _FUTURE_SELL_SIDE or value in _ETF_OPTION_SELL_SIDE:
+        return SignalAction.SELL.value
+    return None
+
+
 def credit_action_of(order_type):
     """BUY / SELL for a credit order_type, or None if it is not one.
 
@@ -237,13 +312,32 @@ class BigQmtOrderGateway:
     def submit(self, request):
         passorder = self._require_passorder()
         action = str(request.action).upper()
-        credit_optype = credit_optype_of(getattr(request, "order_type", None))
+        raw_order_type = getattr(request, "order_type", None)
+        credit_optype = credit_optype_of(raw_order_type)
+        passthrough_optype = passthrough_optype_of(raw_order_type)
         if credit_optype is not None:
             # A credit operation carries more than a side: mapping it back to
             # BUY/SELL would turn 融资买入 into an ordinary buy, which is the
             # bug behind issue #103 -- worse than the rejection it replaced,
             # because it places a real but different order.
             op_type = credit_optype
+        elif passthrough_optype is not None:
+            # Futures/option opTypes carry open-vs-close and today-vs-yesterday.
+            # Forward them untouched -- but only on an account that can trade
+            # them. Letting a futures opType fall through to 23/24 on a STOCK
+            # account is the #103 failure mode again: 平今多 (a close) would go
+            # out as an ordinary stock buy.
+            account_type = str(self.account_type or "").upper()
+            if account_type not in PASSTHROUGH_ACCOUNT_TYPES:
+                raise ValueError(
+                    # ASCII only: this goes to QMT's own log, which drops
+                    # non-ASCII (a Chinese install path came back mangled).
+                    "order_type %s is a futures/option opType but account_type "
+                    "is %r. Set account_type to one of %s, or use 23/24 for "
+                    "stock orders." % (
+                        passthrough_optype, self.account_type,
+                        "/".join(sorted(PASSTHROUGH_ACCOUNT_TYPES))))
+            op_type = passthrough_optype
         elif action == SignalAction.BUY.value:
             op_type = 23
         elif action == SignalAction.SELL.value:

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -1117,6 +1117,16 @@ class BigQmtRpcHandlers:
             raise ValueError(
                 "order_type %s has no implicit buy/sell side; pass action "
                 "explicitly" % raw)
+        # Futures (0-15) and ETF option (50-59) opTypes carry the side in the
+        # type itself. 行权/锁定 (56-59) do not, so they fall through to the
+        # same "pass action explicitly" rejection as 直接还款.
+        passthrough = _passthrough_action_of(raw)
+        if passthrough:
+            return passthrough
+        if _passthrough_optype_of(raw) is not None:
+            raise ValueError(
+                "order_type %s has no implicit buy/sell side; pass action "
+                "explicitly" % raw)
         if raw in (None, ""):
             raise ValueError("action or order_type is required")
         # An order_type WAS supplied and was not recognised. Saying "required"
@@ -1144,10 +1154,24 @@ class BigQmtRpcHandlers:
         except Exception:
             return "unknown version"
 
-    def _credit_order_type_from_params(self, params):
-        """The MiniQMT order_type to forward, when it is a credit operation."""
+    def _forwarded_order_type(self, params):
+        """The order_type to forward untouched to passorder, or None.
+
+        Credit (27-32/40-45/70-75) and futures/option (0-15/50-59) opTypes both
+        encode more than a side, so submit() needs the raw value. Read straight
+        from params -- no state is carried between calls, so this does not
+        depend on the order OrderRequest's keyword arguments happen to be
+        evaluated in.
+        """
         raw = params.get("order_type")
-        return raw if _credit_optype_of(raw) is not None else None
+        if _credit_optype_of(raw) is not None:
+            return raw
+        if _passthrough_optype_of(raw) is not None:
+            return raw
+        return None
+
+    # 旧名保留：外部调用方和既有测试还在用
+    _credit_order_type_from_params = _forwarded_order_type
 
     def _handle_submit_order(self, params):
         if self.order_gateway is None:
@@ -1167,7 +1191,7 @@ class BigQmtRpcHandlers:
             price_type=params.get("price_type") or "LIMIT",
             strategy_name=str(params.get("strategy_name") or "bigqmt_rpc"),
             remark=order_tag,
-            order_type=self._credit_order_type_from_params(params),
+            order_type=self._forwarded_order_type(params),
         )
         if request.action not in ("BUY", "SELL"):
             raise ValueError("action must be BUY or SELL")
@@ -1435,6 +1459,24 @@ def _credit_optype_of(order_type):
         from bigqmt_signal_trader.adapters.order_bigqmt import credit_optype_of
 
         return credit_optype_of(order_type)
+    except Exception:
+        return None
+
+
+def _passthrough_optype_of(order_type):
+    try:
+        from bigqmt_signal_trader.adapters.order_bigqmt import passthrough_optype_of
+
+        return passthrough_optype_of(order_type)
+    except Exception:
+        return None
+
+
+def _passthrough_action_of(order_type):
+    try:
+        from bigqmt_signal_trader.adapters.order_bigqmt import passthrough_action_of
+
+        return passthrough_action_of(order_type)
     except Exception:
         return None
 

--- a/tests/bigqmt_signal_trader/test_futures_option_order_types.py
+++ b/tests/bigqmt_signal_trader/test_futures_option_order_types.py
@@ -1,0 +1,234 @@
+"""期货 / ETF 期权 opType 必须原样到达 passorder（issue 中 PR #129 的场景）。
+
+和 credit 那一层是同一类问题：opType 编码的信息比「买还是卖」多。期货的
+0-15 里带着开/平和今/昨，ETF 期权的 50-59 里带着开/平和备兑。映射回 BUY/SELL
+再重新拼一个 opType 就把这些丢了——平今多会变成普通卖出。
+
+数值全部对着官方枚举核过，不是按数字规律推的：
+https://dict.thinktrader.net/innerApi/enum_constants.html?id=NF25nX
+（本仓库 docs/BIGQMT_INNER_PYTHON_API_REFERENCE.md 10.1 节是它的抄录）
+
+两个容易踩的地方，各有一组用例钉住：
+
+* **官方只定义 0-15**。16-22 没有定义，不能当期货收下——PR #129 的第一版
+  把 0-22 全当期货，多出来的 7 个值没有依据。
+* **ETF 期权是 50-59，不是 48-57**，而且段内不是「偶数买奇数卖」：
+  52 卖出开仓、53 买入平仓、54 备兑开仓、55 备兑平仓，规律从 52 就断了。
+"""
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.adapters.order_bigqmt import (
+    BigQmtOrderGateway, passthrough_action_of, passthrough_optype_of)
+from bigqmt_signal_trader.models import OrderRequest
+from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+
+
+# opType -> (官方含义, 期望的记账方向)。None = 没有买卖方向。
+OFFICIAL = {
+    # 期货/股指期权/商品期权 —— 六键
+    0: ("开多", "BUY"),
+    1: ("平昨多", "SELL"),
+    2: ("平今多", "SELL"),
+    3: ("开空", "SELL"),
+    4: ("平昨空", "BUY"),
+    5: ("平今空", "BUY"),
+    # 四键
+    6: ("平多，优先平今", "SELL"),
+    7: ("平多，优先平昨", "SELL"),
+    8: ("平空，优先平今", "BUY"),
+    9: ("平空，优先平昨", "BUY"),
+    # 两键
+    10: ("卖出，多仓优先平今，余量开空", "SELL"),
+    11: ("卖出，多仓优先平昨，余量开空", "SELL"),
+    12: ("买入，空仓优先平今，余量开多", "BUY"),
+    13: ("买入，空仓优先平昨，余量开多", "BUY"),
+    14: ("买入，不优先平仓", "BUY"),
+    15: ("卖出，不优先平仓", "SELL"),
+    # ETF 期权
+    50: ("买入开仓", "BUY"),
+    51: ("卖出平仓", "SELL"),
+    52: ("卖出开仓", "SELL"),
+    53: ("买入平仓", "BUY"),
+    54: ("备兑开仓", "SELL"),
+    55: ("备兑平仓", "BUY"),
+    56: ("认购行权", None),
+    57: ("认沽行权", None),
+    58: ("证券锁定", None),
+    59: ("证券解锁", None),
+}
+
+UNDEFINED_OP_TYPES = tuple(range(16, 23))   # 官方表里没有
+
+
+class _Recorder(object):
+    def __init__(self):
+        self.op_type = None
+
+    def __call__(self, op_type, order_type, account, code, price_type, price,
+                 volume, strategy, quick, remark, context=None, *args, **kwargs):
+        self.op_type = op_type
+
+
+def _submit(order_type, action="BUY", account_type="FUTURE"):
+    recorder = _Recorder()
+    gateway = BigQmtOrderGateway(account_id="acct", passorder_func=recorder,
+                                 context_info=object(), account_type=account_type)
+    gateway.submit(OrderRequest(
+        signal_id="s", account_id="acct", stock_code="IF2601.IF", action=action,
+        volume=1, price=4000.0, price_type="LIMIT", strategy_name="s",
+        order_type=order_type))
+    return recorder.op_type
+
+
+def _handlers():
+    # 和 test_credit_order_types.py / test_unknown_order_type_message.py 一致：
+    # 这几个方法是纯函数，不需要真的建连接
+    return BigQmtRpcHandlers.__new__(BigQmtRpcHandlers)
+
+
+class DirectionMatchesTheOfficialTableTest(unittest.TestCase):
+    """逐个 opType 对着官方表核方向，不靠数字规律。"""
+
+    def test_every_documented_op_type_has_the_official_side(self):
+        for op_type, (name, expected) in sorted(OFFICIAL.items()):
+            self.assertEqual(passthrough_action_of(op_type), expected,
+                             "opType %d (%s)" % (op_type, name))
+
+    def test_closing_a_long_is_a_sell_and_closing_a_short_is_a_buy(self):
+        # 这是最容易搞反的一组：平多是卖、平空是买
+        for op_type in (1, 2, 6, 7):        # 平昨多/平今多/平多优先今/平多优先昨
+            self.assertEqual(passthrough_action_of(op_type), "SELL", op_type)
+        for op_type in (4, 5, 8, 9):        # 平昨空/平今空/平空优先今/平空优先昨
+            self.assertEqual(passthrough_action_of(op_type), "BUY", op_type)
+
+    def test_etf_option_side_is_not_odd_even(self):
+        # 50 买 / 51 卖之后规律就断了，写死规律会全错
+        self.assertEqual(passthrough_action_of(52), "SELL")   # 卖出开仓
+        self.assertEqual(passthrough_action_of(53), "BUY")    # 买入平仓
+        self.assertEqual(passthrough_action_of(54), "SELL")   # 备兑开仓
+        self.assertEqual(passthrough_action_of(55), "BUY")    # 备兑平仓
+
+    def test_exercise_and_lock_have_no_side(self):
+        for op_type in (56, 57, 58, 59):
+            self.assertIsNone(passthrough_action_of(op_type), op_type)
+            # 但仍然是可直通的 opType
+            self.assertEqual(passthrough_optype_of(op_type), op_type)
+
+
+class RangeBoundaryTest(unittest.TestCase):
+    def test_undefined_range_is_not_treated_as_futures(self):
+        for op_type in UNDEFINED_OP_TYPES:
+            self.assertIsNone(passthrough_optype_of(op_type),
+                              "opType %d 官方表里没有定义" % op_type)
+            self.assertIsNone(passthrough_action_of(op_type), op_type)
+
+    def test_stock_and_credit_types_are_not_diverted(self):
+        for op_type in (23, 24, 27, 28, 32, 33, 34, 70, 75):
+            self.assertIsNone(passthrough_optype_of(op_type), op_type)
+
+    def test_etf_option_range_starts_at_fifty(self):
+        # 48/49 属于组合交易，不是 ETF 期权
+        for op_type in (48, 49):
+            self.assertIsNone(passthrough_optype_of(op_type), op_type)
+
+    def test_garbage_is_rejected_not_crashed(self):
+        for value in (None, "", "abc", object()):
+            self.assertIsNone(passthrough_optype_of(value))
+            self.assertIsNone(passthrough_action_of(value))
+
+
+class SubmitForwardsRawOpTypeTest(unittest.TestCase):
+    def test_futures_account_forwards_the_op_type_untouched(self):
+        for op_type in sorted(OFFICIAL):
+            self.assertEqual(_submit(op_type, action="BUY", account_type="FUTURE"),
+                             op_type, op_type)
+
+    def test_stock_option_account_forwards_too(self):
+        self.assertEqual(_submit(50, account_type="STOCK_OPTION"), 50)
+
+    def test_stock_account_refuses_a_futures_op_type(self):
+        # 关键安全用例：股票账号收到期货 opType 必须拒绝。
+        # 回落到 23/24 会真的发出一笔品种和方向都不对的股票单 —— 这正是
+        # issue #103 的失败模式（"a real but different order"）。
+        with self.assertRaises(ValueError) as ctx:
+            _submit(2, action="BUY", account_type="STOCK")
+        message = str(ctx.exception)
+        self.assertIn("futures/option opType", message)
+        self.assertIn("STOCK", message)
+
+    def test_credit_account_also_refuses_a_futures_op_type(self):
+        with self.assertRaises(ValueError):
+            _submit(0, action="BUY", account_type="CREDIT")
+
+    def test_plain_stock_orders_are_unaffected(self):
+        self.assertEqual(_submit(None, action="BUY", account_type="STOCK"), 23)
+        self.assertEqual(_submit(None, action="SELL", account_type="STOCK"), 24)
+
+
+class RpcActionResolutionTest(unittest.TestCase):
+    def test_action_is_derived_from_the_op_type(self):
+        handlers = _handlers()
+        for op_type, (name, expected) in sorted(OFFICIAL.items()):
+            if expected is None:
+                continue
+            self.assertEqual(
+                handlers._order_action_from_params({"order_type": op_type}),
+                expected, "opType %d (%s)" % (op_type, name))
+
+    def test_directionless_op_types_demand_an_explicit_action(self):
+        handlers = _handlers()
+        for op_type in (56, 57, 58, 59):
+            with self.assertRaises(ValueError) as ctx:
+                handlers._order_action_from_params({"order_type": op_type})
+            self.assertIn("no implicit buy/sell side", str(ctx.exception))
+
+    def test_explicit_action_wins_for_directionless_types(self):
+        handlers = _handlers()
+        params = {"order_type": 56, "action": "BUY"}
+        self.assertEqual(handlers._order_action_from_params(params), "BUY")
+        self.assertEqual(handlers._forwarded_order_type(params), 56)
+
+    def test_undefined_op_type_still_raises_the_deployment_hint(self):
+        handlers = _handlers()
+        with self.assertRaises(ValueError) as ctx:
+            handlers._order_action_from_params({"order_type": 18})
+        self.assertIn("not recognised", str(ctx.exception))
+
+
+class ForwardedOrderTypeIsOrderIndependentTest(unittest.TestCase):
+    """透传值不能靠调用顺序传递。
+
+    PR #129 的第一版把原始值写进 params 字典，再由另一个函数读出来 —— 依赖
+    OrderRequest(...) 里 action= 恰好写在 order_type= 前面这个关键字求值顺序。
+    谁调换一下参数顺序，透传就静默失效，submit() 回落到 14/15，平仓单变开仓单。
+    """
+
+    def test_forwarding_does_not_depend_on_calling_action_first(self):
+        handlers = _handlers()
+        params = {"order_type": 2}
+        # 先取透传值、完全不调 _order_action_from_params，也要拿到 2
+        self.assertEqual(handlers._forwarded_order_type(params), 2)
+        self.assertEqual(handlers._order_action_from_params(params), "SELL")
+        self.assertEqual(handlers._forwarded_order_type(params), 2)
+
+    def test_resolver_leaves_no_state_in_params(self):
+        handlers = _handlers()
+        params = {"order_type": 5}
+        handlers._order_action_from_params(params)
+        self.assertEqual(params, {"order_type": 5}, "不应往 params 里塞中间状态")
+
+    def test_credit_forwarding_is_unchanged(self):
+        handlers = _handlers()
+        self.assertEqual(handlers._forwarded_order_type({"order_type": 27}), 27)
+        self.assertIsNone(handlers._forwarded_order_type({"order_type": 23}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#129 指出的问题是真的，这是按官方枚举重做的一版。

映射依据：[迅投官方 opType 枚举](https://dict.thinktrader.net/innerApi/enum_constants.html?id=NF25nX)（本仓库 `docs/BIGQMT_INNER_PYTHON_API_REFERENCE.md` 10.1 节是它的抄录）。

## 为什么要直通

期货把「开/平、今/昨」编码在 opType 里，ETF 期权还多一个「备兑」。映射回 BUY/SELL 再重新拼一个 opType 就把这些丢了——平今多会变成普通卖出。和 #103 里 融资买入 变普通买入是同一类错误。

## 范围

| 段位 | 官方定义 |
|---|---|
| 0-15 | 期货/股指期权/商品期权：六键 0-5、四键 6-9、两键 10-15 |
| 50-59 | ETF 期权 |

**16-22 官方没有定义**，不收。**ETF 期权起于 50 而不是 48**（48/49 属于组合交易）。

## 两个反直觉的地方

**平多是卖、平空是买。** 平昨多(1)/平今多(2)/平多优先平今(6)/平多优先平昨(7) 都是 SELL；平昨空(4)/平今空(5)/平空优先平今(8)/平空优先平昨(9) 都是 BUY。

**ETF 期权段不是「偶数买奇数卖」**，规律从 52 就断了：

| op | 含义 | 方向 |
|---|---|---|
| 50 | 买入开仓 | BUY |
| 51 | 卖出平仓 | SELL |
| 52 | 卖出开仓 | **SELL** |
| 53 | 买入平仓 | **BUY** |
| 54 | 备兑开仓 | **SELL** |
| 55 | 备兑平仓 | **BUY** |

56 认购行权 / 57 认沽行权 / 58 证券锁定 / 59 证券解锁 没有买卖方向，和 直接还款(32) 一样要求显式传 `action`。

## 安全：股票账号必须拒绝

```python
if credit_optype is not None:        op_type = credit_optype
elif passthrough_optype is not None:
    if account_type not in ("FUTURE", "STOCK_OPTION"):
        raise ValueError(...)        # 不回落到 23/24
    op_type = passthrough_optype
elif action == BUY:                  op_type = 23
elif action == SELL:                 op_type = 24
```

一个 STOCK 账号收到 `order_type=2`（平今多），如果回落到 `action==BUY → 23`，就是一笔品种和方向都不对的**真实股票买单**——正是 `submit()` 里那句注释说的 "a real but different order"。所以直接抛错。

## 透传值不靠调用顺序传

`_forwarded_order_type(params)` 直接从 `params["order_type"]` 读，函数之间不用字典传中间状态。靠 `OrderRequest(...)` 里 `action=` 恰好写在 `order_type=` 前面这个关键字求值顺序是危险的——谁调换一下参数顺序，透传就静默失效，`submit()` 回落到 14/15，**平仓单变开仓单**。有一组用例专门钉住这点。

旧名 `_credit_order_type_from_params` 保留为别名，既有测试和外部调用不受影响。

## 测试

新增 20 个用例，`OFFICIAL` 表逐个 opType 断言方向；边界（16-22 未定义、48/49 不是期权、23/24/27 不被误抢）、股票账号拒绝、行权类要求显式 action、透传与调用顺序无关，各有覆盖。

`python run_all_tests.py` → **880 项全过，0 失败**。

---

对 #129 的作者：思路和问题定位都对，主要是数值表需要照官方枚举核一遍，以及股票账号那条回落路径要堵上。细节见 #129 的评审。
