### PR TITLE
fix: 补上 6 个漏掉的 MiniQMT 兼容层包装（close #130）

### DIFF
--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -1373,12 +1373,26 @@ class BigQmtXtData:
         return self._call("get_instrument_type", code=stock_code, variety_list=variety_list)
 
     def get_stock_type(self, stock_code, variety_list=None):
-        """xtdata.get_stock_type 的同名封装。
+        """xtdata.get_stock_type 的同名封装 —— 大 QMT 上答不了，直接报错。
 
-        大 QMT 侧是 ContextInfo.get_stock_type(stock)，参数名是 stock 不是 code。
-        variety_list 服务端不支持，保留形参只为签名一致。
+        服务端走的是 ContextInfo.get_stock_type(stock)。这个 stub 在大 QMT 上
+        存在（缺失会抛 NotImplementedError），但**对任何代码都返回 0**：实测
+        股票 600000.SH、ETF 589820.SH、沪市债券 186511.SH、期权
+        10011096.SHO 全部是 0，换代码格式（600000 / SH600000 /
+        600000.SSE）也一样。
+
+        返回一个恒为 0 的"类型"比报 AttributeError 更糟：报错看得见，一个
+        错的分类看不见。所以这里显式拒绝，并指向真正能用的那个：
+        get_instrument_type()，实测能区分 stock / fund / etf / bond / index。
         """
-        return self._call("get_stock_type", stock=stock_code)
+        raise NotImplementedError(
+            "get_stock_type is not usable on Big QMT: the server-side "
+            "ContextInfo.get_stock_type stub returns 0 for every code "
+            "(verified live against a stock, an ETF, a bond and an option, and "
+            "against every code format). Use get_instrument_type(stock_code) "
+            "instead -- it returns "
+            "{'stock': ..., 'fund': ..., 'etf': ..., 'bond': ..., 'index': ...}."
+        )
 
     def subscribe_l2thousand(self, stock_code, gear_num=None, callback=None):
         """千档盘口订阅。

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -1372,6 +1372,26 @@ class BigQmtXtData:
     def get_instrument_type(self, stock_code, variety_list=None):
         return self._call("get_instrument_type", code=stock_code, variety_list=variety_list)
 
+    def get_stock_type(self, stock_code, variety_list=None):
+        """xtdata.get_stock_type 的同名封装。
+
+        大 QMT 侧是 ContextInfo.get_stock_type(stock)，参数名是 stock 不是 code。
+        variety_list 服务端不支持，保留形参只为签名一致。
+        """
+        return self._call("get_stock_type", stock=stock_code)
+
+    def subscribe_l2thousand(self, stock_code, gear_num=None, callback=None):
+        """千档盘口订阅。
+
+        callback 在 RPC 模型下没有回调通道，服务端会忽略它 —— 想要推送请用
+        subscribe_whole_quote。这里保留形参只为和 xtdata 签名一致。
+        """
+        return self._call(
+            "subscribe_l2thousand",
+            stock_code=stock_code,
+            gear_num=0 if gear_num is None else gear_num,
+        )
+
     def get_stock_list_in_sector(self, sector_name, real_timetag=-1):
         name = str(sector_name or "")
         try:
@@ -1983,6 +2003,23 @@ class BigQmtXtData:
 
     def download_etf_info(self):
         return self._call("download_etf_info")
+
+    # 下面四个的服务端实现和 RPC 白名单一直都在（market_bigqmt 的
+    # download_* 方法 + redis_rpc 的 MARKET_DATA_METHODS），只是客户端漏了这层
+    # 包装，于是外部调用直接撞 AttributeError（issue #130）。
+    def download_sector_data(self):
+        return self._call("download_sector_data")
+
+    def download_cb_data(self):
+        return self._call("download_cb_data")
+
+    def download_index_weight(self):
+        return self._call("download_index_weight")
+
+    def download_history_contracts(self, incrementally=True):
+        # 形参保留是为了和 xtdata.download_history_contracts(incrementally=True)
+        # 签名一致；大 QMT 那边这个调用没有增量参数，服务端按全量下载处理。
+        return self._call("download_history_contracts")
 
     def get_option_list(self, undl_code, dedate, opttype="", isavailavle=False):
         return self._call("get_option_list", undl_code=undl_code, dedate=dedate, opttype=opttype, isavailavle=isavailavle)

--- a/src/xtquant/xtdata.py
+++ b/src/xtquant/xtdata.py
@@ -105,7 +105,10 @@ def get_trading_dates(market, start_time="", end_time="", count=-1):
 
 
 def get_stock_type(stock):
-    return _compat.xtdata.call_method("get_stock_type", stock=stock)
+    # 走包装而不是 call_method：包装里写了为什么这个方法在大 QMT 上答不了
+    # （ContextInfo stub 对任何代码都返回 0）。两条路径必须一致，否则
+    # 顶层 xtdata 还会把那个 0 递给调用方。
+    return _compat.xtdata.get_stock_type(stock)
 
 
 def get_holidays():

--- a/tests/bigqmt_signal_trader/test_compat_method_coverage.py
+++ b/tests/bigqmt_signal_trader/test_compat_method_coverage.py
@@ -1,0 +1,166 @@
+"""兼容层不能漏掉服务端已经支持的 MiniQMT 方法（issue #130）。
+
+#130 的现象是 `xtdata.download_sector_data()` 抛 AttributeError。查下来服务端
+适配器和 RPC 白名单里一直都有这个方法，缺的只是客户端 BigQmtXtData 上那层包装。
+同一类缺口当时一共 6 个，光靠人工比对迟早会再漏。
+
+所以这里钉一条不变式：
+
+    白名单（MARKET_DATA_METHODS）里的每个方法，要么兼容层有同名包装，
+    要么明确写进 CALL_METHOD_ONLY —— 二选一，不能悄悄漏掉。
+
+`CALL_METHOD_ONLY` 是大 QMT 独有的 ContextInfo 扩展，MiniQMT 本来就没有这些
+方法，按设计走 `xtdata.call_method()` 兜底（README「通用 RPC 兜底」一节）。
+往白名单加新方法时，这个测试会强制你做一次选择。
+
+注意不要用 `hasattr(xtquant.xtdata, name)` 当判据：本仓库 `src/xtquant/` 有个
+shim，测试里 `from xtquant import xtdata` 命中的是兼容层自己，那样断言等于
+自己跟自己比，恒真。
+"""
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.redis_rpc import MARKET_DATA_METHODS
+from bigqmt_signal_trader.xtquant_compat import BigQmtXtData, BigQmtXtTrader
+
+
+# 大 QMT 独有能力（ContextInfo 扩展），MiniQMT 没有对应方法，不需要同名包装。
+# 调用方式：xtdata.call_method("get_float_caps", stockcode="000001.SZ")
+CALL_METHOD_ONLY = frozenset({
+    "get_ETF_list",
+    "get_bvol",
+    "get_contract_expire_date",
+    "get_contract_multiplier",
+    "get_float_caps",
+    "get_last_close",
+    "get_last_volume",
+    "get_open_date",
+    "get_risk_free_rate",
+    "get_svol",
+    "get_total_share",
+    "get_turn_over_rate",
+    "get_weight_in_index",
+})
+
+
+def _exposed(name):
+    return hasattr(BigQmtXtData, name) or hasattr(BigQmtXtTrader, name)
+
+
+class MethodCoverageTest(unittest.TestCase):
+    def test_every_whitelisted_method_is_wrapped_or_declared_call_method_only(self):
+        missing = sorted(name for name in MARKET_DATA_METHODS
+                         if not _exposed(name) and name not in CALL_METHOD_ONLY)
+        self.assertEqual(
+            missing, [],
+            "服务端白名单里有，但兼容层既没包装也没声明为 call_method 专用：%s\n"
+            "MiniQMT 也有的方法 -> 补一个 self._call(\"<name>\", ...) 包装；\n"
+            "大 QMT 独有的能力 -> 加进本文件的 CALL_METHOD_ONLY 并说明。\n"
+            "（issue #130 就是漏了包装撞出来的 AttributeError）" % missing)
+
+    def test_call_method_only_entries_are_really_in_the_whitelist(self):
+        # 清单过期了要能发现：方法从白名单删掉后，这里也该跟着删
+        stale = sorted(name for name in CALL_METHOD_ONLY
+                       if name not in MARKET_DATA_METHODS)
+        self.assertEqual(stale, [], "CALL_METHOD_ONLY 里有白名单已经没有的方法：%s" % stale)
+
+    def test_call_method_only_entries_are_not_secretly_wrapped(self):
+        # 反过来：包装上了就该从清单里挪走，免得清单变成谎话
+        wrapped = sorted(name for name in CALL_METHOD_ONLY if _exposed(name))
+        self.assertEqual(
+            wrapped, [],
+            "这些已经有包装了，应当从 CALL_METHOD_ONLY 移除：%s" % wrapped)
+
+    def test_the_generic_fallback_exists(self):
+        # CALL_METHOD_ONLY 成立的前提
+        self.assertTrue(hasattr(BigQmtXtData, "call_method"))
+
+
+class ReportedGapTest(unittest.TestCase):
+    """issue #130 报的那批：服务端一直支持，客户端漏了包装。"""
+
+    REPORTED = ("download_sector_data", "download_cb_data",
+                "download_index_weight", "download_history_contracts",
+                "get_stock_type", "subscribe_l2thousand")
+
+    def test_all_of_them_are_now_exposed(self):
+        for name in self.REPORTED:
+            self.assertTrue(_exposed(name), name)
+
+    def test_all_of_them_are_whitelisted_server_side(self):
+        for name in self.REPORTED:
+            self.assertIn(name, MARKET_DATA_METHODS, name)
+
+
+class _Recorder(BigQmtXtData):
+    """记录 _call 的参数，不真的发 RPC。"""
+
+    def __init__(self):
+        self.calls = []
+
+    def _call(self, method, **params):
+        self.calls.append((method, params))
+        return "ok"
+
+
+class DownloadWrapperTest(unittest.TestCase):
+    def setUp(self):
+        self.data = _Recorder()
+
+    def test_download_methods_forward_their_own_name_without_params(self):
+        for name in ("download_sector_data", "download_cb_data",
+                     "download_index_weight"):
+            self.data.calls = []
+            self.assertEqual(getattr(self.data, name)(), "ok")
+            self.assertEqual(self.data.calls, [(name, {})], name)
+
+    def test_download_history_contracts_keeps_the_xtdata_signature(self):
+        # xtdata 是 download_history_contracts(incrementally=True)；大 QMT 侧
+        # 没有增量参数，形参保留只为签名一致，不往下转发
+        self.assertEqual(self.data.download_history_contracts(), "ok")
+        self.assertEqual(self.data.download_history_contracts(incrementally=False), "ok")
+        self.assertEqual(
+            self.data.calls,
+            [("download_history_contracts", {}), ("download_history_contracts", {})])
+
+
+class StockTypeWrapperTest(unittest.TestCase):
+    def setUp(self):
+        self.data = _Recorder()
+
+    def test_stock_code_is_forwarded_as_the_server_param_name(self):
+        # 服务端是 ContextInfo.get_stock_type(stock)，参数名是 stock 不是 code
+        self.data.get_stock_type("600000.SH")
+        self.assertEqual(self.data.calls, [("get_stock_type", {"stock": "600000.SH"})])
+
+    def test_variety_list_is_accepted_but_not_forwarded(self):
+        self.data.get_stock_type("600000.SH", variety_list=["stock"])
+        self.assertEqual(self.data.calls, [("get_stock_type", {"stock": "600000.SH"})])
+
+
+class L2ThousandWrapperTest(unittest.TestCase):
+    def setUp(self):
+        self.data = _Recorder()
+
+    def test_gear_num_defaults_to_zero_like_the_server(self):
+        self.data.subscribe_l2thousand("600000.SH")
+        self.assertEqual(
+            self.data.calls,
+            [("subscribe_l2thousand", {"stock_code": "600000.SH", "gear_num": 0})])
+
+    def test_callback_is_accepted_but_not_forwarded(self):
+        # RPC 模型下没有回调通道，服务端也会忽略；要推送用 subscribe_whole_quote
+        self.data.subscribe_l2thousand("600000.SH", gear_num=5, callback=lambda d: None)
+        self.assertEqual(
+            self.data.calls,
+            [("subscribe_l2thousand", {"stock_code": "600000.SH", "gear_num": 5})])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_compat_method_coverage.py
+++ b/tests/bigqmt_signal_trader/test_compat_method_coverage.py
@@ -131,18 +131,20 @@ class DownloadWrapperTest(unittest.TestCase):
 
 
 class StockTypeWrapperTest(unittest.TestCase):
-    def setUp(self):
-        self.data = _Recorder()
+    """get_stock_type 是这批里唯一一个不能直接转发的。
 
-    def test_stock_code_is_forwarded_as_the_server_param_name(self):
-        # 服务端是 ContextInfo.get_stock_type(stock)，参数名是 stock 不是 code
-        self.data.get_stock_type("600000.SH")
-        self.assertEqual(self.data.calls, [("get_stock_type", {"stock": "600000.SH"})])
+    实盘验证发现服务端 ContextInfo.get_stock_type 对任何代码都返回 0
+    （股票 / ETF / 债券 / 期权都一样），转发等于把一个假分类递给调用方。
+    详见 test_get_stock_type_unavailable.py。
+    """
 
-    def test_variety_list_is_accepted_but_not_forwarded(self):
-        self.data.get_stock_type("600000.SH", variety_list=["stock"])
-        self.assertEqual(self.data.calls, [("get_stock_type", {"stock": "600000.SH"})])
+    def test_it_refuses_instead_of_forwarding(self):
+        data = _Recorder()
 
+        with self.assertRaises(NotImplementedError):
+            data.get_stock_type("600000.SH")
+
+        self.assertEqual(data.calls, [])
 
 class L2ThousandWrapperTest(unittest.TestCase):
     def setUp(self):

--- a/tests/bigqmt_signal_trader/test_get_stock_type_unavailable.py
+++ b/tests/bigqmt_signal_trader/test_get_stock_type_unavailable.py
@@ -1,0 +1,129 @@
+# coding: utf-8
+"""get_stock_type must not hand back the server's meaningless 0 (#130 follow-up).
+
+PR #132 added six wrappers for methods the RPC whitelist already carried. Five
+of them fail loudly on Big QMT ("needs native xtdata SDK quote service"), which
+is fine -- the caller learns something. `get_stock_type` was the exception: it
+returned successfully. Live against the deployed bridge:
+
+    600000.SH     (stock)  -> 0
+    589820.SH     (ETF)    -> 0
+    186511.SH     (bond)   -> 0
+    10011096.SHO  (option) -> 0
+    600000 / SH600000 / 600000.SSE   -> 0
+
+Server-side it is `ContextInfo.get_stock_type(stock)`, and a *missing* stub
+would raise NotImplementedError -- so the stub is there and QMT itself answers
+0 for everything. A constant dressed as a classification is worse than the
+AttributeError #130 reported: the error is visible, the wrong answer is not.
+
+So the wrapper refuses, and points at `get_instrument_type`, which was already
+there and which does discriminate (verified live in the same run).
+"""
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.redis_rpc import MARKET_DATA_METHODS
+from bigqmt_signal_trader.xtquant_compat import BigQmtXtData
+
+
+class _Recorder(BigQmtXtData):
+    def __init__(self):
+        self.calls = []
+
+    def _call(self, method, **params):
+        self.calls.append((method, params))
+        return 0                      # what the live bridge actually answers
+
+
+class RefusesTest(unittest.TestCase):
+    def setUp(self):
+        self.data = _Recorder()
+
+    def test_it_raises_instead_of_returning_the_constant(self):
+        with self.assertRaises(NotImplementedError):
+            self.data.get_stock_type("600000.SH")
+
+    def test_it_does_not_even_spend_the_round_trip(self):
+        """No point paying an RPC for an answer we know is meaningless."""
+        try:
+            self.data.get_stock_type("600000.SH")
+        except NotImplementedError:
+            pass
+
+        self.assertEqual(self.data.calls, [])
+
+    def test_the_message_names_the_working_alternative(self):
+        try:
+            self.data.get_stock_type("600000.SH")
+        except NotImplementedError as exc:
+            self.assertIn("get_instrument_type", str(exc))
+        else:
+            self.fail("expected NotImplementedError")
+
+    def test_the_message_says_why_rather_than_just_no(self):
+        try:
+            self.data.get_stock_type("600000.SH")
+        except NotImplementedError as exc:
+            text = str(exc)
+            self.assertIn("returns 0 for every code", text)
+            self.assertIn("ContextInfo.get_stock_type", text)
+        else:
+            self.fail("expected NotImplementedError")
+
+    def test_the_variety_list_parameter_survives_for_signature_parity(self):
+        with self.assertRaises(NotImplementedError):
+            self.data.get_stock_type("600000.SH", variety_list=["stock"])
+
+
+class StillExposedTest(unittest.TestCase):
+    """Refusing is not the same as deleting.
+
+    The coverage invariant in test_compat_method_coverage.py asks that every
+    whitelisted method be wrapped or declared call-method-only. A wrapper that
+    raises still satisfies it -- and should, because the raise is the useful
+    part.
+    """
+
+    def test_it_is_still_an_attribute(self):
+        self.assertTrue(hasattr(BigQmtXtData, "get_stock_type"))
+
+    def test_it_is_still_whitelisted_server_side(self):
+        self.assertIn("get_stock_type", MARKET_DATA_METHODS)
+
+
+class TheAlternativeStillWorksTest(unittest.TestCase):
+    """Regression guard: don't break the method we are redirecting people to."""
+
+    def test_get_instrument_type_still_forwards(self):
+        data = _Recorder()
+
+        data.get_instrument_type("600000.SH")
+
+        self.assertEqual(data.calls,
+                         [("get_instrument_type",
+                           {"code": "600000.SH", "variety_list": None})])
+
+
+class ShimAgreesTest(unittest.TestCase):
+    """The top-level xtquant.xtdata shim must not route around the refusal."""
+
+    def test_the_shim_forwards_to_the_wrapper_not_call_method(self):
+        import io
+
+        path = os.path.join(ROOT, "src", "xtquant", "xtdata.py")
+        with io.open(path, encoding="utf-8") as handle:
+            source = handle.read()
+
+        self.assertIn("return _compat.xtdata.get_stock_type(stock)", source)
+        self.assertNotIn('call_method("get_stock_type"', source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_xtdata_shim.py
+++ b/tests/bigqmt_signal_trader/test_xtdata_shim.py
@@ -44,6 +44,11 @@ class _FakeXtData:
         ))
         return True
 
+    def get_stock_type(self, stock_code, variety_list=None):
+        # 真实包装会抛 NotImplementedError；这里只验证 shim 转发到哪
+        self.calls.append(("get_stock_type", (stock_code,)))
+        return "ETF"
+
     def call_method(self, method, **params):
         self.calls.append(("call_method", (method, params)))
         return "ETF"
@@ -91,10 +96,16 @@ class XtdataShimSignatureTest(unittest.TestCase):
         self.assertEqual(name, "download_history_data2")
         self.assertEqual(args[-1], "front")
 
-    def test_get_stock_type_forwards_through_generic_compat_method(self):
-        """顶层 shim 只转发现有通用 RPC，不复制证券分类逻辑。"""
+    def test_get_stock_type_forwards_to_the_wrapper(self):
+        """顶层 shim 只转发，不复制证券分类逻辑。
+
+        以前走 call_method("get_stock_type")，绕开了包装。实盘验证后包装改成
+        拒绝（服务端 ContextInfo stub 对任何代码都返回 0），两条路径必须一致，
+        否则顶层 xtdata 还会把那个 0 递给调用方。详见
+        test_get_stock_type_unavailable.py。
+        """
         self.assertEqual(shim.get_stock_type("510300.SH"), "ETF")
-        self.assertEqual(self.fake.calls, [("call_method", ("get_stock_type", {"stock": "510300.SH"}))])
+        self.assertEqual(self.fake.calls, [("get_stock_type", ("510300.SH",))])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #130.

## 根因

`xtdata.download_sector_data()` 抛 `AttributeError` 不是因为不支持——服务端适配器 `market_bigqmt.download_sector_data()` 和 RPC 白名单 `MARKET_DATA_METHODS` 里**一直都有**，缺的只是客户端 `BigQmtXtData` 上那层包装。调用方只能靠 `call_method("download_sector_data")` 绕过去。

同一类缺口一共 6 个，一并补上：

| 方法 | 说明 |
|---|---|
| `download_sector_data` | #130 报的那个 |
| `download_cb_data` | 可转债数据下载 |
| `download_index_weight` | 指数权重下载 |
| `download_history_contracts` | 过期合约下载 |
| `get_stock_type` | 品种类型 |
| `subscribe_l2thousand` | 千档盘口 |

## 签名上的三个细节

- **`download_history_contracts(incrementally=True)`** —— 形参保留是为了和 `xtdata` 签名一致，但大 QMT 侧这个调用没有增量参数，不往下转发。
- **`get_stock_type`** —— 服务端是 `ContextInfo.get_stock_type(stock)`，参数名是 `stock` 不是 `code`，转发时要用对。
- **`subscribe_l2thousand`** 的 `callback` —— RPC 模型下没有回调通道，服务端本来也会忽略。形参保留只为签名一致，想要推送请用 `subscribe_whole_quote`。

## 防复发

新增 `tests/bigqmt_signal_trader/test_compat_method_coverage.py`，钉一条不变式：

> 白名单里的每个方法，**要么**兼容层有同名包装，**要么**明确写进 `CALL_METHOD_ONLY`。

`CALL_METHOD_ONLY` 是 13 个大 QMT 独有的 ContextInfo 扩展（`get_float_caps` / `get_total_share` / `get_bvol` 等），MiniQMT 本来就没有这些方法，按设计走 `call_method()` 兜底，README「通用 RPC 兜底」一节已有说明。

往白名单加新方法时，这个测试会强制做一次选择——补包装，或者声明它是大 QMT 独有。同类缺口不会再悄悄漏掉。另外两个用例反向盯着清单本身：清单里有白名单已删的方法会失败，清单里有其实已经包装了的也会失败，避免清单变成谎话。

### 一个踩过的坑

判据不能写成 `hasattr(xtquant.xtdata, name)`：本仓库 `src/xtquant/` 有 shim，测试里 `from xtquant import xtdata` 命中的是兼容层自己，那样断言等于自己跟自己比，**恒真**。我第一版就是这么写的，删掉 `download_sector_data` 跑测试照样通过才发现。现在改成对着白名单 + 显式清单判，和 shim 无关。

## 验证

- 新增 12 个用例；删掉任意一个包装，守卫用例会失败并指名道姓
- `python run_all_tests.py` → **872 项全过，0 失败**

## 顺带发现，本 PR 没动

`create_sector` 的签名和 MiniQMT 对不上：

```
xtdata.create_sector(parent_node, sector_name, overwrite=True)   # 真实
compat.create_sector(sector_name, stock_list)                    # 当前
```

改它是破坏性变更（现有调用方会挂），而且 `create_sector_folder` / `remove_stock_from_sector` / `reset_sector` 服务端也还没有。想单开一个 issue 讨论要不要对齐。
