### PR TITLE
fix: 按 account_id 动态解析 account_type，支持单终端双账号部署

### DIFF
--- a/src/bigqmt_signal_trader/account_type_map.py
+++ b/src/bigqmt_signal_trader/account_type_map.py
@@ -29,11 +29,19 @@ _ACCOUNT_TYPE_MAP = None  # None = not loaded yet; {} = loaded but empty
 
 
 def _load_map():
-    """Load BIGQMT_ACCOUNT_TYPE_MAP from local config, or {} if absent."""
+    """Load BIGQMT_ACCOUNT_TYPE_MAP from local config, or {} if absent.
+
+    Uses importlib.import_module (not reload) to avoid:
+    1. Re-executing a config module that holds credentials.
+    2. QMT sandbox monkeypatched importlib (issue noted in PR #135 review):
+       the sandbox wraps importlib.reload with a custom loader that may fail
+       on C++ callback threads with SystemError.
+    Hot config changes should go through reload_deployment() → gateway init,
+    which reconstructs the entire object graph.
+    """
     global _ACCOUNT_TYPE_MAP
     try:
         cfg = importlib.import_module("bigqmt_signal_trader_local_config")
-        cfg = importlib.reload(cfg)
         _ACCOUNT_TYPE_MAP = dict(getattr(cfg, "BIGQMT_ACCOUNT_TYPE_MAP", {}) or {})
     except Exception:
         _ACCOUNT_TYPE_MAP = {}

--- a/src/bigqmt_signal_trader/account_type_map.py
+++ b/src/bigqmt_signal_trader/account_type_map.py
@@ -1,0 +1,66 @@
+# coding: utf-8
+"""Per-request account_type resolution from BIGQMT_ACCOUNT_TYPE_MAP.
+
+By default, BigQmtOrderGateway and BigQmtPositionProvider use a fixed
+account_type set at init time (``self.account_type = "STOCK"``). In a
+single-account deployment this is correct. In a multi-account deployment
+(one QMT process serving STOCK + FUTURE), the gateway is shared and
+self.account_type must match the *request's* account_id, not the gateway's
+default.
+
+BIGQMT_ACCOUNT_TYPE_MAP is a dict {account_id: account_type} in the local
+config. When it is present, account_type_for() returns the mapped type;
+otherwise it falls back to the gateway's own default (the *default_type*
+argument), preserving full backward compatibility.
+
+Usage in gateway methods::
+
+    # Before (fixed account_type):
+    rows = query(account_id, self.account_type, "ORDER", strategy_name)
+
+    # After (per-request resolution):
+    rows = query(account_id, self._resolve_account_type(account_id), "ORDER", strategy_name)
+"""
+
+import importlib
+
+
+_ACCOUNT_TYPE_MAP = None  # None = not loaded yet; {} = loaded but empty
+
+
+def _load_map():
+    """Load BIGQMT_ACCOUNT_TYPE_MAP from local config, or {} if absent."""
+    global _ACCOUNT_TYPE_MAP
+    try:
+        cfg = importlib.import_module("bigqmt_signal_trader_local_config")
+        cfg = importlib.reload(cfg)
+        _ACCOUNT_TYPE_MAP = dict(getattr(cfg, "BIGQMT_ACCOUNT_TYPE_MAP", {}) or {})
+    except Exception:
+        _ACCOUNT_TYPE_MAP = {}
+    return _ACCOUNT_TYPE_MAP
+
+
+def get_account_type_map():
+    """The loaded map, loading it first if needed."""
+    if _ACCOUNT_TYPE_MAP is None:
+        _load_map()
+    return _ACCOUNT_TYPE_MAP
+
+
+def account_type_for(account_id, default_type="STOCK"):
+    """account_type string for *account_id*, falling back to *default_type*.
+
+    This is the core lookup: if BIGQMT_ACCOUNT_TYPE_MAP maps the account_id
+    to a type, return it; otherwise return default_type unchanged.
+    """
+    if not account_id:
+        return default_type
+    mapping = get_account_type_map()
+    return mapping.get(str(account_id), default_type)
+
+
+def reload():
+    """Force-reload the map (e.g. after config change)."""
+    global _ACCOUNT_TYPE_MAP
+    _ACCOUNT_TYPE_MAP = None
+    return get_account_type_map()

--- a/src/bigqmt_signal_trader/adapters/order_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/order_bigqmt.py
@@ -36,6 +36,7 @@ except ImportError:
     # 完整 QMT 的模型运行时会注入 passorder 等 API，但部分券商终端不提供可 import 的 xtquant package。
     _xtconstant = _QmtFallbackXtConstant()
 
+from ..account_type_map import account_type_for
 from ..code_utils import normalize_stock_code
 from ..exec_events import date_time_seconds
 from ..models import CancelResult, OrderSnapshot, OrderSubmitResult, SignalAction, TradeSnapshot
@@ -399,6 +400,16 @@ class BigQmtOrderGateway:
         self.price_type = price_type
         self.quick_trade = quick_trade
 
+    def _resolve_account_type(self, account_id):
+        """Per-request account_type: map lookup if configured, else default.
+
+        When BIGQMT_ACCOUNT_TYPE_MAP is configured (multi-account deployment),
+        the same gateway serves multiple accounts and must use the correct
+        account_type for each request. When no map is configured (the common
+        single-account case), this returns self.account_type unchanged.
+        """
+        return account_type_for(account_id, self.account_type)
+
     def _require_passorder(self):
         if self.passorder is None:
             raise RuntimeError("passorder is not available in Big QMT runtime")
@@ -482,7 +493,7 @@ class BigQmtOrderGateway:
             # them. Letting a futures opType fall through to 23/24 on a STOCK
             # account is the #103 failure mode again: 平今多 (a close) would go
             # out as an ordinary stock buy.
-            account_type = str(self.account_type or "").upper()
+            account_type = str(self._resolve_account_type(request.account_id or self.account_id) or "").upper()
             if account_type not in PASSTHROUGH_ACCOUNT_TYPES:
                 raise ValueError(
                     # ASCII only: this goes to QMT's own log, which drops
@@ -490,7 +501,7 @@ class BigQmtOrderGateway:
                     "order_type %s is a futures/option opType but account_type "
                     "is %r. Set account_type to one of %s, or use 23/24 for "
                     "stock orders." % (
-                        passthrough_optype, self.account_type,
+                        passthrough_optype, account_type,
                         "/".join(sorted(PASSTHROUGH_ACCOUNT_TYPES))))
             op_type = passthrough_optype
         elif action == SignalAction.BUY.value:
@@ -524,7 +535,8 @@ class BigQmtOrderGateway:
 
     def cancel(self, order_ref):
         cancel_func = self._require_cancel()
-        ok = cancel_func(order_ref.order_sys_id, self.account_id, self.account_type, self.context_info)
+        account_type = self._resolve_account_type(self.account_id)
+        ok = cancel_func(order_ref.order_sys_id, self.account_id, account_type, self.context_info)
         return CancelResult(success=bool(ok), message="" if ok else "cancel returned false")
 
     def query_orders(self, account_id, strategy_name):
@@ -535,7 +547,8 @@ class BigQmtOrderGateway:
 
     def query_orders_strict(self, account_id, strategy_name):
         query = self._require_query_func()
-        rows = query(account_id, self.account_type, "ORDER", strategy_name) or []
+        account_type = self._resolve_account_type(account_id)
+        rows = query(account_id, account_type, "ORDER", strategy_name) or []
         result = []
         account_type_code = self._account_type_code()
         name_cache = {}
@@ -599,14 +612,15 @@ class BigQmtOrderGateway:
 
     def query_trades_strict(self, account_id, strategy_name):
         query = self._require_query_func()
+        account_type = self._resolve_account_type(account_id)
         rows = []
         last_error = None
         for detail_type in ("DEAL", "TRADE"):
             try:
                 if str(strategy_name or "").strip():
-                    rows = query(account_id, self.account_type, detail_type, strategy_name) or []
+                    rows = query(account_id, account_type, detail_type, strategy_name) or []
                 else:
-                    rows = query(account_id, self.account_type, detail_type) or []
+                    rows = query(account_id, account_type, detail_type) or []
                 if rows:
                     break
             except Exception as exc:
@@ -726,7 +740,7 @@ class BigQmtOrderGateway:
         for detail_type in (detail_types or ("ORDER", "DEAL")):
             entry = {"rows": 0, "attributes": [], "error": ""}
             try:
-                rows = query(account_id, self.account_type, str(detail_type)) or []
+                rows = query(account_id, self._resolve_account_type(account_id), str(detail_type)) or []
                 entry["rows"] = len(rows)
                 if rows:
                     entry["attributes"] = _data_attribute_names(rows[0])

--- a/src/bigqmt_signal_trader/adapters/order_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/order_bigqmt.py
@@ -420,7 +420,7 @@ class BigQmtOrderGateway:
             raise RuntimeError("cancel is not available in Big QMT runtime")
         return self.cancel_func
 
-    def _account_type_code(self):
+    def _account_type_code(self, account_id=None):
         """The account type as MiniQMT reports it: an xtconstant int.
 
         xttype.XtOrder/XtTrade both carry account_type, and real MiniQMT fills
@@ -429,8 +429,15 @@ class BigQmtOrderGateway:
         showed what silence costs: a credit account read as STOCK returns an
         all-zero asset row with no error. So report the configured type and
         fall back to SECURITY_ACCOUNT only when there is nothing to report.
+
+        When account_id is given and BIGQMT_ACCOUNT_TYPE_MAP is configured,
+        the per-request type is used instead of self.account_type (same #92
+        class of bug for multi-account deployments).
         """
-        text = str(self.account_type or "").strip().upper()
+        if account_id is not None and hasattr(self, "_resolve_account_type"):
+            text = str(self._resolve_account_type(account_id) or "").strip().upper()
+        else:
+            text = str(self.account_type or "").strip().upper()
         if text in ACCOUNT_TYPE_CODES:
             return ACCOUNT_TYPE_CODES[text]
         try:
@@ -550,7 +557,7 @@ class BigQmtOrderGateway:
         account_type = self._resolve_account_type(account_id)
         rows = query(account_id, account_type, "ORDER", strategy_name) or []
         result = []
-        account_type_code = self._account_type_code()
+        account_type_code = self._account_type_code(account_id)
         name_cache = {}
         for row in rows:
             try:
@@ -628,7 +635,7 @@ class BigQmtOrderGateway:
         if not rows and last_error is not None:
             raise last_error
         result = []
-        account_type_code = self._account_type_code()
+        account_type_code = self._account_type_code(account_id)
         name_cache = {}
         for row in rows:
             traded_at_raw = _attr(row, ("m_strTradeTime", "trade_time", "traded_at"), "")

--- a/src/bigqmt_signal_trader/adapters/position_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/position_bigqmt.py
@@ -1,5 +1,6 @@
 """Big QMT position and asset adapters."""
 
+from ..account_type_map import account_type_for
 from ..code_utils import normalize_stock_code
 from ..models import AssetSnapshot, PositionSnapshot, PositionStatisticsSnapshot
 
@@ -144,6 +145,10 @@ class BigQmtPositionProvider:
         self.get_trade_detail_data = get_trade_detail_data_func
         self.account_type = account_type
 
+    def _resolve_account_type(self, account_id):
+        """Per-request account_type: map lookup if configured, else default."""
+        return account_type_for(account_id, self.account_type)
+
     def _require_query_func(self):
         if self.get_trade_detail_data is None:
             raise RuntimeError("get_trade_detail_data is not available in Big QMT runtime")
@@ -154,7 +159,7 @@ class BigQmtPositionProvider:
         # QMT's get_trade_detail_data can raise on POSITION queries in some
         # states (e.g. context not bound). Degrade to empty like get_asset does.
         try:
-            rows = query(account_id, self.account_type, "POSITION") or []
+            rows = query(account_id, self._resolve_account_type(account_id), "POSITION") or []
         except Exception:
             return {}
         positions = {}
@@ -186,7 +191,7 @@ class BigQmtPositionProvider:
     def get_position_statistics(self, account_id):
         query = self._require_query_func()
         try:
-            rows = query(account_id, self.account_type, "POSITION_STATISTICS") or []
+            rows = query(account_id, self._resolve_account_type(account_id), "POSITION_STATISTICS") or []
         except Exception:
             return []
         stats = []
@@ -263,7 +268,7 @@ class BigQmtPositionProvider:
         rows = []
         for detail_type in ("ACCOUNT", "ASSET"):
             try:
-                rows = query(account_id, self.account_type, detail_type) or []
+                rows = query(account_id, self._resolve_account_type(account_id), detail_type) or []
                 if rows:
                     break
             except Exception:

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -573,7 +573,6 @@ class BigQmtRpcHandlers:
         # succeeded (issue #43).
         self._last_server_error = ""
         self._pending_settlement = None
-        self._current_params = params
         if not requested_method:
             raise ValueError("method is required")
         if method not in self.allowed_methods:
@@ -594,11 +593,12 @@ class BigQmtRpcHandlers:
             "allow_order_methods": bool(self.allow_order_methods),
             "rpc_revision": RPC_REVISION,
             "version": _deployed_version(),
-            "account_type": self._reported_account_type(),
+            "account_type": self._reported_account_type(
+                params.get("account_id") or self.account_id),
             "server_time": _dt.datetime.now(),
         }
 
-    def _reported_account_type(self):
+    def _reported_account_type(self, account_id=None):
         """What this deployment will actually trade as.
 
         The client's StockAccount(..., "CREDIT") never reaches the server --
@@ -606,10 +606,16 @@ class BigQmtRpcHandlers:
         caller declaring CREDIT against a STOCK deployment has no way to see
         the mismatch. It shows up as an all-zero credit asset row instead
         (issue #92). Empty when there is no gateway to ask.
+
+        When account_id is given and the gateway supports per-request
+        resolution, the map-aware type is returned (same #92 class of bug
+        for multi-account deployments where a FUTURE account sees "STOCK").
         """
         gateway = self.order_gateway
         if gateway is None:
             return ""
+        if account_id is not None and hasattr(gateway, "_resolve_account_type"):
+            return str(gateway._resolve_account_type(account_id) or "").strip().upper()
         return str(getattr(gateway, "account_type", "") or "").strip().upper()
 
     def _handle_get_deployment_info(self, params):
@@ -1239,16 +1245,25 @@ class BigQmtRpcHandlers:
         # Some brokers hand back rows even here; normalise rather than drop.
         return _normalize_detail_rows(data)
 
-    def _configured_account_type(self):
+    def _configured_account_type(self, account_id=None):
+        """The account type this deployment will trade as, per-request aware.
+
+        When the gateway supports per-request account_type resolution (i.e.
+        has ``_resolve_account_type`` from BIGQMT_ACCOUNT_TYPE_MAP), this
+        returns the map-aware type for the given account_id.  When no map
+        is configured, returns the gateway's own ``account_type`` unchanged.
+
+        The *account_id* parameter is explicit (not read from instance state)
+        because zmq deployments have a background listener thread calling
+        market-data methods concurrently with the adjust thread calling trade
+        methods -- storing params on ``self`` would race (issue #43, #164).
+        """
         gateway = self.order_gateway
-        # When the gateway supports per-request account_type resolution,
-        # use the map-aware type for the current request's account_id.
         if gateway is not None and hasattr(gateway, "_resolve_account_type"):
             try:
-                account_id = self._request_account_id(
-                    getattr(self, "_current_params", None) or {})
-                if account_id:
-                    return str(gateway._resolve_account_type(account_id)).strip().upper()
+                aid = account_id or self.account_id or ""
+                if aid:
+                    return str(gateway._resolve_account_type(aid)).strip().upper()
             except Exception:
                 pass
         return str(
@@ -1292,7 +1307,7 @@ class BigQmtRpcHandlers:
         return self._call_qmt_global(
             "get_unclosed_compacts",
             self._request_account_id(params),
-            self._configured_account_type(),
+            self._configured_account_type(self._request_account_id(params)),
         )
 
     def _handle_query_credit_subjects(self, params):
@@ -1372,14 +1387,14 @@ class BigQmtRpcHandlers:
         return self._call_qmt_global(
             "get_unclosed_compacts",
             self._request_account_id(params),
-            self._configured_account_type(),
+            self._configured_account_type(self._request_account_id(params)),
         )
 
     def _handle_get_closed_compacts(self, params):
         return self._call_qmt_global(
             "get_closed_compacts",
             self._request_account_id(params),
-            self._configured_account_type(),
+            self._configured_account_type(self._request_account_id(params)),
         )
 
     def _handle_get_debt_contract(self, params):

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -573,6 +573,7 @@ class BigQmtRpcHandlers:
         # succeeded (issue #43).
         self._last_server_error = ""
         self._pending_settlement = None
+        self._current_params = params
         if not requested_method:
             raise ValueError("method is required")
         if method not in self.allowed_methods:
@@ -1239,8 +1240,19 @@ class BigQmtRpcHandlers:
         return _normalize_detail_rows(data)
 
     def _configured_account_type(self):
+        gateway = self.order_gateway
+        # When the gateway supports per-request account_type resolution,
+        # use the map-aware type for the current request's account_id.
+        if gateway is not None and hasattr(gateway, "_resolve_account_type"):
+            try:
+                account_id = self._request_account_id(
+                    getattr(self, "_current_params", None) or {})
+                if account_id:
+                    return str(gateway._resolve_account_type(account_id)).strip().upper()
+            except Exception:
+                pass
         return str(
-            getattr(self.order_gateway, "account_type", "CREDIT") or "CREDIT"
+            getattr(gateway, "account_type", "CREDIT") or "CREDIT"
         ).strip().upper()
 
     def _query_trade_detail(self, params, detail_type, strategy_name=""):
@@ -1254,8 +1266,11 @@ class BigQmtRpcHandlers:
         gateway = self.order_gateway
         if gateway is None or gateway.get_trade_detail_data is None:
             return []
+        account_type = (gateway._resolve_account_type(account_id)
+                        if hasattr(gateway, "_resolve_account_type")
+                        else getattr(gateway, "account_type", "STOCK"))
         try:
-            rows = gateway.get_trade_detail_data(account_id, gateway.account_type, detail_type, strategy_name)
+            rows = gateway.get_trade_detail_data(account_id, account_type, detail_type, strategy_name)
             return _normalize_detail_rows(rows)
         except Exception:
             return []

--- a/tests/bigqmt_signal_trader/test_account_type_map.py
+++ b/tests/bigqmt_signal_trader/test_account_type_map.py
@@ -1,0 +1,349 @@
+# coding: utf-8
+"""Tests for account_type_map per-request resolution (PR #135).
+
+litaolemo's review requested 5 specific scenarios plus an integration test:
+  1. No MAP configured → falls back to default type
+  2. MAP present with matching key → correct mapping
+  3. Key not in MAP → fallback to default
+  4. Empty/None account_id → fallback to default
+  5. int key → str() conversion matches string keys in MAP
+
+Plus:
+  - Gateway._resolve_account_type integration
+  - OrderGateway._account_type_code(account_id) per-request
+  - BigQmtRpcHandlers._configured_account_type(account_id) per-request
+  - BigQmtRpcHandlers._reported_account_type(account_id) per-request
+  - No importlib.reload is called (the #3 review item)
+"""
+
+import importlib
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SRC = os.path.join(ROOT, "src")
+sys.path.insert(0, SRC)
+
+from bigqmt_signal_trader.account_type_map import (
+    account_type_for,
+    get_account_type_map,
+    reload as reload_map,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: account_type_map pure functions
+# ---------------------------------------------------------------------------
+
+class AccountTypeForTest(unittest.TestCase):
+    """The 5 scenarios requested in PR #135 review."""
+
+    def setUp(self):
+        # Force a fresh load for each test
+        reload_map()
+
+    def test_no_map_falls_back_to_default(self):
+        """Scenario 1: no BIGQMT_ACCOUNT_TYPE_MAP → default_type."""
+        sys.modules.pop("bigqmt_signal_trader_local_config", None)
+        reload_map()
+        result = account_type_for("any_account", default_type="CREDIT")
+        self.assertEqual(result, "CREDIT")
+
+    def test_map_present_correct_mapping(self):
+        """Scenario 2: MAP has the key → returns mapped type."""
+        fake_cfg = types.ModuleType("bigqmt_signal_trader_local_config")
+        fake_cfg.BIGQMT_ACCOUNT_TYPE_MAP = {"123456": "CREDIT", "789012": "FUTURE"}
+        with mock.patch.dict("sys.modules",
+                             {"bigqmt_signal_trader_local_config": fake_cfg}):
+            reload_map()
+            self.assertEqual(account_type_for("123456", "STOCK"), "CREDIT")
+            self.assertEqual(account_type_for("789012", "STOCK"), "FUTURE")
+
+    def test_key_not_in_map_falls_back(self):
+        """Scenario 3: key exists but account_id is not in MAP → default."""
+        fake_cfg = types.ModuleType("bigqmt_signal_trader_local_config")
+        fake_cfg.BIGQMT_ACCOUNT_TYPE_MAP = {"111": "CREDIT"}
+        with mock.patch.dict("sys.modules",
+                             {"bigqmt_signal_trader_local_config": fake_cfg}):
+            reload_map()
+            self.assertEqual(account_type_for("999", "STOCK"), "STOCK")
+
+    def test_empty_or_none_account_id_falls_back(self):
+        """Scenario 4: account_id is empty string or None → default."""
+        fake_cfg = types.ModuleType("bigqmt_signal_trader_local_config")
+        fake_cfg.BIGQMT_ACCOUNT_TYPE_MAP = {"111": "CREDIT"}
+        with mock.patch.dict("sys.modules",
+                             {"bigqmt_signal_trader_local_config": fake_cfg}):
+            reload_map()
+            self.assertEqual(account_type_for("", "STOCK"), "STOCK")
+            self.assertEqual(account_type_for(None, "CREDIT"), "CREDIT")
+
+    def test_int_key_converted_to_str(self):
+        """Scenario 5: int key is str()-converted so it matches string keys.
+
+        BIGQMT_ACCOUNT_TYPE_MAP keys are strings (from Python dict literals
+        in the config file). account_type_for() applies str() to the key
+        before lookup, so passing an int 123456 WILL match the string key
+        "123456". This is the designed behavior: account_ids in QMT are
+        always strings, and the str() cast catches accidental int usage.
+        """
+        fake_cfg = types.ModuleType("bigqmt_signal_trader_local_config")
+        fake_cfg.BIGQMT_ACCOUNT_TYPE_MAP = {"123456": "CREDIT"}
+        with mock.patch.dict("sys.modules",
+                             {"bigqmt_signal_trader_local_config": fake_cfg}):
+            reload_map()
+            # int 123456 is str()-converted and matches "123456"
+            result = account_type_for(123456, "STOCK")
+            self.assertEqual(result, "CREDIT")
+
+    def test_int_key_not_in_still_falls_back(self):
+        """An int that has no corresponding string key → default."""
+        fake_cfg = types.ModuleType("bigqmt_signal_trader_local_config")
+        fake_cfg.BIGQMT_ACCOUNT_TYPE_MAP = {"111": "CREDIT"}
+        with mock.patch.dict("sys.modules",
+                             {"bigqmt_signal_trader_local_config": fake_cfg}):
+            reload_map()
+            self.assertEqual(account_type_for(999, "STOCK"), "STOCK")
+
+    def test_reload_clears_cached_map(self):
+        """reload() forces a fresh load on next access."""
+        fake_cfg = types.ModuleType("bigqmt_signal_trader_local_config")
+        fake_cfg.BIGQMT_ACCOUNT_TYPE_MAP = {"AAA": "CREDIT"}
+        with mock.patch.dict("sys.modules",
+                             {"bigqmt_signal_trader_local_config": fake_cfg}):
+            reload_map()
+            self.assertEqual(account_type_for("AAA", "STOCK"), "CREDIT")
+
+        # Change the config
+        fake_cfg.BIGQMT_ACCOUNT_TYPE_MAP = {"AAA": "FUTURE"}
+        with mock.patch.dict("sys.modules",
+                             {"bigqmt_signal_trader_local_config": fake_cfg}):
+            reload_map()
+            self.assertEqual(account_type_for("AAA", "STOCK"), "FUTURE")
+
+    def test_map_with_none_value_treated_as_empty(self):
+        """BIGQMT_ACCOUNT_TYPE_MAP = None → treated as {} → fallback."""
+        fake_cfg = types.ModuleType("bigqmt_signal_trader_local_config")
+        fake_cfg.BIGQMT_ACCOUNT_TYPE_MAP = None
+        with mock.patch.dict("sys.modules",
+                             {"bigqmt_signal_trader_local_config": fake_cfg}):
+            reload_map()
+            self.assertEqual(account_type_for("any", "STOCK"), "STOCK")
+
+
+# ---------------------------------------------------------------------------
+# Integration: _resolve_account_type on gateway
+# ---------------------------------------------------------------------------
+
+class GatewayResolveAccountTypeTest(unittest.TestCase):
+    """_resolve_account_type on order/position gateway delegates to the map."""
+
+    def test_order_gateway_uses_map(self):
+        from bigqmt_signal_trader.adapters.order_bigqmt import BigQmtOrderGateway
+
+        fake_cfg = types.ModuleType("bigqmt_signal_trader_local_config")
+        fake_cfg.BIGQMT_ACCOUNT_TYPE_MAP = {"ACCT_CREDIT": "CREDIT"}
+        with mock.patch.dict("sys.modules",
+                             {"bigqmt_signal_trader_local_config": fake_cfg}):
+            reload_map()
+            gw = BigQmtOrderGateway(context_info=None, account_type="STOCK")
+            self.assertEqual(gw._resolve_account_type("ACCT_CREDIT"), "CREDIT")
+            self.assertEqual(gw._resolve_account_type("ACCT_UNKNOWN"), "STOCK")
+
+    def test_position_gateway_uses_map(self):
+        from bigqmt_signal_trader.adapters.position_bigqmt import BigQmtPositionProvider
+
+        fake_cfg = types.ModuleType("bigqmt_signal_trader_local_config")
+        fake_cfg.BIGQMT_ACCOUNT_TYPE_MAP = {"ACCT_CREDIT": "CREDIT"}
+        with mock.patch.dict("sys.modules",
+                             {"bigqmt_signal_trader_local_config": fake_cfg}):
+            reload_map()
+            prov = BigQmtPositionProvider(
+                get_trade_detail_data_func=None, account_type="STOCK")
+            self.assertEqual(prov._resolve_account_type("ACCT_CREDIT"), "CREDIT")
+            self.assertEqual(prov._resolve_account_type("ACCT_UNKNOWN"), "STOCK")
+
+
+# ---------------------------------------------------------------------------
+# Integration: _account_type_code(account_id) on order gateway
+# ---------------------------------------------------------------------------
+
+class AccountTypeCodePerRequestTest(unittest.TestCase):
+    """_account_type_code(account_id) respects per-request MAP lookup."""
+
+    def test_with_map_returns_mapped_code(self):
+        from bigqmt_signal_trader.adapters.order_bigqmt import BigQmtOrderGateway
+
+        fake_cfg = types.ModuleType("bigqmt_signal_trader_local_config")
+        fake_cfg.BIGQMT_ACCOUNT_TYPE_MAP = {"CREDIT_ACCT": "CREDIT"}
+        with mock.patch.dict("sys.modules",
+                             {"bigqmt_signal_trader_local_config": fake_cfg}):
+            reload_map()
+            gw = BigQmtOrderGateway(context_info=None, account_type="STOCK")
+            code_mapped = gw._account_type_code("CREDIT_ACCT")
+            code_default = gw._account_type_code(None)
+            # Both should be ints
+            self.assertIsInstance(code_mapped, int)
+            self.assertIsInstance(code_default, int)
+
+    def test_without_account_id_uses_self_account_type(self):
+        from bigqmt_signal_trader.adapters.order_bigqmt import BigQmtOrderGateway
+
+        fake_cfg = types.ModuleType("bigqmt_signal_trader_local_config")
+        fake_cfg.BIGQMT_ACCOUNT_TYPE_MAP = {"CREDIT_ACCT": "CREDIT"}
+        with mock.patch.dict("sys.modules",
+                             {"bigqmt_signal_trader_local_config": fake_cfg}):
+            reload_map()
+            gw = BigQmtOrderGateway(context_info=None, account_type="CREDIT")
+            # No account_id → uses self.account_type = "CREDIT"
+            code = gw._account_type_code()
+            self.assertIsInstance(code, int)
+
+    def test_no_map_account_id_ignored(self):
+        from bigqmt_signal_trader.adapters.order_bigqmt import BigQmtOrderGateway
+
+        # No MAP configured
+        sys.modules.pop("bigqmt_signal_trader_local_config", None)
+        reload_map()
+        gw = BigQmtOrderGateway(context_info=None, account_type="STOCK")
+        code_no_id = gw._account_type_code()
+        code_with_id = gw._account_type_code("some_acct")
+        # Without a MAP, both should return the same code (self.account_type)
+        self.assertEqual(code_no_id, code_with_id)
+
+
+# ---------------------------------------------------------------------------
+# Integration: _configured_account_type(account_id) on BigQmtRpcHandlers
+# ---------------------------------------------------------------------------
+
+class ConfiguredAccountTypePerRequestTest(unittest.TestCase):
+    """_configured_account_type(account_id=...) avoids _current_params race."""
+
+    def _make_handlers(self, gateway_account_type="STOCK", account_type_map=None):
+        from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+        from bigqmt_signal_trader.adapters.order_bigqmt import BigQmtOrderGateway
+
+        if account_type_map is not None:
+            fake_cfg = types.ModuleType("bigqmt_signal_trader_local_config")
+            fake_cfg.BIGQMT_ACCOUNT_TYPE_MAP = account_type_map
+            with mock.patch.dict("sys.modules",
+                                 {"bigqmt_signal_trader_local_config": fake_cfg}):
+                reload_map()
+        else:
+            sys.modules.pop("bigqmt_signal_trader_local_config", None)
+            reload_map()
+
+        gw = BigQmtOrderGateway(context_info=None, account_type=gateway_account_type)
+        handlers = BigQmtRpcHandlers(
+            account_id="DEFAULT_ACCT",
+            market_data=None,
+            position_provider=None,
+            order_gateway=gw,
+        )
+        return handlers
+
+    def test_no_map_returns_gateway_default(self):
+        h = self._make_handlers(gateway_account_type="CREDIT")
+        self.assertEqual(h._configured_account_type(), "CREDIT")
+
+    def test_with_map_returns_mapped_type(self):
+        h = self._make_handlers(
+            gateway_account_type="STOCK",
+            account_type_map={"CREDIT_ACCT": "CREDIT"})
+        self.assertEqual(
+            h._configured_account_type("CREDIT_ACCT"), "CREDIT")
+
+    def test_map_key_missing_returns_gateway_default(self):
+        h = self._make_handlers(
+            gateway_account_type="STOCK",
+            account_type_map={"OTHER": "FUTURE"})
+        self.assertEqual(
+            h._configured_account_type("CREDIT_ACCT"), "STOCK")
+
+    def test_no_account_id_uses_self_account_id(self):
+        h = self._make_handlers(
+            gateway_account_type="STOCK",
+            account_type_map={"DEFAULT_ACCT": "CREDIT"})
+        # No explicit account_id → falls back to self.account_id
+        self.assertEqual(h._configured_account_type(), "CREDIT")
+
+    def test_no_current_params_attribute(self):
+        """Verify that _current_params no longer exists on the instance."""
+        h = self._make_handlers()
+        self.assertFalse(hasattr(h, "_current_params"))
+
+
+# ---------------------------------------------------------------------------
+# Integration: _reported_account_type(account_id) on BigQmtRpcHandlers
+# ---------------------------------------------------------------------------
+
+class ReportedAccountTypePerRequestTest(unittest.TestCase):
+    """_reported_account_type(account_id=...) respects per-request MAP."""
+
+    def _make_handlers(self, gateway_account_type="STOCK", account_type_map=None):
+        from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+        from bigqmt_signal_trader.adapters.order_bigqmt import BigQmtOrderGateway
+
+        if account_type_map is not None:
+            fake_cfg = types.ModuleType("bigqmt_signal_trader_local_config")
+            fake_cfg.BIGQMT_ACCOUNT_TYPE_MAP = account_type_map
+            with mock.patch.dict("sys.modules",
+                                 {"bigqmt_signal_trader_local_config": fake_cfg}):
+                reload_map()
+        else:
+            sys.modules.pop("bigqmt_signal_trader_local_config", None)
+            reload_map()
+
+        gw = BigQmtOrderGateway(context_info=None, account_type=gateway_account_type)
+        handlers = BigQmtRpcHandlers(
+            account_id="DEFAULT_ACCT",
+            market_data=None,
+            position_provider=None,
+            order_gateway=gw,
+        )
+        return handlers
+
+    def test_no_gateway_returns_empty(self):
+        from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+        h = BigQmtRpcHandlers.__new__(BigQmtRpcHandlers)
+        h.order_gateway = None
+        self.assertEqual(h._reported_account_type(), "")
+
+    def test_with_map_returns_mapped_type(self):
+        h = self._make_handlers(
+            gateway_account_type="STOCK",
+            account_type_map={"CREDIT_ACCT": "CREDIT"})
+        self.assertEqual(
+            h._reported_account_type("CREDIT_ACCT"), "CREDIT")
+
+    def test_without_account_id_returns_gateway_default(self):
+        h = self._make_handlers(gateway_account_type="CREDIT")
+        self.assertEqual(h._reported_account_type(), "CREDIT")
+
+
+# ---------------------------------------------------------------------------
+# Regression: importlib.reload is never called
+# ---------------------------------------------------------------------------
+
+class NoImportlibReloadTest(unittest.TestCase):
+    """_load_map must use import_module, NOT reload (PR #135 review item #3)."""
+
+    def test_reload_is_not_called_in_load_map(self):
+        from bigqmt_signal_trader import account_type_map as atm
+
+        with mock.patch.object(importlib, "reload") as mock_reload:
+            # Force a fresh load
+            atm._ACCOUNT_TYPE_MAP = None
+            fake_cfg = types.ModuleType("bigqmt_signal_trader_local_config")
+            fake_cfg.BIGQMT_ACCOUNT_TYPE_MAP = {"X": "CREDIT"}
+            with mock.patch.dict("sys.modules",
+                                 {"bigqmt_signal_trader_local_config": fake_cfg}):
+                atm.get_account_type_map()
+            mock_reload.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_order_identity_local.py
+++ b/tests/bigqmt_signal_trader/test_order_identity_local.py
@@ -150,7 +150,7 @@ class FilteredQueryNamesRowsTest(unittest.TestCase):
         gateway._rows = rows
         gateway._require_query_func = lambda: (
             lambda account_id, account_type, kind, strategy_name: rows)
-        gateway._account_type_code = lambda: 2
+        gateway._account_type_code = lambda account_id=None: 2
         gateway.account_type = "STOCK"
         gateway.context_info = None
         return gateway


### PR DESCRIPTION
问题:
BigQmtOrderGateway / BigQmtPositionProvider 的 self.account_type 在 __init__ 时固定（默认 "STOCK"），所有 get_trade_detail_data、cancel、query_orders、query_trades 调用都用这个固定值。
在单终端双账号部署（一个 QMT 进程同时服务 STOCK + FUTURE 两个账号）中，期货 account_id 查询时仍传 account_type="STOCK"，返回全零行——静默数据丢失，和 #92 同类问题。
根因:
account_type 在 gateway 初始化时绑定，之后不再按请求重新解析。但每个请求都带了 account_id，可以映射到不同的 account_type。
修复:
在两个 gateway 类上增加 _resolve_account_type(account_id)，从 BIGQMT_ACCOUNT_TYPE_MAP 查表。未配置时直接返回 self.account_type——对单账号部署零影响。
配置示例（bigqmt_signal_trader_local_config.py）：
BIGQMT_ACCOUNT_TYPE_MAP = {
    "8886009168": "STOCK",
    "809151689": "FUTURE",
}
改动（4 文件，+112 -12）
- account_type_map.py（新增）：account_type_for(id, default) 查表 + fallback
- order_bigqmt.py：_resolve_account_type + 6 处调用（cancel、query_orders、query_trades、describe_detail_fields、submit 透传守卫）
- position_bigqmt.py：_resolve_account_type + 3 处调用（get_positions、get_position_statistics、get_asset）
- redis_rpc.py：_query_trade_detail 和 _configured_account_type 按请求动态解析；handle() 存 _current_params 供 _configured_account_type 读取
向后兼容
- 未配置 MAP → _resolve_account_type 返回 self.account_type，与现有行为完全一致
- 无方法签名变更
- 无新增必填配置


我们的单终端双账号方案:
#131 讨论中提到想了解双账号方案，这里简述我们的做法：
场景：一个 QMT 进程（D:\Program\QMT）跑一个策略实例 BIGQMT_REDIS_DRYRUN.py，同时服务股票（8886009168）和期货（809151689）两个账号。
方案：
1. 双 RPC channel：两个 RedisPubSubRpcService 各监一个 account_id channel（bigqmt:rpc:req:8886009168 / bigqmt:rpc:req:809151689），共用同一个 BigQmtRpcHandlers 实例。股票客户端走股票 channel，期货客户端走期货 channel
2. DualAccountOrderGateway（继承 BigQmtOrderGateway）：每次请求前 save/restore self.account_type + self.account_id，然后 delegate 到 super()——这样上游 submit() 里的 PASSTHROUGH_ACCOUNT_TYPES 检查和 credit/passthrough 分支都正确工作，无需复制逻辑
3. DualAccountPositionProvider（同理）：save/restore 后 delegate 到 super()
4. patch_rpc_handlers：patch _configured_account_type 使其按请求 account_id 动态查表；patch _query_trade_detail 同理；patch _handle_cancel_order 传递 account_id
5. 配置：BIGQMT_ACCOUNT_TYPE_MAP = {"8886009168": "STOCK", "809151689": "FUTURE"}
本 PR 的意义：如果合入，_resolve_account_type 内置到 gateway 后，DualAccountOrderGateway 的 save/restore 就不再需要——submit/query/cancel 直接从 _resolve_account_type 拿到正确的 account_type。双账号方案的代码量将大幅减少，只剩双 channel 编排层。