### PR TITLE
Fix generated ZMQ client port mismatch

### DIFF
--- a/src/bigqmt_signal_trader/init_config.py
+++ b/src/bigqmt_signal_trader/init_config.py
@@ -79,6 +79,22 @@ def _zmq_default_port(account_id):
     return _default_zmq_port(account_id)
 
 
+def _zmq_server_bind_host(client_host):
+    """Bind loopback for same-host clients, wildcard for a remote QMT host.
+
+    ``client_host`` is the address the external program uses to reach the QMT
+    machine.  A server cannot bind that public/DNS name reliably, so a remote
+    deployment listens on all local interfaces and leaves interface/firewall
+    restriction to the operator.
+    """
+    normalized = str(client_host or "").strip().lower()
+    if normalized in ("", "127.0.0.1", "localhost"):
+        from .transports.zmq_transport import DEFAULT_ZMQ_HOST
+
+        return DEFAULT_ZMQ_HOST
+    return "0.0.0.0"
+
+
 def render_server_config(answers):
     """bigqmt_signal_trader_local_config.py -- read by the QMT-side strategy."""
     lines = [
@@ -101,6 +117,14 @@ def render_server_config(answers):
         '    "username": %r,' % str(answers["username"]),
         '    "password": %r,' % str(answers["password"]),
     ]
+    if str(answers["transport"]) == "zmq":
+        port = _zmq_default_port(answers["account_id"])
+        bind_host = _zmq_server_bind_host(answers["host"])
+        lines.extend([
+            "    # Same-host ZMQ stays on loopback. A remote QMT address makes the",
+            "    # server bind all interfaces; restrict that port with a firewall.",
+            '    "zmq": {"bind_address": "tcp://%s:%d"},' % (bind_host, port),
+        ])
     if answers["allow_order_methods"]:
         lines.append("    # Remote order/cancel is ON. Turn it off if you only need queries.")
     else:
@@ -159,10 +183,14 @@ def render_client_config(answers):
     if transport == "zmq":
         port = _zmq_default_port(answers["account_id"])
         lines.extend([
-            "    # The QMT-side server derives this port from the account id. Set it",
-            "    # explicitly to skip service discovery; change it if the server logs",
-            "    # a different bind port.",
-            '    "zmq": {"connect_address": "tcp://%s:%d"},' % (str(answers["host"]), port),
+            "    # QMT host/port are explicit so RPC and quote-push clients use the",
+            "    # same machine. The server config generated alongside this file",
+            "    # binds loopback for local use or 0.0.0.0 for a remote QMT host.",
+            '    "zmq": {',
+            '        "host": %r,' % str(answers["host"]),
+            '        "port": %d,' % port,
+            '        "connect_address": "tcp://%s:%d",' % (str(answers["host"]), port),
+            "    },",
         ])
     lines.extend([
         "}",
@@ -313,10 +341,19 @@ def prompt_answers(write, read, read_secret=None):
             write, read, "Redis 密码（无则回车，输入不回显）", "",
             secret=True, read_secret=read_secret)
     else:
-        answers["host"] = _ask(write, read, "服务端地址", DEFAULTS["host"])
+        answers["host"] = _ask(
+            write, read,
+            "QMT 终端地址（同机用 127.0.0.1；跨机填 QMT 主机 IP/主机名）",
+            DEFAULTS["host"],
+        )
         answers["port"] = _zmq_default_port(answers["account_id"])
         write("  zmq 端口按账号推导为 %d（服务端日志会打印实际绑定端口）。\n"
               % answers["port"])
+        if _zmq_server_bind_host(answers["host"]) == "0.0.0.0":
+            write(
+                "  跨机 ZMQ 会让 QMT 服务端绑定 0.0.0.0；请用 Windows "
+                "防火墙把该端口限制到可信客户端。\n"
+            )
 
     write("\n远程下单/撤单默认关闭。打开后，任何能连上这条通道的程序都可以下单。\n")
     answers["allow_order_methods"] = _ask_bool(

--- a/src/bigqmt_signal_trader/init_config.py
+++ b/src/bigqmt_signal_trader/init_config.py
@@ -71,10 +71,12 @@ def _zmq_default_port(account_id):
     """The zmq transport derives its port from the account id when no explicit
     address is configured; mirror that so the client block points somewhere
     real instead of a placeholder."""
-    digits = "".join(character for character in str(account_id) if character.isdigit())
-    if not digits:
-        return 15563
-    return 15000 + (int(digits) % 1000)
+    # Keep one source of truth for the derivation.  Duplicating the constants
+    # here previously made bigqmt-init generate a client address in the 15000
+    # range while the QMT-side ZmqTransport listened in the 15560 range.
+    from .transports.zmq_transport import _default_zmq_port
+
+    return _default_zmq_port(account_id)
 
 
 def render_server_config(answers):

--- a/tests/bigqmt_signal_trader/test_init_config.py
+++ b/tests/bigqmt_signal_trader/test_init_config.py
@@ -21,6 +21,7 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 sys.path.insert(0, os.path.join(ROOT, "src"))
 
 from bigqmt_signal_trader import init_config
+from bigqmt_signal_trader.transports.zmq_transport import _default_zmq_address
 
 
 class _Script(object):
@@ -116,6 +117,19 @@ class RenderedConfigTest(unittest.TestCase):
 
         address = loaded["BIGQMT_REDIS_CONFIG"]["zmq"]["connect_address"]
         self.assertTrue(address.startswith("tcp://192.168.1.9:"), address)
+
+    def test_zmq_client_address_matches_the_server_transport_default(self):
+        """The generated client must dial the endpoint ZmqTransport binds."""
+        for account_id in ("8886800503", "account-without-digits"):
+            loaded = _load(init_config.render_client_config(
+                _answers(account_id=account_id, transport="zmq",
+                         host="192.168.1.9")), "c.py")
+
+            address = loaded["BIGQMT_REDIS_CONFIG"]["zmq"]["connect_address"]
+            self.assertEqual(
+                address,
+                _default_zmq_address(account_id, host="192.168.1.9"),
+            )
 
     def test_credentials_survive_characters_that_would_break_naive_quoting(self):
         nasty = "a'b\"c\\d#e"

--- a/tests/bigqmt_signal_trader/test_init_config.py
+++ b/tests/bigqmt_signal_trader/test_init_config.py
@@ -21,7 +21,11 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 sys.path.insert(0, os.path.join(ROOT, "src"))
 
 from bigqmt_signal_trader import init_config
-from bigqmt_signal_trader.transports.zmq_transport import _default_zmq_address
+from bigqmt_signal_trader.transports.zmq_transport import (
+    DEFAULT_ZMQ_HOST,
+    _default_zmq_address,
+    _default_zmq_port,
+)
 
 
 class _Script(object):
@@ -115,8 +119,11 @@ class RenderedConfigTest(unittest.TestCase):
         loaded = _load(init_config.render_client_config(
             _answers(transport="zmq", host="192.168.1.9")), "c.py")
 
-        address = loaded["BIGQMT_REDIS_CONFIG"]["zmq"]["connect_address"]
+        zmq = loaded["BIGQMT_REDIS_CONFIG"]["zmq"]
+        address = zmq["connect_address"]
         self.assertTrue(address.startswith("tcp://192.168.1.9:"), address)
+        self.assertEqual(zmq["host"], "192.168.1.9")
+        self.assertEqual(zmq["port"], _default_zmq_port("8886800503"))
 
     def test_zmq_client_address_matches_the_server_transport_default(self):
         """The generated client must dial the endpoint ZmqTransport binds."""
@@ -130,6 +137,38 @@ class RenderedConfigTest(unittest.TestCase):
                 address,
                 _default_zmq_address(account_id, host="192.168.1.9"),
             )
+
+    def test_zmq_same_host_configs_use_the_same_loopback_endpoint(self):
+        answers = _answers(
+            account_id="8886800503", transport="zmq", host=DEFAULT_ZMQ_HOST
+        )
+        server = _load(init_config.render_server_config(answers), "s.py")
+        client = _load(init_config.render_client_config(answers), "c.py")
+
+        expected = _default_zmq_address("8886800503", host=DEFAULT_ZMQ_HOST)
+        self.assertEqual(
+            server["BIGQMT_REDIS_CONFIG"]["zmq"]["bind_address"], expected
+        )
+        self.assertEqual(
+            client["BIGQMT_REDIS_CONFIG"]["zmq"]["connect_address"], expected
+        )
+
+    def test_zmq_remote_host_connects_to_qmt_and_server_binds_all_interfaces(self):
+        answers = _answers(
+            account_id="8886800503", transport="zmq", host="192.168.8.13"
+        )
+        server = _load(init_config.render_server_config(answers), "s.py")
+        client = _load(init_config.render_client_config(answers), "c.py")
+        port = _default_zmq_port("8886800503")
+
+        self.assertEqual(
+            client["BIGQMT_REDIS_CONFIG"]["zmq"]["connect_address"],
+            "tcp://192.168.8.13:%d" % port,
+        )
+        self.assertEqual(
+            server["BIGQMT_REDIS_CONFIG"]["zmq"]["bind_address"],
+            "tcp://0.0.0.0:%d" % port,
+        )
 
     def test_credentials_survive_characters_that_would_break_naive_quoting(self):
         nasty = "a'b\"c\\d#e"
@@ -199,6 +238,8 @@ class PromptFlowTest(unittest.TestCase):
         self.assertEqual(answers["transport"], "zmq")
         self.assertEqual(answers["password"], "")
         self.assertNotIn("Redis 密码", "".join(script.prompts))
+        self.assertIn("0.0.0.0", script.text())
+        self.assertIn("防火墙", script.text())
 
     def test_no_redis_single_file_forces_zmq(self):
         """Choosing a build that cannot import redis must not leave the config


### PR DESCRIPTION
## What changed

- make `bigqmt-init` reuse `ZmqTransport`'s canonical default-port helper
- generate matching ZMQ server/client endpoints instead of leaving the server on an unrelated implicit default
- keep same-host deployments on loopback
- for remote QMT hosts, generate a client endpoint for that host and a server bind endpoint on `0.0.0.0`, with a firewall warning
- include explicit `host`, `port`, and `connect_address` so RPC and quote-push clients agree
- add regression coverage for numeric/fallback account ids and local/remote host layouts

This removes the duplicated `15000 + mod 1000` calculation that could generate a client endpoint different from the server's canonical `15560 + mod 100` endpoint, and covers the host half requested in review.

The branch is based on current `main` (`29ce7d3`, including #131); `git rebase origin/main` reports it is already up to date.

## Tests

- `python -m pytest tests/bigqmt_signal_trader/test_init_config.py -q` — 27 passed
- `python -m pytest -q` in a clean config-import environment — 1105 passed, 3 skipped, 3 subtests passed

## Live QMT validation

Pending. I will add the generated-config ZMQ ping result before merge. No order will be submitted.

Fixes #136