### PR TITLE
Verify QMT login reaches the main window

### DIFF
--- a/src/bigqmt_signal_trader/qmt_launcher.py
+++ b/src/bigqmt_signal_trader/qmt_launcher.py
@@ -378,6 +378,29 @@ def _looks_like_login_window(rect, screen_width, screen_height):
     return width < screen_width * 0.65 and height < screen_height * 0.65
 
 
+def _wait_for_main_window(
+        find_window, get_rect, screen_width, screen_height,
+        timeout_seconds=90.0, poll_interval=1.0):
+    """Wait until the QMT login shell is replaced by the main terminal.
+
+    FormulaServer port 58600 already listens while the login dialog is still
+    open, so a port-only readiness check can report success after the broker
+    has rejected or timed out the login.  Require the visible QMT window to
+    transition to main-window proportions before declaring login complete.
+    """
+    deadline = time.monotonic() + max(float(timeout_seconds), 0.0)
+    while True:
+        handle = find_window()
+        if handle:
+            rect = get_rect(handle)
+            if not _looks_like_login_window(
+                    rect, screen_width, screen_height):
+                return handle
+        if time.monotonic() >= deadline:
+            return None
+        time.sleep(max(float(poll_interval), 0.0))
+
+
 def _login_via_window(credentials, window_title_prefix=None, appear_timeout_seconds=90.0):
     """Type credentials into the QMT login dialog.
 
@@ -600,6 +623,18 @@ def _login_via_window(credentials, window_title_prefix=None, appear_timeout_seco
         return
     # 用 Enter 提交而不是点坐标——布局无关（issue #128）。
     _key(win32con.VK_RETURN)
+    if not _wait_for_main_window(
+            _find,
+            win32gui.GetWindowRect,
+            user32.GetSystemMetrics(0),
+            user32.GetSystemMetrics(1),
+            timeout_seconds=appear_timeout_seconds):
+        raise QmtLauncherError(
+            "QMT login did not reach the main window within %.0fs; the login "
+            "dialog may be showing a broker/network/credential error."
+            % appear_timeout_seconds
+        )
+    log.info("QMT login completed; main window detected")
 
 
 def restart_qmt(install_dir, settle_seconds=5.0, **open_kwargs):

--- a/tests/bigqmt_signal_trader/test_qmt_launcher.py
+++ b/tests/bigqmt_signal_trader/test_qmt_launcher.py
@@ -241,6 +241,31 @@ class LoginWindowDetectionTest(unittest.TestCase):
         self.assertFalse(qmt_launcher._looks_like_login_window(
             (250, 120, 1650, 1020), 1920, 1200))
 
+    def test_login_completion_waits_for_the_main_window(self):
+        login = (816, 420, 2064, 1306)
+        main = (0, 0, 2880, 1740)
+        handles = iter((10, 20))
+        rects = {10: login, 20: main}
+
+        result = qmt_launcher._wait_for_main_window(
+            lambda: next(handles), rects.get, 2880, 1800,
+            timeout_seconds=1.0, poll_interval=0.0,
+        )
+
+        self.assertEqual(result, 20)
+
+    def test_login_completion_rejects_a_persistent_login_dialog(self):
+        result = qmt_launcher._wait_for_main_window(
+            lambda: 10,
+            lambda _handle: (816, 420, 2064, 1306),
+            2880,
+            1800,
+            timeout_seconds=0.0,
+            poll_interval=0.0,
+        )
+
+        self.assertIsNone(result)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

QMT's FormulaServer port 58600 already listens while the broker login dialog is still visible. `open_qmt()` currently presses Enter and immediately delegates readiness to that port, so a rejected or timed-out login can be reported as a successful terminal start.

Observed live on 2026-09-01 after #140 merged:

- the DPI-aware path entered account/password into the correct fields and submitted
- port 58600 was listening
- the login shell remained visible and QMT displayed broker error `200003` (`超时`)
- `XtClient_20260901.log` recorded `CProxyClient::onLogin ... status = 21` and `slot_onLoginStatus ... 错误200003,超时`
- no RPC bridge mounted, despite the old readiness check returning immediately

## Fix

After submitting credentials, wait for the visible QMT window to transition from login-shell proportions to main-window proportions. A missing/intermediate window keeps waiting; a persistent login shell times out with a specific `QmtLauncherError`. FormulaServer port readiness remains the subsequent process-health check, but can no longer substitute for login completion.

## Tests

- targeted launcher tests: 22 passed
- full suite on current main (including #140 and #138): 1150 passed, 3 skipped, 3 subtests passed
- new tests cover both login→main transition and a persistent login shell

This is a small follow-up to #140 discovered during live negative-path validation. No order was submitted.
