### PR TITLE
Confirm falsey cancel results by order status

### DIFF
--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -187,6 +187,8 @@ METHOD_ALIASES = {
 BUY_ORDER_TYPES = {"23", "STOCK_BUY", "BUY", "B"}
 SELL_ORDER_TYPES = {"24", "STOCK_SELL", "SELL", "S"}
 CANCELABLE_ORDER_STATUSES = {"50", "55"}
+CANCELED_ORDER_STATUSES = {"53", "54"}
+TERMINAL_NON_CANCEL_ORDER_STATUSES = {"56", "57"}
 SAFE_B64_PREFIX = "b64s:"
 SAFE_B64_DIGIT_ENCODE = str.maketrans("0123456789", "!#$%&()*~?")
 SAFE_B64_DIGIT_DECODE = str.maketrans("!#$%&()*~?", "0123456789")
@@ -433,6 +435,29 @@ class OrderSettlement(object):
         self.deadline = deadline
         self.attempts = 0
         self.server_error = ""
+        self.request = None
+        self.response = None
+
+
+class CancelSettlement(object):
+    """One falsey native cancel result awaiting the order's actual status.
+
+    Full QMT's injected ``cancel`` return is not reliable across terminal
+    builds.  On Guojin 2.1.19.0 it returned falsey even though the broker
+    acknowledged the request and the order moved to status 54 within 67 ms
+    (issue #148).  Like order-id settlement, status readback must stay on the
+    adjust thread because get_trade_detail_data is empty on worker threads.
+    """
+
+    __slots__ = ("order_ref", "account_id", "result", "deadline", "attempts",
+                 "request", "response")
+
+    def __init__(self, order_ref, account_id, result, deadline):
+        self.order_ref = order_ref
+        self.account_id = account_id
+        self.result = result
+        self.deadline = deadline
+        self.attempts = 0
         self.request = None
         self.response = None
 
@@ -1593,12 +1618,94 @@ class BigQmtRpcHandlers:
     def _handle_cancel_order(self, params):
         if self.order_gateway is None:
             raise RuntimeError("order_gateway is not configured")
+        account_id = self._request_account_id(params)
         order_sys_id = str(params.get("order_sys_id") or params.get("order_sysid") or params.get("order_id") or "")
         if not order_sys_id:
             raise ValueError("order_sys_id or order_id is required")
-        return self.order_gateway.cancel(
-            OrderRef(order_sys_id=order_sys_id, user_order_id=str(params.get("user_order_id") or ""))
+        order_ref = OrderRef(
+            order_sys_id=order_sys_id,
+            user_order_id=str(params.get("user_order_id") or ""),
         )
+        result = self.order_gateway.cancel(order_ref)
+
+        # A truthy native return keeps the existing fast path.  A falsey one is
+        # ambiguous on full QMT: issue #148 captured cancel() returning falsey
+        # while the broker accepted the request and status became 54.  Park only
+        # that ambiguous response and let the main-thread order snapshot settle
+        # it; never turn a genuinely filled/rejected/still-active order into a
+        # successful cancel.
+        if getattr(result, "success", None) is False:
+            settlement = CancelSettlement(
+                order_ref,
+                account_id,
+                result,
+                _monotonic() + self.order_settle_timeout_seconds,
+            )
+            if self.settle_orders_inline:
+                try:
+                    import time as _time
+                    _time.sleep(self.order_settle_timeout_seconds)
+                    self._apply_cancel_lookup(settlement, final=True)
+                except Exception:
+                    pass
+            else:
+                self._pending_settlement = settlement
+        return result
+
+    def _apply_cancel_lookup(self, settlement, final=False):
+        """Resolve an ambiguous native cancel return from the order snapshot."""
+        settlement.attempts += 1
+        order_sys_id = str(settlement.order_ref.order_sys_id or "")
+        try:
+            strict_query = getattr(self.order_gateway, "query_orders_strict", None)
+            if callable(strict_query):
+                orders = strict_query(settlement.account_id, "") or []
+            else:
+                orders = self.order_gateway.query_orders(settlement.account_id, "") or []
+        except Exception as exc:
+            if not final:
+                return False
+            settlement.result.success = False
+            settlement.result.message = (
+                "cancel status lookup failed after %d attempt(s): %s: %s"
+                % (settlement.attempts, exc.__class__.__name__, exc)
+            )
+            return True
+
+        matches = [
+            order for order in orders
+            if str(getattr(order, "order_sys_id", "") or "") == order_sys_id
+        ]
+        if not matches:
+            if not final:
+                return False
+            settlement.result.success = False
+            settlement.result.message = (
+                "cancel was not confirmed: order %s was not found after %d lookup(s)"
+                % (order_sys_id, settlement.attempts)
+            )
+            return True
+
+        status = str(getattr(matches[0], "status", "") or "")
+        if status in CANCELED_ORDER_STATUSES:
+            settlement.result.success = True
+            settlement.result.message = ""
+            return True
+        if status in TERMINAL_NON_CANCEL_ORDER_STATUSES:
+            settlement.result.success = False
+            settlement.result.message = (
+                "cancel was not confirmed: order %s reached status %s"
+                % (order_sys_id, status)
+            )
+            return True
+        if not final:
+            return False
+        settlement.result.success = False
+        settlement.result.message = (
+            "cancel was not confirmed after %d lookup(s): order %s is still status %s"
+            % (settlement.attempts, order_sys_id, status or "unknown")
+        )
+        return True
 
 
 def _bool_value(value, default=False):
@@ -1778,9 +1885,9 @@ class RedisPubSubRpcService:
         self._deferred_count = 0
         self.print_prefix = print_prefix
         self.pending = queue.Queue(maxsize=int(max_queue_size))
-        # Orders whose reply is waiting on QMT assigning an order id. Unbounded
-        # on purpose: every entry is an order that already reached the broker,
-        # so dropping one would strand a live order with no reply.
+        # Submit/cancel replies waiting on a main-thread order snapshot.
+        # Unbounded on purpose: every entry represents a live broker operation,
+        # so dropping one would strand it with no reply.
         self._pending_settlements = queue.Queue()
         self._running = threading.Event()
         self._thread = None
@@ -1972,7 +2079,7 @@ class RedisPubSubRpcService:
         return payload
 
     def settle_pending_orders(self, max_items=100):
-        """Retry parked order lookups. MUST be called from the adjust thread.
+        """Retry parked submit/cancel lookups on the adjust thread.
 
         A queue rather than a list because rpc_listener_methods is configurable:
         if submit_order is ever put in it, the producer becomes the listener
@@ -1993,7 +2100,10 @@ class RedisPubSubRpcService:
                 break
             expired = _monotonic() >= settlement.deadline
             try:
-                done = self.handlers._apply_order_lookup(settlement, final=expired)
+                if isinstance(settlement, CancelSettlement):
+                    done = self.handlers._apply_cancel_lookup(settlement, final=expired)
+                else:
+                    done = self.handlers._apply_order_lookup(settlement, final=expired)
             except Exception:
                 done = True  # never strand a submitted order in the queue
             if not done:
@@ -2002,7 +2112,7 @@ class RedisPubSubRpcService:
             response = settlement.response
             response["data"] = to_jsonable(settlement.result)
             response["ok"] = True
-            if settlement.server_error:
+            if getattr(settlement, "server_error", ""):
                 response["server_error"] = settlement.server_error
             response["handled_at"] = _dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             try:
@@ -2094,9 +2204,10 @@ class RedisPubSubRpcService:
             server_error = getattr(self.handlers, "_last_server_error", None)
             if server_error:
                 response["server_error"] = str(server_error)
-            # passorder already ran, but QMT assigns the order id asynchronously.
-            # Park the reply instead of sleeping on this thread; a later adjust
-            # tick settles and publishes it (issue #44).
+            # passorder may still be awaiting its asynchronously assigned id;
+            # a falsey native cancel may still be awaiting a reliable terminal
+            # status (#148). Park either reply instead of sleeping on this
+            # thread; a later adjust tick settles and publishes it (#44).
             take = getattr(self.handlers, "take_pending_settlement", None)
             settlement = take() if callable(take) else None
             if settlement is not None:

--- a/tests/bigqmt_signal_trader/test_redis_rpc.py
+++ b/tests/bigqmt_signal_trader/test_redis_rpc.py
@@ -10,7 +10,13 @@ sys.path.insert(0, os.path.join(ROOT, "src"))
 
 from bigqmt_signal_trader.adapters.market_bigqmt import BigQmtMarketDataProvider
 from bigqmt_signal_trader.adapters.order_dryrun import DryRunOrderGateway
-from bigqmt_signal_trader.models import AssetSnapshot, OrderSnapshot, PositionSnapshot, TradeSnapshot
+from bigqmt_signal_trader.models import (
+    AssetSnapshot,
+    CancelResult,
+    OrderSnapshot,
+    PositionSnapshot,
+    TradeSnapshot,
+)
 from bigqmt_signal_trader.redis_rpc import (
     RPC_REVISION,
     BigQmtRpcHandlers,
@@ -280,6 +286,152 @@ class LateLandingOrderGateway(DryRunOrderGateway):
                 status="50",
             )
         ]
+
+
+class FalseyCancelGateway(DryRunOrderGateway):
+    """Full QMT #148: native cancel is falsey before status confirms success."""
+
+    def __init__(self, statuses, native_success=False, query_error=None):
+        super().__init__()
+        self.statuses = list(statuses)
+        self.native_success = native_success
+        self.query_error = query_error
+        self.lookups = 0
+
+    def cancel(self, order_ref):
+        self.cancelled.append(order_ref)
+        return CancelResult(
+            success=self.native_success,
+            message="" if self.native_success else "cancel returned false",
+        )
+
+    def query_orders(self, account_id, strategy_name):
+        self.lookups += 1
+        if self.query_error is not None:
+            raise self.query_error
+        if not self.statuses:
+            return []
+        status = self.statuses[min(self.lookups - 1, len(self.statuses) - 1)]
+        return [
+            OrderSnapshot(
+                order_sys_id="cancel-1",
+                user_order_id="remark-cancel-1",
+                stock_code="510050.SH",
+                action="BUY",
+                volume=100,
+                traded_volume=0,
+                status=status,
+            )
+        ]
+
+
+class AsyncCancelSettlementTest(unittest.TestCase):
+    """issue #148: order status, not cancel() truthiness, is authoritative."""
+
+    @staticmethod
+    def _service(gateway, timeout=5.0):
+        redis_client = FakeRedis()
+        handlers = BigQmtRpcHandlers(
+            account_id="acct",
+            market_data=FakeMarketData(),
+            position_provider=FakePositionProvider(),
+            order_gateway=gateway,
+            allow_order_methods=True,
+            order_settle_timeout_seconds=timeout,
+        )
+        return redis_client, RedisPubSubRpcService(
+            redis_client, handlers, account_id="acct")
+
+    @staticmethod
+    def _cancel(service, request_id="cancel-request-1"):
+        service.enqueue_payload({
+            "request_id": request_id,
+            "account_id": "acct",
+            "method": "cancel_order_stock_sysid",
+            "params": {"order_sysid": "cancel-1"},
+        })
+
+    def test_falsey_native_return_waits_for_status_54_and_reports_success(self):
+        gateway = FalseyCancelGateway(["50", "54"])
+        redis_client, service = self._service(gateway)
+        self._cancel(service)
+
+        service.drain_pending()
+        self.assertNotIn(
+            "bigqmt:rpc:resp:acct:cancel-request-1", redis_client.kv)
+        self.assertEqual(service.pending_settlement_count(), 1)
+
+        service.drain_pending()
+
+        response = json.loads(
+            redis_client.kv["bigqmt:rpc:resp:acct:cancel-request-1"])
+        self.assertTrue(response["ok"], response["error"])
+        self.assertTrue(response["data"]["success"])
+        self.assertEqual(response["data"]["message"], "")
+        self.assertEqual(gateway.lookups, 2)
+        self.assertEqual(len(gateway.cancelled), 1)
+
+    def test_partial_cancel_status_53_also_reports_success(self):
+        gateway = FalseyCancelGateway(["53"])
+        redis_client, service = self._service(gateway)
+        self._cancel(service)
+
+        service.drain_pending()
+
+        response = json.loads(
+            redis_client.kv["bigqmt:rpc:resp:acct:cancel-request-1"])
+        self.assertTrue(response["data"]["success"])
+
+    def test_terminal_filled_status_does_not_become_cancel_success(self):
+        gateway = FalseyCancelGateway(["56"])
+        redis_client, service = self._service(gateway)
+        self._cancel(service)
+
+        service.drain_pending()
+
+        response = json.loads(
+            redis_client.kv["bigqmt:rpc:resp:acct:cancel-request-1"])
+        self.assertTrue(response["ok"], response["error"])
+        self.assertFalse(response["data"]["success"])
+        self.assertIn("reached status 56", response["data"]["message"])
+
+    def test_active_order_at_deadline_remains_cancel_failure(self):
+        gateway = FalseyCancelGateway(["50"])
+        redis_client, service = self._service(gateway, timeout=0.0)
+        self._cancel(service)
+
+        service.drain_pending()
+
+        response = json.loads(
+            redis_client.kv["bigqmt:rpc:resp:acct:cancel-request-1"])
+        self.assertFalse(response["data"]["success"])
+        self.assertIn("is still status 50", response["data"]["message"])
+
+    def test_lookup_error_at_deadline_remains_cancel_failure(self):
+        gateway = FalseyCancelGateway(
+            ["54"], query_error=RuntimeError("QMT query unavailable"))
+        redis_client, service = self._service(gateway, timeout=0.0)
+        self._cancel(service)
+
+        service.drain_pending()
+
+        response = json.loads(
+            redis_client.kv["bigqmt:rpc:resp:acct:cancel-request-1"])
+        self.assertFalse(response["data"]["success"])
+        self.assertIn("cancel status lookup failed", response["data"]["message"])
+
+    def test_truthy_native_return_keeps_the_immediate_fast_path(self):
+        gateway = FalseyCancelGateway(["50"], native_success=True)
+        redis_client, service = self._service(gateway)
+        self._cancel(service)
+
+        service.drain_pending()
+
+        response = json.loads(
+            redis_client.kv["bigqmt:rpc:resp:acct:cancel-request-1"])
+        self.assertTrue(response["data"]["success"])
+        self.assertEqual(gateway.lookups, 0)
+        self.assertEqual(service.pending_settlement_count(), 0)
 
 
 class AsyncOrderSettlementTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- treat a falsey full-QMT `cancel()` result as ambiguous instead of final
- settle the reply on the QMT adjust thread by querying the exact `order_sys_id`
- report statuses 53/54 as cancellation success; keep 56/57, lookup errors, missing orders, and still-active orders at timeout as failures
- preserve the existing immediate fast path when the native return is truthy

## Why status readback

The live reproduction in #148 showed the native call returning false while the broker acknowledged the request and moved the order from status 50 to 54 within 67 ms. Treating every non-exception call as success would fix that false negative but create false positives. Exact order-status readback keeps both sides conservative.

The settlement reuses the existing asynchronous order-settlement queue so `get_trade_detail_data` remains on the QMT adjust thread. No worker-thread query or blocking sleep is added to the normal RPC path.

## Tests

- `python -m pytest tests/bigqmt_signal_trader/test_redis_rpc.py -q` — 49 passed
- `python -m pytest tests/bigqmt_signal_trader/ -q` — 1139 passed, 3 skipped, 3 subtests passed

Added regression coverage for status 50 -> 54, partial cancel 53, filled 56, active-at-timeout 50, readback errors, and the truthy native fast path.

Fixes #148