### PR TITLE
deploy: one-shot Windows deployment script for the redis bridge

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,67 @@
+# deploy/ — 一键部署包（2核4G Windows 服务器适用）
+
+把整个 `deploy\` 文件夹拷到新服务器，按下面执行。
+
+## 前提（脚本不负责的部分）
+1. 已安装大 QMT 客户端并登录交易
+2. QMT 菜单里点过 **下载 python库**（脚本会检查 `bin.x64\Lib\site-packages\xtquant`）
+3. Python 二选一：
+   - **miniconda/anaconda（推荐，加 `-Conda` 参数）**——已装则直接用；**没装会自动下载
+     Miniconda 官方安装器静默装到 `<WorkDir>\miniconda3`**（官方源国内直连可达；
+     离线机器可提前下载安装器后传 `-MinicondaUrl "C:\temp\Miniconda3-....exe"`）
+   - 或系统 Python ≥ 3.10 在 PATH 上（默认走 venv）
+   - 注意：`-WorkDir` 路径不要含空格（Miniconda 静默安装的限制）
+4. 管理员 PowerShell
+
+## 一键部署
+
+```powershell
+cd <deploy目录>
+powershell -ExecutionPolicy Bypass -File .\deploy_qmt_bridge.ps1 `
+    -QmtDir  "C:\你的券商QMT目录" `
+    -Account "资金账号" `
+    -WorkDir "C:\qmt_bridge" `
+    -Conda `
+    -Proxy   "http://127.0.0.1:7897"        # 没有代理就删掉这行
+```
+
+脚本幂等，可重复跑。**pip / conda 包源 / Miniconda 安装器默认全部走清华镜像**（国内实测 ~2MB/s；
+需要换回官方源时传 `-PipIndex https://pypi.org/simple`，conda/Miniconda 同理见脚本内默认值）。
+做完的事：建客户端环境（`-Conda` 走 miniconda py3.13 前缀环境，否则系统 python venv）并装包 → 拷服务端 4 项进 QMT python 目录 →
+下载/解压 Redis → 注册 Windows 服务（bind 127.0.0.1 + 随机密码 + 192mb 上限）→
+生成服务端/客户端配置 → 放入 `qmt_cli.py`。
+
+**离线服务器**：先在别的机器下载 Redis zip，
+加参数 `-RedisZip "C:\temp\Redis-x64-5.0.14.zip"`（PyPI 下载仍需网络，或提前做好 venv 拷贝过去）。
+
+## 部署后只剩两步人工操作
+1. QMT → 模型交易 → 加载 `<QMT目录>\python\BIGQMT_REDIS_DRYRUN.py` → **运行模式切"实盘"** → 启动
+2. 验证（python 路径按所用路线二选一——`-Conda` 用第一行，系统 python venv 用第二行）：
+   ```powershell
+   & "C:\qmt_bridge\envs\bigqmt\python.exe" "C:\qmt_bridge\client\qmt_cli.py" ping
+   & "C:\qmt_bridge\envs\bigqmt-client\Scripts\python.exe" "C:\qmt_bridge\client\qmt_cli.py" ping
+   ```
+   > PowerShell 里执行带引号的路径必须以 `&` 开头；行尾不要多引号。
+
+## 检查状态（不写任何东西）
+
+```powershell
+powershell -File .\deploy_qmt_bridge.ps1 -QmtDir "..." -Account "..." -WorkDir "..." -CheckOnly
+```
+
+## 2核4G 内存预算
+| 组件 | 占用 |
+|---|---|
+| 大 QMT（登录+行情） | ~1.5G（关掉不用的面板/自选股能省不少） |
+| Redis（已限 192mb noeviction） | ≤200M |
+| Python 策略进程（pandas+aiohttp） | ~400M |
+| 系统剩余 | ~1.5G |
+
+合计约 3.2-3.5G，可用但别再跑其他重负载。Redis 密码在 `<WorkDir>\redis\redis_password.txt`。
+
+## 策略代码（可选）
+加 `-WithStrategy -StrategySrc "C:\path\to\my_code"` 会把策略目录一起拷到 `<WorkDir>\my_code`；
+注意检查 `order_config.json` 里的 `account_num` 与 `-Account` 一致。
+
+## 细节文档
+部署原理、传输层对比、排错见仓库根目录 [README](../README.md) 与 [docs/DEPLOY_QUICKSTART.md](../docs/DEPLOY_QUICKSTART.md)。

--- a/deploy/deploy_qmt_bridge.ps1
+++ b/deploy/deploy_qmt_bridge.ps1
@@ -1,0 +1,269 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  One-shot deployment of the xtquant_big_convert Redis bridge on a fresh Windows box.
+.DESCRIPTION
+  Target: 2C4G Windows server with Big QMT installed and logged in.
+  Idempotent - safe to re-run. Skips completed steps.
+.PARAMETER QmtDir   Big QMT install root, e.g. C:\JianghaiQMT
+.PARAMETER Account  Capital account id (digits), e.g. 8886800503
+.PARAMETER WorkDir  Deployment root (default C:\qmt_bridge)
+.PARAMETER RedisZip Offline redis zip path; skip GitHub download when provided
+.PARAMETER Proxy    HTTP proxy for downloads, e.g. http://127.0.0.1:7897
+#>
+param(
+    [Parameter(Mandatory=$true)][string]$QmtDir,
+    [Parameter(Mandatory=$true)][string]$Account,
+    [string]$WorkDir = "C:\qmt_bridge",
+    [string]$RedisZip = "",
+    [string]$Proxy = "",
+    [switch]$CheckOnly,
+    [switch]$Conda,
+    [string]$MinicondaUrl = "",
+    [string]$PipIndex = "https://pypi.tuna.tsinghua.edu.cn/simple",
+    [switch]$WithStrategy,
+    [string]$StrategySrc = ""
+)
+$ErrorActionPreference = "Stop"
+
+function Step($m) { Write-Host ""
+  Write-Host ("== " + $m) -ForegroundColor Cyan }
+function Ok($m)   { Write-Host ("   [ok] " + $m) -ForegroundColor Green }
+function Info($m) { Write-Host ("   .. " + $m) }
+
+# ---- 0. preconditions -----------------------------------------------------
+Step "0/7 preconditions"
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+           ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin -and -not $CheckOnly) { throw "Please run from an elevated (Administrator) PowerShell." }
+if ($CheckOnly) {
+    Info "check-only mode: reporting state, no writes"
+    $items = [ordered]@{
+        "QMT dir"            = Test-Path "$QmtDir\bin.x64\XtItClient.exe"
+        "xtquant lib"        = Test-Path "$QmtDir\bin.x64\Lib\site-packages\xtquant"
+        "server files"       = Test-Path "$QmtDir\python\BIGQMT_REDIS_DRYRUN.py"
+        "server local config"= Test-Path "$QmtDir\python\bigqmt_signal_trader_local_config.py"
+        "client env"         = ((Test-Path "$WorkDir\envs\bigqmt-client\Scripts\python.exe") -or (Test-Path "$WorkDir\envs\bigqmt\python.exe"))
+        "redis binaries"     = Test-Path "$WorkDir\redis\Redis-x64-5.0.14\redis-server.exe"
+        "redis password file"= Test-Path "$WorkDir\redis\redis_password.txt"
+        "redis service"      = [bool](Get-Service RedisBigQMT -ErrorAction SilentlyContinue)
+        "client config"      = Test-Path "$WorkDir\client\bigqmt_signal_trader_client_config.py"
+        "qmt_cli"            = Test-Path "$WorkDir\client\qmt_cli.py"
+    }
+    $missing = 0
+    foreach ($k in $items.Keys) {
+        $mark = if ($items[$k]) { "[ok]     " } else { "[missing]"; $missing++ }
+        Write-Host ("   $mark $k")
+    }
+    if ($missing -gt 0) { Write-Host "   $missing item(s) missing -> run without -CheckOnly (as Administrator)" }
+    else { Write-Host "   deployment complete" }
+    return
+}
+if (-not (Test-Path "$QmtDir\bin.x64\XtItClient.exe")) { throw "Big QMT not found under $QmtDir" }
+if (-not (Test-Path "$QmtDir\bin.x64\Lib\site-packages\xtquant")) {
+    throw "xtquant library missing. Open QMT and run its 'download python libraries' first."
+}
+$pyExe = (Get-Command python -ErrorAction SilentlyContinue).Source
+if (-not $pyExe -and -not $Conda) { throw "System Python not found on PATH (>= 3.10), or pass -Conda to use miniconda." }
+Ok "QMT found; xtquant present; python: $pyExe"
+
+# ---- 1. client environment (conda py313 or venv) --------------------------
+Step "1/7 client env (xtquant-big-convert + pandas)"
+if ($Conda) {
+    $condaExe = (Get-Command conda -ErrorAction SilentlyContinue).Source
+    if (-not $condaExe) {
+        foreach ($cand in @("$env:USERPROFILE\miniconda3\Scripts\conda.exe",
+                            "$env:USERPROFILE\anaconda3\Scripts\conda.exe",
+                            "C:\ProgramData\miniconda3\Scripts\conda.exe")) {
+            if (Test-Path $cand) { $condaExe = $cand; break }
+        }
+    }
+    if (-not $condaExe) {
+        Info "conda not found - auto-installing Miniconda into $WorkDir\miniconda3"
+        $condaHome = "$WorkDir\miniconda3".TrimEnd("\\")
+        if ($condaHome.Contains(" ")) { throw "WorkDir path contains spaces; Miniconda silent install cannot handle it - choose a space-free -WorkDir." }
+        $condaExe  = "$condaHome\Scripts\conda.exe"
+        $installer = "$WorkDir\Miniconda3-latest-Windows-x86_64.exe"
+        if (-not (Test-Path $installer)) {
+            $url = if ($MinicondaUrl) { $MinicondaUrl } else { "https://mirrors.tuna.tsinghua.edu.cn/anaconda/miniconda/Miniconda3-latest-Windows-x86_64.exe" }
+            $dlArgs = @("-L","--max-time","900","-o",$installer,$url)
+            if ($Proxy) { $dlArgs = @("-x",$Proxy) + $dlArgs }
+            & curl.exe @dlArgs
+            if ($LASTEXITCODE -ne 0) { throw "miniconda download failed (offline? pre-download and pass -MinicondaUrl <local exe path>)" }
+        }
+        # silent install; /D= must be the LAST argument, unquoted, no trailing backslash
+        Start-Process -FilePath $installer -ArgumentList "/InstallationType=JustMe","/AddToPath=0","/RegisterPython=0","/S","/D=$condaHome" -Wait
+        if (-not (Test-Path $condaExe)) { throw "miniconda silent install failed - $condaExe missing" }
+        Ok "miniconda installed: $condaHome"
+    }
+    $venv = "$WorkDir\envs\bigqmt"
+    $vpy  = "$venv\python.exe"
+    if (-not (Test-Path $vpy)) {
+        New-Item -ItemType Directory -Force "$WorkDir\envs" | Out-Null
+        if ($Proxy) { $env:HTTP_PROXY = $Proxy; $env:HTTPS_PROXY = $Proxy }
+        # conda >= 25 requires accepting defaults-channel ToS before
+        # non-interactive use; older builds lack the subcommand (ignore errors).
+        foreach ($ch in @("https://repo.anaconda.com/pkgs/main",
+                          "https://repo.anaconda.com/pkgs/r",
+                          "https://repo.anaconda.com/pkgs/msys2")) {
+            & $condaExe tos accept --override-channels --channel $ch *> $null
+        }
+        & $condaExe create -y -p $venv -c https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/main --override-channels python=3.13
+        if ($LASTEXITCODE -ne 0) { throw "conda create failed" }
+    }
+    Ok "conda env: $venv (python 3.13)"
+} else {
+    $venv = "$WorkDir\envs\bigqmt-client"
+    $vpy  = "$venv\Scripts\python.exe"
+    if (-not (Test-Path $vpy)) {
+        New-Item -ItemType Directory -Force "$WorkDir\envs" | Out-Null
+        & $pyExe -m venv $venv
+        if ($LASTEXITCODE -ne 0) { throw "venv creation failed" }
+    }
+}
+& $vpy -m pip --version *> $null
+if ($LASTEXITCODE -ne 0) { & $vpy -m ensurepip --upgrade }
+$pkgList = & $vpy -m pip list 2>$null | Out-String
+$pipArgs = @("-m","pip","install","-i",$PipIndex,"--upgrade","pip")
+if ($Proxy) { $pipArgs += @("--proxy",$Proxy) }
+& $vpy @pipArgs *> $null
+if ($pkgList -notmatch "xtquant-big-convert") {
+    & $vpy -m pip install $(if ($Proxy) { @("--proxy",$Proxy) } else { @() }) -i $PipIndex "xtquant-big-convert[redis]" pandas
+    if ($LASTEXITCODE -ne 0) { throw "pip install failed (check network/proxy)" }
+}
+Ok "venv ready: $vpy"
+
+# ---- 2. server files into QMT python dir ----------------------------------
+Step "2/7 copy bridge server files into QMT python dir"
+$src = (& $vpy -c "import bigqmt_signal_trader_strategy as m, os; print(os.path.dirname(m.__file__))").Trim()
+$dst = "$QmtDir\python"
+foreach ($item in @("bigqmt_signal_trader","bigqmt_signal_trader_strategy.py",
+                    "bigqmt_signal_trader_redis_rpc_runtime.py","BIGQMT_REDIS_DRYRUN.py")) {
+    Copy-Item (Join-Path $src $item) (Join-Path $dst $item) -Recurse -Force
+}
+Ok "copied to $dst"
+
+# ---- 3. redis download / unzip --------------------------------------------
+Step "3/7 redis 5.0.14"
+$rdir = "$WorkDir\redis"
+$zip  = "$rdir\Redis-x64-5.0.14.zip"
+if (-not $RedisZip) { $RedisZip = $zip }
+if (-not (Test-Path $RedisZip)) {
+    New-Item -ItemType Directory -Force $rdir | Out-Null
+    $dlArgs = @("-L","--max-time","600","-o",$RedisZip,
+      "https://github.com/tporadowski/redis/releases/download/v5.0.14/Redis-x64-5.0.14.zip")
+    if ($Proxy) { $dlArgs = @("-x",$Proxy) + $dlArgs }
+    & curl.exe @dlArgs
+    if ($LASTEXITCODE -ne 0) { throw "redis download failed (offline? pass -RedisZip <path>)" }
+}
+if (-not (Test-Path "$rdir\Redis-x64-5.0.14\redis-server.exe")) {
+    Expand-Archive $RedisZip "$rdir\Redis-x64-5.0.14" -Force
+}
+Ok "redis binaries: $rdir\Redis-x64-5.0.14"
+
+# ---- 4. redis password / conf / service -----------------------------------
+Step "4/7 redis service (bind 127.0.0.1 + password + 192mb cap)"
+$pwFile = "$rdir\redis_password.txt"
+if (Test-Path $pwFile) { $pw = (Get-Content $pwFile -Raw).Trim() }
+else {
+    $pw = -join ((48..57)+(97..122) | Get-Random -Count 20 | ForEach-Object {[char]$_})
+    Set-Content $pwFile $pw -NoNewline -Encoding ASCII
+}
+$conf = "$rdir\Redis-x64-5.0.14\redis.windows-service.conf"
+$marker = "# === bigqmt bridge additions ==="
+if (-not (Select-String -Path $conf -SimpleMatch -Pattern $marker -Quiet)) {
+    Add-Content $conf "`r`n$marker`r`nbind 127.0.0.1`r`nrequirepass $pw`r`nmaxmemory 192mb`r`nmaxmemory-policy noeviction"
+}
+$svc = Get-Service RedisBigQMT -ErrorAction SilentlyContinue
+if (-not $svc) {
+    & "$rdir\Redis-x64-5.0.14\redis-server.exe" --service-install $conf --service-name RedisBigQMT
+    if ($LASTEXITCODE -ne 0) { throw "redis service-install failed" }
+}
+$svc = Get-Service RedisBigQMT
+if ($svc.Status -ne "Running") { Start-Service RedisBigQMT }
+Ok ("redis service: " + (Get-Service RedisBigQMT).Status)
+
+# ---- 5. server-side config -------------------------------------------------
+Step "5/7 write server-side local config"
+$localCfg = @"
+# coding: utf-8
+BIGQMT_ACCOUNT_ID = "$Account"
+BIGQMT_ACCOUNT_TYPE = "STOCK"
+
+BIGQMT_REDIS_CONFIG = {
+    "host": "127.0.0.1",
+    "port": 6379,
+    "db": 5,
+    "username": "",
+    "password": "$pw",
+    "rpc_allow_order_methods": True,
+    "rpc_process_in_listener": True,
+    "rpc_listener_methods": ("*",),
+    "rpc_background_threads": False,
+    "schedule_adjust": True,
+    "schedule_adjust_interval": "100nMilliSecond",
+    "full_tick_cache_enabled": False,
+    "download_jobs_enabled": False,
+    "exec_events_enabled": True,
+    "exec_events_debug_raw_fields": False,
+}
+"@
+Set-Content "$dst\bigqmt_signal_trader_local_config.py" $localCfg -Encoding UTF8
+Ok "$dst\bigqmt_signal_trader_local_config.py"
+
+# ---- 6. client config + CLI ------------------------------------------------
+Step "6/7 client config + CLI"
+$cdir = "$WorkDir\client"
+New-Item -ItemType Directory -Force $cdir | Out-Null
+$cliSrc = Join-Path $PSScriptRoot "qmt_cli.py"
+if (-not (Test-Path $cliSrc)) { throw "qmt_cli.py must sit next to this script (deploy bundle)." }
+Copy-Item $cliSrc "$cdir\qmt_cli.py" -Force
+$clientCfg = @"
+# coding: utf-8
+BIGQMT_ACCOUNT_ID = "$Account"
+BIGQMT_RPC_TIMEOUT_SECONDS = 30.0
+
+BIGQMT_REDIS_CONFIG = {
+    "host": "127.0.0.1",
+    "port": 6379,
+    "db": 5,
+    "username": "",
+    "password": "$pw",
+    "transport": "redis",
+    "protocol": 2,
+}
+
+BIGQMT_FULL_TICK_CACHE_CONFIG = {"enabled": False}
+BIGQMT_FORMULA_SERVER_CONFIG = {"enabled": False}
+BIGQMT_LOCAL_CACHE_CONFIG = {
+    "enabled": True,
+    "dir": r"$cdir\.bigqmt_cache",
+    "fallback_rpc": False,
+    "format": "auto",
+}
+"@
+Set-Content "$cdir\bigqmt_signal_trader_client_config.py" $clientCfg -Encoding UTF8
+Ok "client config + qmt_cli.py in $cdir"
+
+# ---- 7. optional: strategy folder -----------------------------------------
+if ($WithStrategy) {
+    Step "7/7 strategy folder"
+    if (-not $StrategySrc -or -not (Test-Path $StrategySrc)) { throw "-WithStrategy needs -StrategySrc <dir>" }
+    Copy-Item "$StrategySrc\*" "$WorkDir\my_code" -Recurse -Force
+    Ok "strategy copied to $WorkDir\my_code (check order_config.json account_num)"
+}
+
+# ---- done: manual steps ----------------------------------------------------
+Write-Host ""
+Write-Host "================ DEPLOYMENT DONE - manual steps left ================" -ForegroundColor Yellow
+Write-Host @"
+1. In QMT: model trading -> add strategy -> load
+   $dst\BIGQMT_REDIS_DRYRUN.py
+   set run mode to LIVE (实盘), start it.
+   Output panel must show: [bigqmt_rpc] started channel=bigqmt:rpc:req:$Account
+2. Verify from outside:
+   & "$vpy" "$cdir\qmt_cli.py" ping
+   & "$vpy" "$cdir\qmt_cli.py" asset
+3. redis password saved at: $pwFile
+4. Memory budget on 2C4G: QMT ~1.5G + redis <=192M + python ~400M. Close QMT panels you do not use.
+"@ -ForegroundColor Yellow

--- a/deploy/qmt_cli.py
+++ b/deploy/qmt_cli.py
@@ -1,0 +1,343 @@
+# coding: utf-8
+"""Big QMT redis-bridge CLI client (Jianghai Securities deployment).
+
+External-python entry point for querying assets/positions/orders/trades and
+market data through the xtquant_big_convert RPC bridge, plus order submit and
+cancel. Usage examples:
+
+    python qmt_cli.py discover
+    python qmt_cli.py ping
+    python qmt_cli.py asset
+    python qmt_cli.py positions
+    python qmt_cli.py orders
+    python qmt_cli.py trades
+    python qmt_cli.py tick 000001.SZ 600519.SH
+    python qmt_cli.py kline 000001.SZ --period 1d --count 5
+    python qmt_cli.py buy 000001.SZ 100 10.50
+    python qmt_cli.py sell 000001.SZ 100 11.00
+    python qmt_cli.py cancel 1234
+    python qmt_cli.py watch
+
+The account id is read from bigqmt_client_config.BIGQMT_ACCOUNT_ID, or from
+--account / BIGQMT_ACCOUNT_ID env var. `discover` scans Redis for the account
+id the QMT-side strategy registered.
+"""
+import argparse
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import bigqmt_signal_trader_client_config as cfg  # noqa: E402
+
+from bigqmt_signal_trader.xtquant_compat import (  # noqa: E402
+    BigQmtRpcClient,
+    BigQmtXtTrader,
+    BigQmtXtData,
+)
+from xtquant import xtconstant  # noqa: E402
+from xtquant.xttype import StockAccount  # noqa: E402
+import redis  # noqa: E402
+
+
+def account_id(args):
+    value = (
+        getattr(args, "account", "")
+        or os.environ.get("BIGQMT_ACCOUNT_ID", "")
+        or getattr(cfg, "BIGQMT_ACCOUNT_ID", "")
+    )
+    value = str(value or "").strip()
+    if not value:
+        sys.exit(
+            "account id is empty: run `qmt_cli.py discover` first, then set "
+            "BIGQMT_ACCOUNT_ID in bigqmt_client_config.py"
+        )
+    return value
+
+
+def redis_kwargs():
+    return dict(cfg.BIGQMT_REDIS_CONFIG)
+
+
+def raw_redis():
+    kw = redis_kwargs()
+    kw.pop("transport", None)
+    kw.pop("zmq", None)
+    username = kw.get("username") or None
+    kw["username"] = username
+    return redis.Redis(**kw)
+
+
+def make_trader(acc_id):
+    return BigQmtXtTrader(
+        account_id=acc_id,
+        redis_config=redis_kwargs(),
+        timeout_seconds=getattr(cfg, "BIGQMT_RPC_TIMEOUT_SECONDS", 30.0),
+    )
+
+
+def make_data(acc_id):
+    client = BigQmtRpcClient(
+        account_id=acc_id,
+        redis_config=redis_kwargs(),
+        timeout_seconds=getattr(cfg, "BIGQMT_RPC_TIMEOUT_SECONDS", 30.0),
+    )
+    return BigQmtXtData(client)
+
+
+def as_stock_account(acc_id):
+    account_type = str(getattr(cfg, "BIGQMT_ACCOUNT_TYPE", "STOCK") or "STOCK")
+    return StockAccount(acc_id, account_type)
+
+
+def fmt_row(obj, fields):
+    out = {}
+    for name in fields:
+        value = getattr(obj, name, None)
+        if isinstance(value, float):
+            value = round(value, 4)
+        out[name] = value
+    return out
+
+
+def cmd_discover(args):
+    r = raw_redis()
+    keys = [k.decode() if isinstance(k, bytes) else k for k in r.keys("bigqmt:*")]
+    if not keys:
+        print("no bigqmt:* keys in redis db=%s -- is the QMT strategy running?" % r.connection_pool.connection_kwargs.get("db"))
+        return
+    accounts = set()
+    for key in keys:
+        for prefix in ("bigqmt:positions:", "bigqmt:rpc:req:", "bigqmt:order_events:", "bigqmt:trade_events:"):
+            if key.startswith(prefix):
+                accounts.add(key[len(prefix):])
+    print("redis keys:")
+    for key in sorted(keys):
+        print("  ", key)
+    print("discovered accounts:", sorted(accounts) or "(none yet)")
+
+
+def cmd_ping(args):
+    acc_id = account_id(args)
+    trader = make_trader(acc_id)
+    started = time.time()
+    pong = trader.client.call("ping")
+    elapsed_ms = (time.time() - started) * 1000.0
+    print("ping OK in %.1f ms" % elapsed_ms)
+    print(json.dumps(pong, ensure_ascii=False, indent=2, default=str))
+
+
+def cmd_asset(args):
+    acc_id = account_id(args)
+    trader = make_trader(acc_id)
+    asset = trader.query_stock_asset(as_stock_account(acc_id))
+    if asset is None:
+        print("query_stock_asset returned None")
+        return
+    print(json.dumps(fmt_row(asset, [
+        "account_id", "account_type", "cash", "frozen_cash",
+        "market_value", "total_asset",
+    ]), ensure_ascii=False, indent=2, default=str))
+
+
+def cmd_positions(args):
+    acc_id = account_id(args)
+    trader = make_trader(acc_id)
+    positions = trader.query_stock_positions(as_stock_account(acc_id)) or []
+    print("positions: %d" % len(positions))
+    for pos in positions:
+        print(json.dumps(fmt_row(pos, [
+            "stock_code", "volume", "can_use_volume", "open_price",
+            "market_value", "on_road_volume", "yesterday_volume",
+        ]), ensure_ascii=False, default=str))
+
+
+def cmd_orders(args):
+    acc_id = account_id(args)
+    trader = make_trader(acc_id)
+    orders = trader.query_stock_orders(
+        as_stock_account(acc_id), cancelable_only=args.cancelable
+    ) or []
+    print("orders: %d" % len(orders))
+    for order in orders:
+        print(json.dumps(fmt_row(order, [
+            "order_id", "stock_code", "order_type", "order_volume",
+            "price", "traded_volume", "order_status", "strategy_name",
+            "order_time", "order_remark",
+        ]), ensure_ascii=False, default=str))
+
+
+def cmd_trades(args):
+    acc_id = account_id(args)
+    trader = make_trader(acc_id)
+    trades = trader.query_stock_trades(as_stock_account(acc_id)) or []
+    print("trades: %d" % len(trades))
+    for trade in trades:
+        print(json.dumps(fmt_row(trade, [
+            "stock_code", "order_type", "traded_volume", "traded_price",
+            "traded_amount", "traded_time", "order_id",
+        ]), ensure_ascii=False, default=str))
+
+
+def cmd_tick(args):
+    acc_id = account_id(args)
+    data = make_data(acc_id)
+    ticks = data.get_full_tick(args.codes) or {}
+    for code in args.codes:
+        tick = ticks.get(code)
+        if not tick:
+            print("%s: no data" % code)
+            continue
+        print(json.dumps({
+            "code": code,
+            "lastPrice": tick.get("lastPrice"),
+            "time": tick.get("time"),
+            "bidPrice": tick.get("bidPrice"),
+            "askPrice": tick.get("askPrice"),
+            "pvolume": tick.get("pvolume"),
+        }, ensure_ascii=False, default=str))
+
+
+def cmd_kline(args):
+    acc_id = account_id(args)
+    data = make_data(acc_id)
+    result = data.get_market_data_ex(
+        ["open", "high", "low", "close", "volume", "amount"],
+        [args.code], period=args.period, count=args.count,
+        dividend_type="none", fill_data=False,
+    ) or {}
+    df = result.get(args.code)
+    if df is None or len(df) == 0:
+        print("no kline for %s (not downloaded in QMT local data?)" % args.code)
+        return
+    print(df.to_string())
+
+
+def cmd_order(args, order_type):
+    acc_id = account_id(args)
+    trader = make_trader(acc_id)
+    account = as_stock_account(acc_id)
+    if trader.connect() != 0:
+        sys.exit("connect failed")
+    price_type = xtconstant.FIX_PRICE if args.price > 0 else xtconstant.LATEST_PRICE
+    order_id = trader.order_stock(
+        account, args.code, order_type, args.volume, price_type,
+        args.price, "bigqmt_cli", args.remark or "cli-order",
+    )
+    if isinstance(order_id, int) and order_id == -1:
+        sys.exit("order rejected (order_stock returned -1)")
+    print("order submitted, order_id=%s" % order_id)
+
+
+def cmd_cancel(args):
+    acc_id = account_id(args)
+    trader = make_trader(acc_id)
+    account = as_stock_account(acc_id)
+    result = trader.cancel_order_stock(account, args.order_id)
+    print("cancel_order_stock -> %s (0 = success, -1 = failure)" % result)
+
+
+class _Printer:
+    def on_disconnected(self):
+        print("[event] disconnected")
+
+    def on_stock_order(self, order):
+        print("[order] %s" % json.dumps(fmt_row(order, [
+            "order_id", "stock_code", "order_type", "order_volume",
+            "price", "traded_volume", "order_status",
+        ]), ensure_ascii=False, default=str))
+
+    def on_stock_trade(self, trade):
+        print("[trade] %s" % json.dumps(fmt_row(trade, [
+            "stock_code", "order_type", "traded_volume", "traded_price",
+        ]), ensure_ascii=False, default=str))
+
+    def on_order_error(self, error):
+        print("[order_error] %s" % json.dumps(fmt_row(error, [
+            "order_id", "error_id", "error_msg",
+        ]), ensure_ascii=False, default=str))
+
+    def on_cancel_error(self, error):
+        print("[cancel_error] %s" % json.dumps(fmt_row(error, [
+            "order_id", "error_id", "error_msg",
+        ]), ensure_ascii=False, default=str))
+
+    def on_order_stock_async_response(self, response):
+        print("[async_response] %s" % json.dumps(fmt_row(response, [
+            "seq", "order_id",
+        ]), ensure_ascii=False, default=str))
+
+    def on_account_status(self, status):
+        print("[account_status] %s" % json.dumps(fmt_row(status, [
+            "account_id", "account_type", "status",
+        ]), ensure_ascii=False, default=str))
+
+
+def cmd_watch(args):
+    acc_id = account_id(args)
+    trader = make_trader(acc_id)
+    account = as_stock_account(acc_id)
+    trader.register_callback(_Printer())
+    trader.start()
+    if trader.connect() != 0:
+        sys.exit("connect failed")
+    trader.subscribe(account)
+    print("watching exec events for %s ... Ctrl+C to stop" % acc_id)
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("\nstopped.")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Big QMT redis-bridge CLI")
+    parser.add_argument("--account", default="", help="override account id")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("discover", help="scan redis for registered accounts")
+    sub.add_parser("ping", help="rpc ping")
+    sub.add_parser("asset", help="query account asset")
+    sub.add_parser("positions", help="query positions")
+    p_orders = sub.add_parser("orders", help="query orders")
+    p_orders.add_argument("--cancelable", action="store_true")
+    sub.add_parser("trades", help="query trades")
+    p_tick = sub.add_parser("tick", help="full tick snapshot")
+    p_tick.add_argument("codes", nargs="+")
+    p_kline = sub.add_parser("kline", help="kline from QMT local data")
+    p_kline.add_argument("code")
+    p_kline.add_argument("--period", default="1d")
+    p_kline.add_argument("--count", type=int, default=10)
+    for name, order_type in (("buy", xtconstant.STOCK_BUY), ("sell", xtconstant.STOCK_SELL)):
+        p = sub.add_parser(name, help="submit a %s order" % name)
+        p.add_argument("code")
+        p.add_argument("volume", type=int)
+        p.add_argument("price", type=float, help="0 = latest-price (market) order")
+        p.add_argument("--remark", default="")
+        p.set_defaults(order_type=order_type)
+    p_cancel = sub.add_parser("cancel", help="cancel an order")
+    p_cancel.add_argument("order_id")
+    sub.add_parser("watch", help="watch order/trade callbacks")
+
+    args = parser.parse_args(argv)
+    handlers = {
+        "discover": cmd_discover,
+        "ping": cmd_ping,
+        "asset": cmd_asset,
+        "positions": cmd_positions,
+        "orders": cmd_orders,
+        "trades": cmd_trades,
+        "tick": cmd_tick,
+        "kline": cmd_kline,
+        "buy": lambda a: cmd_order(a, a.order_type),
+        "sell": lambda a: cmd_order(a, a.order_type),
+        "cancel": cmd_cancel,
+        "watch": cmd_watch,
+    }
+    handlers[args.command](args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds `deploy/`: a one-shot Windows deployment bundle for the redis bridge.

- `deploy_qmt_bridge.ps1` bootstraps a fresh Windows box end to end:
  - client env via **miniconda py3.13 prefix env** (`-Conda`; auto-installs Miniconda, accepts channel ToS automatically) or system-python venv
  - pip/conda/Miniconda downloads default to tsinghua mirrors (override via `-PipIndex` / `-MinicondaUrl`)
  - copies the bridge server files into the QMT python dir
  - installs **redis 5.0.14 as a Windows service** (127.0.0.1 bind, generated password, 192mb noeviction cap)
  - writes both side configs (incl. `rpc_allow_order_methods`, `protocol: 2` for redis-py>=5 against redis 5.0)
- `qmt_cli.py`: ping / asset / positions / orders / trades / tick / kline / buy / sell / cancel / watch / discover over the bridge
- idempotent; `-CheckOnly` gives a no-write state report

## Verified live

Jianghai Securities big-QMT on a 2C4G Windows server, bridge 0.3.16:
ping (~100ms), asset / positions / orders / trades queries, five-level tick,
and a real submit+cancel round trip (order status 50) with exec events on the
`bigqmt:order_events:{account}` stream.

## Notes

- Broker builds where account auto-detection fails (context_info lacks
  account attributes) need an explicit `BIGQMT_ACCOUNT_ID`; documented in the
  deploy README with two ways to recover the id.
- conda>=25 rejects non-interactive `create` until channel ToS is accepted;
  handled automatically (older conda silently ignores the subcommand).
