### PR TITLE
contracts: keep Protocol import working on py3.6 without typing_extensions

### DIFF
--- a/src/bigqmt_signal_trader/contracts.py
+++ b/src/bigqmt_signal_trader/contracts.py
@@ -6,7 +6,14 @@ from typing import Dict, List
 try:
     from typing import Protocol
 except ImportError:  # pragma: no cover
-    from typing_extensions import Protocol
+    try:
+        from typing_extensions import Protocol
+    except ImportError:
+        # Very old embedded environments (QMT built-in Python 3.6 without
+        # typing_extensions): Protocol is only used for structural typing
+        # documentation here, so a plain stand-in keeps imports working.
+        class Protocol(object):
+            pass
 
 from .models import (
     AccountSnapshot,


### PR DESCRIPTION
## What

`contracts.py` falls back to `typing_extensions.Protocol` when `typing.Protocol` is missing. QMT terminals ship embedded Python 3.6 (e.g. the Jianghai Securities build, python36.dll) **without typing_extensions**, so importing this module would raise ImportError there.

This adds a plain stand-in as the last fallback, keeping imports working on legacy terminals.

## Why it is latent

Nothing in the package imports `contracts.py` today, so nothing breaks right now. But every file in `src/` already passes `ast.parse(feature_version=(3,6))` (verified: 72 files, zero failures), and the redis bridge server is confirmed working on the embedded 3.6 in production (bridge 0.3.16: ping, queries, live submit+cancel, exec events) -- so it would be nice to keep the 3.6 story fully intact and maybe document it, rather than let a single typing import quietly break it.
