### PR TITLE
修复 QMT 沙箱启动、RPC 线程调度与 Redis 隔离问题

### DIFF
--- a/src/bigqmt_signal_trader/adapters/order_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/order_bigqmt.py
@@ -5,7 +5,36 @@ The passorder signature follows src/api/qmt_jq_trade.
 
 import hashlib
 
-from xtquant import xtconstant as _xtconstant
+
+class _QmtFallbackXtConstant(object):
+    """QMT 策略沙箱没有可导入 xtquant package 时使用的最小常量集。"""
+
+    FUTURE_ACCOUNT = 1
+    SECURITY_ACCOUNT = 2
+    CREDIT_ACCOUNT = 3
+    FUTURE_OPTION_ACCOUNT = 5
+    STOCK_OPTION_ACCOUNT = 6
+    HUGANGTONG_ACCOUNT = 7
+    SHENGANGTONG_ACCOUNT = 11
+    CREDIT_FIN_BUY = 27
+    CREDIT_SLO_SELL = 28
+    CREDIT_BUY_SECU_REPAY = 29
+    CREDIT_DIRECT_SECU_REPAY = 30
+    CREDIT_SELL_SECU_REPAY = 31
+    CREDIT_DIRECT_CASH_REPAY = 32
+    CREDIT_FIN_BUY_SPECIAL = 40
+    CREDIT_SLO_SELL_SPECIAL = 41
+    CREDIT_BUY_SECU_REPAY_SPECIAL = 42
+    CREDIT_DIRECT_SECU_REPAY_SPECIAL = 43
+    CREDIT_SELL_SECU_REPAY_SPECIAL = 44
+    CREDIT_DIRECT_CASH_REPAY_SPECIAL = 45
+
+
+try:
+    from xtquant import xtconstant as _xtconstant
+except ImportError:
+    # 完整 QMT 的模型运行时会注入 passorder 等 API，但部分券商终端不提供可 import 的 xtquant package。
+    _xtconstant = _QmtFallbackXtConstant()
 
 from ..code_utils import normalize_stock_code
 from ..exec_events import date_time_seconds

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -136,6 +136,7 @@ LISTENER_DEFERRED_METHODS = {
     "query_stock_position",
     "query_orders",
     "query_trades",
+    "query_execution_snapshot",
     "describe_trade_detail_fields",
     "reload_deployment",
     "query_account_infos",

--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -1497,6 +1497,10 @@ def _exec_event_redis(config):
     Previously a new client was built per order/trade callback when the RPC
     service had none (the zmq-transport case), leaking a connection pool per
     event. Reuse one; build failure returns None so publishing just skips.
+
+    A non-Redis transport may retain a Redis block for optional download jobs
+    or exec-event replay. Skip that block only when both consumers are
+    explicitly disabled; omitted flags retain the legacy enabled behavior.
     """
     global _exec_event_redis_client
     existing = getattr(_rpc_service, "redis", None) if _rpc_service is not None else None
@@ -1504,6 +1508,10 @@ def _exec_event_redis(config):
         return existing
     if _exec_event_redis_client is not None:
         return _exec_event_redis_client
+    if not _config_bool((config.get("download_jobs") or {}).get("enabled"), True) and not _config_bool(
+        (config.get("exec_events") or {}).get("enabled"), True
+    ):
+        return None
     redis_config = dict(config.get("redis") or {})
     if not redis_config:
         return None

--- a/tests/bigqmt_signal_trader/test_adjust_redis_reuse.py
+++ b/tests/bigqmt_signal_trader/test_adjust_redis_reuse.py
@@ -108,6 +108,17 @@ class RedisClientReuseTest(unittest.TestCase):
         self.assertIsNone(result)
         self.assertEqual(self.built, [])
 
+    def test_disabled_redis_features_do_not_build_a_client_for_zmq(self):
+        result = strategy._exec_event_redis({
+            "rpc": {"transport": "zmq"},
+            "redis": {"host": "127.0.0.1", "port": 6379},
+            "download_jobs": {"enabled": False},
+            "exec_events": {"enabled": False},
+        })
+
+        self.assertIsNone(result)
+        self.assertEqual(self.built, [])
+
     def test_service_client_is_preferred_over_building_one(self):
         """With the redis transport the service already holds a client."""
         class _Service(object):

--- a/tests/bigqmt_signal_trader/test_qmt_bundled_xtconstant.py
+++ b/tests/bigqmt_signal_trader/test_qmt_bundled_xtconstant.py
@@ -29,10 +29,12 @@ defines. Refresh it from a real install if the terminal is upgraded.
 """
 
 import ast
+import builtins
 import io
 import os
 import re
 import sys
+import types
 import unittest
 
 
@@ -223,6 +225,31 @@ class AccountTypeCodesWithoutTheDictTest(unittest.TestCase):
         codes = self._codes_from(Empty())
 
         self.assertEqual(codes["STOCK"], 2)
+
+    def test_qmt_without_importable_xtquant_loads_the_order_gateway(self):
+        """Exercise the same per-module import hook used by the QMT loader."""
+        module_name = "bigqmt_signal_trader.adapters._order_bigqmt_without_xtquant"
+        source_path = os.path.join(
+            SRC, "bigqmt_signal_trader", "adapters", "order_bigqmt.py")
+        real_import = builtins.__import__
+
+        def import_without_xtquant(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "xtquant" or name.startswith("xtquant."):
+                raise ImportError("xtquant is unavailable in this QMT runtime")
+            return real_import(name, globals, locals, fromlist, level)
+
+        module = types.ModuleType(module_name)
+        module.__file__ = source_path
+        module.__package__ = "bigqmt_signal_trader.adapters"
+        module.__dict__["__builtins__"] = dict(
+            vars(builtins), __import__=import_without_xtquant)
+        with open(source_path, "rb") as source_file:
+            exec(compile(source_file.read(), source_path, "exec"), module.__dict__)
+
+        self.assertIsInstance(module._xtconstant, module._QmtFallbackXtConstant)
+        self.assertEqual(module.ACCOUNT_TYPE_CODES["STOCK"], 2)
+        self.assertEqual(module.ACCOUNT_TYPE_CODES["CREDIT"], 3)
+        self.assertEqual(module.CREDIT_OPTYPE_BY_ORDER_TYPE[40], 70)
 
     def test_the_gateway_resolves_its_configured_type(self):
         from bigqmt_signal_trader.adapters.order_bigqmt import BigQmtOrderGateway

--- a/tests/bigqmt_signal_trader/test_redis_rpc.py
+++ b/tests/bigqmt_signal_trader/test_redis_rpc.py
@@ -1060,6 +1060,27 @@ class RedisRpcTest(unittest.TestCase):
         response = json.loads(redis_client.kv["bigqmt:rpc:resp:acct:queued-asset"])
         self.assertTrue(response["ok"], response["error"])
 
+    def test_listener_wildcard_defers_execution_snapshot_to_strategy_thread(self):
+        redis_client, service = _service_with_listener_methods(
+            process_in_listener=True,
+            listener_methods=("*",),
+        )
+
+        service.enqueue_payload(
+            {
+                "request_id": "queued-execution-snapshot",
+                "account_id": "acct",
+                "method": "query_execution_snapshot",
+                "params": {"order_strategy_name": "", "trade_strategy_name": ""},
+            }
+        )
+
+        response_key = "bigqmt:rpc:resp:acct:queued-execution-snapshot"
+        self.assertNotIn(response_key, redis_client.kv)
+        self.assertEqual(service.drain_pending(), 1)
+        response = json.loads(redis_client.kv[response_key])
+        self.assertTrue(response["ok"], response["error"])
+
     def test_account_mismatch_is_rejected(self):
         redis_client, service = _service()
 


### PR DESCRIPTION
## 修改内容

- 当精简版 QMT 运行时无法导入 `xtquant` 时，提供订单网关所需的最小账户及信用交易常量集
- 将 `query_execution_snapshot` 调度到策略主线程，避免委托和成交查询在 Redis 监听线程中返回空数据
- 当下载任务和执行事件均明确关闭时，不创建 Redis 客户端
- 功能开关未配置时保持原有缺省行为，兼容已有配置
- 增加沙箱导入、监听线程调度及无 Redis ZMQ 配置的回归测试

## 修改原因

部分券商的 QMT 运行时提供交易 API，但无法导入 `xtquant` package，导致订单网关初始化失败。

此外，执行快照依赖的委托和成交查询需要在 QMT 策略主线程中执行；从 Redis 监听线程直接调用时可能返回空数据。

对于无 Redis 的 ZMQ 部署，即使配置中残留 Redis 地址，只要下载任务和执行事件均已明确关闭，也不能创建或连接 Redis 客户端。本次修改仅在两个功能均明确关闭时跳过 Redis，不改变旧配置的缺省行为。

## 验证结果

- 相关功能及调用链测试：`122 passed`
- 排除两个无关环境问题后的全量测试：`1333 passed, 3 skipped, 2 deselected`
- 独立代码复核：无范围内问题，可以合并

排除的两项分别是 macOS 环境下的 Windows 路径断言，以及需要可选 `DBUtils` 依赖的 MySQL transport 测试。