### PR TITLE
feat: multi-account RPC service (dual-channel, step 2)

### DIFF
--- a/src/bigqmt_signal_trader/adapters/order_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/order_bigqmt.py
@@ -540,10 +540,11 @@ class BigQmtOrderGateway:
             message="passorder submitted",
         )
 
-    def cancel(self, order_ref):
+    def cancel(self, order_ref, account_id=None):
         cancel_func = self._require_cancel()
-        account_type = self._resolve_account_type(self.account_id)
-        ok = cancel_func(order_ref.order_sys_id, self.account_id, account_type, self.context_info)
+        aid = account_id or self.account_id
+        account_type = self._resolve_account_type(aid)
+        ok = cancel_func(order_ref.order_sys_id, aid, account_type, self.context_info)
         return CancelResult(success=bool(ok), message="" if ok else "cancel returned false")
 
     def query_orders(self, account_id, strategy_name):

--- a/src/bigqmt_signal_trader/adapters/order_dryrun.py
+++ b/src/bigqmt_signal_trader/adapters/order_dryrun.py
@@ -19,7 +19,7 @@ class DryRunOrderGateway:
             order_sys_id=None,
         )
 
-    def cancel(self, order_ref):
+    def cancel(self, order_ref, account_id=None):
         self.cancelled.append(order_ref)
         return None
 

--- a/src/bigqmt_signal_trader/multi_account.py
+++ b/src/bigqmt_signal_trader/multi_account.py
@@ -1,0 +1,237 @@
+# coding: utf-8
+"""Multi-account RPC service: one strategy instance serving multiple accounts.
+
+When ``BIGQMT_ACCOUNT_TYPE_MAP`` (in the local config) maps multiple account IDs
+to different account types (e.g. ``{"123456": "STOCK", "789012": "FUTURE"}``),
+a single QMT terminal can serve both accounts from one strategy instance.
+
+This module provides:
+
+- :func:`build_multi_account_rpc_service` — the entry point called from
+  ``_build_rpc_service`` in the strategy module. When the map has only one
+  entry (or is empty), it falls back to the single-service builder unchanged.
+- :class:`MultiAccountRpcServiceManager` — a thin wrapper that delegates
+  start/stop/drain to all services and exposes the primary's attributes.
+- :class:`SecondaryHandlersProxy` — injects the secondary account_id into
+  every ``handle()`` call, so per-request account_type resolution (from
+  ``account_type_map.py``, PR #135) routes correctly for the secondary
+  channel.
+
+Architecture
+~~~~~~~~~~~~
+
+One ``BigQmtRpcHandlers`` instance is shared across all RPC services.  The
+primary service runs on the adjust thread (``background_threads=False``);
+secondary services run on background threads (``background_threads=True``),
+with trade-context requests (submit, cancel, query) deferred to the primary's
+drain loop via ``pending`` queues.
+
+Per-request account_type resolution (PR #135) means the gateway's
+``_resolve_account_type(account_id)`` returns the correct type for each
+request's account_id — no save/restore of ``self.account_type`` is needed,
+and no monkey-patching of the handlers class is required.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class SecondaryHandlersProxy:
+    """Inject secondary account_id into params for every ``handle()`` call.
+
+    Both primary and secondary RPC services share the same handlers instance,
+    so ``handlers.account_id`` is always the primary's.  This proxy ensures the
+    secondary's account_id is injected into ``params``, allowing per-request
+    account_type resolution to route correctly for secondary-channel requests
+    (including ping, which otherwise has no account_id in params).
+
+    Attribute access is delegated to the proxied handlers, so this is
+    transparent to callers.
+    """
+
+    def __init__(self, handlers, account_id):
+        object.__setattr__(self, "_proxied", handlers)
+        object.__setattr__(self, "_secondary_account_id", str(account_id or ""))
+
+    def handle(self, method, params=None):
+        params = dict(params or {})
+        if "account_id" not in params and self._secondary_account_id:
+            params["account_id"] = self._secondary_account_id
+        return self._proxied.handle(method, params)
+
+    def __getattr__(self, name):
+        return getattr(self._proxied, name)
+
+    def __setattr__(self, name, value):
+        setattr(self._proxied, name, value)
+
+
+class MultiAccountRpcServiceManager:
+    """Manages primary + secondary RPC services for multi-account deployment.
+
+    Delegates start/stop/drain to all services.  Exposes the primary service's
+    attributes (``redis``, ``listen_redis``, ``account_id``, etc.) so that the
+    strategy module can treat a single-service or multi-service deployment
+    identically.
+    """
+
+    def __init__(self, services, handlers):
+        self._services = services
+        self.handlers = handlers
+        self._primary = services[0]
+        self.account_id = services[0].account_id
+        self.redis = services[0].redis
+        self.listen_redis = services[0].listen_redis
+
+    def start(self):
+        for s in self._services:
+            try:
+                s.start()
+            except Exception as e:
+                logger.error("multi_account start %s: %s", s.account_id[:3], e)
+
+    def stop(self):
+        for s in self._services:
+            try:
+                s.stop()
+            except Exception:
+                pass
+
+    def drain_request_queue(self, max_items=20):
+        return sum(
+            s.drain_request_queue(max_items)
+            for s in self._services
+            if hasattr(s, "drain_request_queue")
+        )
+
+    def drain_pending(self, max_items=20):
+        return sum(
+            s.drain_pending(max_items)
+            for s in self._services
+            if hasattr(s, "drain_pending")
+        )
+
+    def __getattr__(self, name):
+        return getattr(self._primary, name)
+
+
+def build_multi_account_rpc_service(context_info, app, config, build_single_fn):
+    """Build one ``RedisPubSubRpcService`` per account in the type map.
+
+    Falls back to the single-service builder (``build_single_fn``) when the
+    map is empty or has only one entry — zero behavior change for
+    single-account deployments.
+
+    Parameters
+    ----------
+    context_info, app, config :
+        Forwarded to ``build_single_fn`` for the primary service.
+    build_single_fn : callable
+        The original ``_build_rpc_service`` from the strategy module.
+
+    Returns
+    -------
+    RedisPubSubRpcService or MultiAccountRpcServiceManager or None
+    """
+    from .account_type_map import get_account_type_map
+
+    account_map = get_account_type_map()
+    if not account_map:
+        return build_single_fn(context_info, app, config)
+
+    primary = build_single_fn(context_info, app, config)
+    if primary is None:
+        return None
+
+    if len(account_map) <= 1:
+        return primary
+
+    # Build secondary service(s) — same handlers, different channel
+    services = [primary]
+    for aid in account_map:
+        if str(aid) == str(primary.account_id):
+            continue
+        sec = _build_secondary(primary, str(aid), config)
+        if sec:
+            services.append(sec)
+
+    logger.info(
+        "multi_account: %d services, primary=%s***",
+        len(services),
+        primary.account_id[:3],
+    )
+    return MultiAccountRpcServiceManager(services, primary.handlers)
+
+
+def _build_secondary(primary, account_id, config):
+    """Build a secondary ``RedisPubSubRpcService`` sharing the primary's handlers.
+
+    The secondary gets its own Redis connection (so ``stop()`` on the secondary
+    doesn't kill the primary's listener) and a ``SecondaryHandlersProxy`` that
+    injects the secondary's account_id into every request.
+    """
+    try:
+        from .redis_rpc import RedisPubSubRpcService
+        from .transports.redis_transport import RedisTransport
+        from .adapters import redis_common
+    except ImportError:
+        logger.warning("multi_account: secondary build failed (import error)")
+        return None
+
+    rpc_config = dict((config.get("rpc") or {}))
+
+    # Build an independent Redis client for the secondary service.
+    # Shares the same host/port/db/password as primary, but is a separate
+    # connection so closing it during stop() won't affect the primary.
+    try:
+        redis_config = dict(config.get("redis") or {})
+        redis_config.update(dict(rpc_config.get("redis") or {}))
+        if redis_config.get("socket_timeout") in (None, ""):
+            redis_config["socket_timeout"] = 10
+        secondary_listen_redis = redis_common.build_redis_client(redis_config)
+    except Exception:
+        # Fallback: share primary's connection (suboptimal but functional)
+        secondary_listen_redis = primary.listen_redis
+
+    transport = RedisTransport(
+        redis_client=secondary_listen_redis,
+        account_id=account_id,
+        response_redis_client=primary.redis,
+        request_channel_template=rpc_config.get(
+            "request_channel_template", "bigqmt:rpc:req:{account_id}"),
+        request_queue_template=rpc_config.get(
+            "request_queue_template", "bigqmt:rpc:queue:{account_id}"),
+        response_channel_template=rpc_config.get(
+            "response_channel_template",
+            "bigqmt:rpc:resp:{account_id}:{request_id}"),
+        response_list_template=rpc_config.get(
+            "response_list_template",
+            "bigqmt:rpc:respq:{account_id}:{request_id}"),
+        response_key_template=rpc_config.get(
+            "response_key_template",
+            "bigqmt:rpc:resp:{account_id}:{request_id}"),
+        response_ttl_seconds=int(rpc_config.get("response_ttl_seconds", 60)),
+        print_prefix="[bigqmt_rpc_2nd]",
+    )
+
+    return RedisPubSubRpcService(
+        redis_client=secondary_listen_redis,
+        response_redis_client=primary.redis,
+        handlers=SecondaryHandlersProxy(primary.handlers, account_id),
+        account_id=account_id,
+        request_channel_template=rpc_config.get(
+            "request_channel_template", "bigqmt:rpc:req:{account_id}"),
+        response_channel_template=rpc_config.get(
+            "response_channel_template",
+            "bigqmt:rpc:resp:{account_id}:{request_id}"),
+        response_key_template=rpc_config.get(
+            "response_key_template",
+            "bigqmt:rpc:resp:{account_id}:{request_id}"),
+        response_ttl_seconds=int(rpc_config.get("response_ttl_seconds", 60)),
+        max_queue_size=int(rpc_config.get("max_queue_size", 200)),
+        process_in_listener=True,
+        listener_methods=rpc_config.get("listener_methods") or ("*",),
+        background_threads=True,
+        transport=transport,
+    )

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -1925,7 +1925,7 @@ class BigQmtRpcHandlers:
             order_sys_id=order_sys_id,
             user_order_id=str(params.get("user_order_id") or ""),
         )
-        result = self.order_gateway.cancel(order_ref)
+        result = self.order_gateway.cancel(order_ref, account_id=account_id)
 
         # The native cancel return is not trustworthy in EITHER direction.
         # #148: falsey while the broker accepted the cancel (status became 54

--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -766,7 +766,7 @@ def _build_rpc_service(context_info, app, config):
         "[bigqmt_rpc] transport=%s mode process_in_listener=%s listener_methods=%s allow_order_methods=%s background_threads=%s"
         % (transport_name, process_in_listener, listener_methods, allow_order_methods, background_threads)
     )
-    return RedisPubSubRpcService(
+    service = RedisPubSubRpcService(
         redis_client=redis_client,
         response_redis_client=response_redis_client,
         handlers=handlers,
@@ -782,6 +782,23 @@ def _build_rpc_service(context_info, app, config):
         debug_log_limit=int(rpc_config.get("debug_log_limit", 5)),
         transport=transport,
     )
+    # Multi-account: when BIGQMT_ACCOUNT_TYPE_MAP has multiple entries,
+    # build one RPC service per account sharing the same handlers.
+    try:
+        from bigqmt_signal_trader.multi_account import build_multi_account_rpc_service
+        multi_service = build_multi_account_rpc_service(
+            context_info, app, config,
+            # The single-service builder: reuse everything we just built
+            # as the primary, and let build_multi_account_rpc_service
+            # create secondary services if the map has more entries.
+            lambda ctx, app, cfg: service if ctx is context_info else None,
+        )
+        if multi_service is not service:
+            # Multi-account mode: wrapped in MultiAccountRpcServiceManager
+            return multi_service
+    except Exception as _ma_err:
+        print("[bigqmt_rpc] multi_account check failed (single-account fallback): %s" % _ma_err)
+    return service
 
 
 def _start_rpc_service(context_info, app, config):

--- a/tests/bigqmt_signal_trader/test_app.py
+++ b/tests/bigqmt_signal_trader/test_app.py
@@ -83,7 +83,7 @@ class FakeOrderGateway:
 
         return OrderSubmitResult(status="SUBMITTED", user_order_id="bq:sig:1")
 
-    def cancel(self, order_ref):
+    def cancel(self, order_ref, account_id=None):
         return None
 
     def query_orders(self, account_id, strategy_name):

--- a/tests/bigqmt_signal_trader/test_multi_account.py
+++ b/tests/bigqmt_signal_trader/test_multi_account.py
@@ -1,0 +1,274 @@
+# coding: utf-8
+"""Tests for multi_account.py: multi-account RPC service manager.
+
+Covers:
+  1. SecondaryHandlersProxy injects account_id into params
+  2. MultiAccountRpcServiceManager delegates start/stop/drain
+  3. build_multi_account_rpc_service with 0/1/2+ entries in MAP
+  4. cancel(order_ref, account_id=...) per-request routing
+  5. Single-account fallback (MAP empty or single entry)
+"""
+
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SRC = os.path.join(ROOT, "src")
+sys.path.insert(0, SRC)
+
+from bigqmt_signal_trader.account_type_map import reload as reload_map
+from bigqmt_signal_trader.multi_account import (
+    SecondaryHandlersProxy,
+    MultiAccountRpcServiceManager,
+    build_multi_account_rpc_service,
+)
+
+
+# ---------------------------------------------------------------------------
+# SecondaryHandlersProxy
+# ---------------------------------------------------------------------------
+
+class SecondaryHandlersProxyTest(unittest.TestCase):
+
+    def test_injects_account_id_when_missing(self):
+        handlers = types.SimpleNamespace(handle=mock.MagicMock(return_value="ok"))
+        proxy = SecondaryHandlersProxy(handlers, "FUTURE_ACCT")
+        result = proxy.handle("ping", {"foo": "bar"})
+        handlers.handle.assert_called_once_with("ping", {"foo": "bar", "account_id": "FUTURE_ACCT"})
+        self.assertEqual(result, "ok")
+
+    def test_does_not_override_existing_account_id(self):
+        handlers = types.SimpleNamespace(handle=mock.MagicMock(return_value="ok"))
+        proxy = SecondaryHandlersProxy(handlers, "FUTURE_ACCT")
+        proxy.handle("ping", {"account_id": "STOCK_ACCT"})
+        handlers.handle.assert_called_once_with("ping", {"account_id": "STOCK_ACCT"})
+
+    def test_injects_on_empty_params(self):
+        handlers = types.SimpleNamespace(handle=mock.MagicMock(return_value="ok"))
+        proxy = SecondaryHandlersProxy(handlers, "FUTURE_ACCT")
+        proxy.handle("ping")
+        handlers.handle.assert_called_once_with("ping", {"account_id": "FUTURE_ACCT"})
+
+    def test_delegates_attribute_access(self):
+        handlers = types.SimpleNamespace(account_id="PRIMARY", order_gateway=None)
+        proxy = SecondaryHandlersProxy(handlers, "SECONDARY")
+        self.assertEqual(proxy.account_id, "PRIMARY")
+        self.assertIsNone(proxy.order_gateway)
+
+    def test_delegates_setattr(self):
+        handlers = types.SimpleNamespace(x=1)
+        proxy = SecondaryHandlersProxy(handlers, "SEC")
+        proxy.x = 42
+        self.assertEqual(handlers.x, 42)
+
+
+# ---------------------------------------------------------------------------
+# MultiAccountRpcServiceManager
+# ---------------------------------------------------------------------------
+
+class MultiAccountRpcServiceManagerTest(unittest.TestCase):
+
+    def _service(self, account_id="ACCT1"):
+        svc = mock.MagicMock()
+        svc.account_id = account_id
+        svc.redis = "redis_obj"
+        svc.listen_redis = "listen_redis_obj"
+        svc.drain_request_queue.return_value = 5
+        svc.drain_pending.return_value = 3
+        return svc
+
+    def test_delegates_start(self):
+        s1, s2 = self._service(), self._service("ACCT2")
+        mgr = MultiAccountRpcServiceManager([s1, s2], handlers="h")
+        mgr.start()
+        s1.start.assert_called_once()
+        s2.start.assert_called_once()
+
+    def test_delegates_stop(self):
+        s1, s2 = self._service(), self._service("ACCT2")
+        mgr = MultiAccountRpcServiceManager([s1, s2], handlers="h")
+        mgr.stop()
+        s1.stop.assert_called_once()
+        s2.stop.assert_called_once()
+
+    def test_drain_sums(self):
+        s1, s2 = self._service(), self._service("ACCT2")
+        mgr = MultiAccountRpcServiceManager([s1, s2], handlers="h")
+        self.assertEqual(mgr.drain_request_queue(max_items=20), 10)
+        self.assertEqual(mgr.drain_pending(max_items=20), 6)
+
+    def test_primary_attrs_exposed(self):
+        s1 = self._service()
+        mgr = MultiAccountRpcServiceManager([s1], handlers="h")
+        self.assertEqual(mgr.account_id, "ACCT1")
+        self.assertEqual(mgr.redis, "redis_obj")
+        self.assertEqual(mgr.listen_redis, "listen_redis_obj")
+
+    def test_getattr_delegates_to_primary(self):
+        s1 = self._service()
+        s1.some_attr = "value"
+        mgr = MultiAccountRpcServiceManager([s1], handlers="h")
+        self.assertEqual(mgr.some_attr, "value")
+
+
+# ---------------------------------------------------------------------------
+# build_multi_account_rpc_service
+# ---------------------------------------------------------------------------
+
+class BuildMultiAccountServiceTest(unittest.TestCase):
+
+    def setUp(self):
+        reload_map()
+
+    def test_empty_map_falls_back_to_single(self):
+        """No MAP → build_single_fn called, result returned as-is."""
+        sys.modules.pop("bigqmt_signal_trader_local_config", None)
+        reload_map()
+        single = mock.MagicMock()
+        result = build_multi_account_rpc_service(None, None, {}, single)
+        single.assert_called_once()
+        self.assertEqual(result, single.return_value)
+
+    def test_single_entry_map_falls_back_to_single(self):
+        """MAP with 1 entry → still single service."""
+        fake_cfg = types.ModuleType("bigqmt_signal_trader_local_config")
+        fake_cfg.BIGQMT_ACCOUNT_TYPE_MAP = {"ACCT1": "STOCK"}
+        with mock.patch.dict("sys.modules",
+                             {"bigqmt_signal_trader_local_config": fake_cfg}):
+            reload_map()
+            single = mock.MagicMock()
+            result = build_multi_account_rpc_service(None, None, {}, single)
+            single.assert_called_once()
+            self.assertEqual(result, single.return_value)
+
+    def test_two_entries_builds_secondary(self):
+        """MAP with 2 entries → MultiAccountRpcServiceManager with 2 services."""
+        fake_cfg = types.ModuleType("bigqmt_signal_trader_local_config")
+        fake_cfg.BIGQMT_ACCOUNT_TYPE_MAP = {"ACCT1": "STOCK", "ACCT2": "FUTURE"}
+        with mock.patch.dict("sys.modules",
+                             {"bigqmt_signal_trader_local_config": fake_cfg}):
+            reload_map()
+
+            primary = mock.MagicMock()
+            primary.account_id = "ACCT1"
+            primary.redis = "redis"
+            primary.listen_redis = "listen_redis"
+
+            single = mock.MagicMock(return_value=primary)
+
+            # Mock _build_secondary to avoid needing real Redis
+            with mock.patch(
+                "bigqmt_signal_trader.multi_account._build_secondary"
+            ) as mock_secondary:
+                secondary = mock.MagicMock()
+                secondary.account_id = "ACCT2"
+                mock_secondary.return_value = secondary
+
+                result = build_multi_account_rpc_service(
+                    None, None, {}, single)
+                self.assertIsInstance(result, MultiAccountRpcServiceManager)
+                self.assertEqual(len(result._services), 2)
+                mock_secondary.assert_called_once()
+
+    def test_build_single_returns_none_propagates(self):
+        """build_single_fn returns None → None."""
+        sys.modules.pop("bigqmt_signal_trader_local_config", None)
+        reload_map()
+        result = build_multi_account_rpc_service(
+            None, None, {}, lambda *a, **kw: None)
+        self.assertIsNone(result)
+
+
+# ---------------------------------------------------------------------------
+# cancel(account_id) per-request routing
+# ---------------------------------------------------------------------------
+
+class CancelPerRequestTest(unittest.TestCase):
+    """cancel(order_ref, account_id=...) routes via _resolve_account_type."""
+
+    def test_cancel_with_account_id(self):
+        from bigqmt_signal_trader.adapters.order_bigqmt import BigQmtOrderGateway
+
+        fake_cfg = types.ModuleType("bigqmt_signal_trader_local_config")
+        fake_cfg.BIGQMT_ACCOUNT_TYPE_MAP = {"FUTURE_ACCT": "FUTURE"}
+        with mock.patch.dict("sys.modules",
+                             {"bigqmt_signal_trader_local_config": fake_cfg}):
+            reload_map()
+            gw = BigQmtOrderGateway(context_info=None, account_type="STOCK")
+
+            # Mock cancel_func to capture args
+            captured = {}
+            def fake_cancel(order_sys_id, account_id, account_type, context_info):
+                captured["account_id"] = account_id
+                captured["account_type"] = account_type
+                return True
+
+            gw.cancel_func = fake_cancel
+            from bigqmt_signal_trader.models import OrderRef
+            result = gw.cancel(OrderRef(order_sys_id="SYS1", user_order_id="U1"),
+                               account_id="FUTURE_ACCT")
+            self.assertTrue(result.success)
+            self.assertEqual(captured["account_id"], "FUTURE_ACCT")
+            self.assertEqual(captured["account_type"], "FUTURE")
+
+    def test_cancel_without_account_id_uses_default(self):
+        from bigqmt_signal_trader.adapters.order_bigqmt import BigQmtOrderGateway
+
+        sys.modules.pop("bigqmt_signal_trader_local_config", None)
+        reload_map()
+        gw = BigQmtOrderGateway(context_info=None, account_type="STOCK")
+
+        captured = {}
+        def fake_cancel(order_sys_id, account_id, account_type, context_info):
+            captured["account_id"] = account_id
+            captured["account_type"] = account_type
+            return True
+
+        gw.cancel_func = fake_cancel
+        gw.account_id = "DEFAULT_ACCT"
+        from bigqmt_signal_trader.models import OrderRef
+        result = gw.cancel(OrderRef(order_sys_id="SYS1", user_order_id="U1"))
+        self.assertTrue(result.success)
+        self.assertEqual(captured["account_id"], "DEFAULT_ACCT")
+        self.assertEqual(captured["account_type"], "STOCK")
+
+
+# ---------------------------------------------------------------------------
+# Integration: _handle_cancel_order passes account_id
+# ---------------------------------------------------------------------------
+
+class CancelHandlerIntegrationTest(unittest.TestCase):
+    """_handle_cancel_order passes account_id to gateway.cancel()."""
+
+    def test_cancel_handler_passes_account_id(self):
+        from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+        from bigqmt_signal_trader.adapters.order_dryrun import DryRunOrderGateway
+
+        # Patch cancel to capture account_id
+        captured = {}
+        original_cancel = DryRunOrderGateway.cancel
+        def capturing_cancel(self, order_ref, account_id=None):
+            captured["account_id"] = account_id
+            return original_cancel(self, order_ref, account_id=account_id)
+
+        with mock.patch.object(DryRunOrderGateway, "cancel", capturing_cancel):
+            gw = DryRunOrderGateway()
+            handlers = BigQmtRpcHandlers(
+                account_id="PRIMARY_ACCT",
+                market_data=None,
+                position_provider=None,
+                order_gateway=gw,
+                allow_order_methods=True,
+            )
+            handlers._handle_cancel_order({
+                "account_id": "FUTURE_ACCT",
+                "order_sys_id": "SYS123",
+            })
+            self.assertEqual(captured["account_id"], "FUTURE_ACCT")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_redis_rpc.py
+++ b/tests/bigqmt_signal_trader/test_redis_rpc.py
@@ -298,7 +298,7 @@ class FalseyCancelGateway(DryRunOrderGateway):
         self.query_error = query_error
         self.lookups = 0
 
-    def cancel(self, order_ref):
+    def cancel(self, order_ref, account_id=None):
         self.cancelled.append(order_ref)
         return CancelResult(
             success=self.native_success,


### PR DESCRIPTION
## 多账号 RPC 服务（双账号方案第二步）

这是 PR #135（per-request account_type 查询）的自然后续。#135 解决了"读"的问题（查询按 account_id 路由），本 PR 解决"写+架构"问题（下单/撤单按 account_id 路由 + 双 RPC channel）。

### 背景

#77 的结论是：**一个策略实例服务多个账号**是正确路径。litaolemo 在 #77 更正中说：

> 他们的做法是双 RPC channel + gateway 子类 save/restore。**PR #135 要做的就是把第 2 步内置进 gateway，这样 save/restore 那层就不用了。#135 合入后会简单不少。**

本 PR 就是"简单不少"之后的完整实现。

### 改动

| 文件 | 改动 |
|------|------|
| **新增** `multi_account.py` | `SecondaryHandlersProxy`、`MultiAccountRpcServiceManager`、`build_multi_account_rpc_service()` |
| `order_bigqmt.py` | `cancel(order_ref, account_id=None)` — 撤单按 account_id 查 MAP |
| `order_dryrun.py` | `cancel` 签名同步 |
| `redis_rpc.py` | `_handle_cancel_order` 传 account_id 给 gateway.cancel() |
| `strategy.py` | `_build_rpc_service` 末尾检测 MAP，多账号时自动包装为 MultiAccountRpcServiceManager |
| **新增** `test_multi_account.py` | 17 个测试 |

### 架构

```
MAP 有多个条目时：
  Primary RPC service   → adjust thread (background_threads=False)
  Secondary RPC service → background thread (background_threads=True)
                          trade requests deferred to primary's drain loop
  共享同一个 BigQmtRpcHandlers
  SecondaryHandlersProxy 注入 secondary account_id 到 params
```

### 与 #135 的关系

- **#135**: `_resolve_account_type(account_id)` 查 MAP → 查询路由 ✅
- **本 PR**: `cancel(account_id)` + 双 channel + MultiAccountRpcServiceManager → 完整多账号 ✅
- 合入顺序：先 #135，后本 PR

### 向后兼容

- MAP 为空或单条 → 零行为变化（单 service）
- `cancel(account_id=None)` 默认 `self.account_id`
- 不需要 save/restore，不需要 monkey-patch，不需要 threading.local

### 测试

1333/1333 通过（17 个新增 + 1316 原有），0 失败。