### PR TITLE
feat: ORDER 委托行透出成交金额 trade_amount (#173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 - **ORDER 委托行透出成交金额 `trade_amount`**（#173，@feel-think 请求）：ccxt 适配层（QmtExchange）要 order dict 的 `cost`。ORDER 行原生带 `m_dTradeAmount`，但 `OrderSnapshot` 取了 `price_type` / `traded_price`，唯独没取成交金额 —— 金额此前只在 DEAL 行以 `amount` 透出。
 
-  于是拿一笔委托的 cost 只有两条路，都不好：按 `order_sysid` 聚合 DEAL 行（多一次 RPC），或用 `traded_price × traded_volume` 估算 —— 单笔成交两者相等，分笔成交时成交均价有舍入，会和柜台差几分。
+  于是拿一笔委托的 cost 只有两条路，都不好：按 `order_sysid` 聚合 DEAL 行（多一次 RPC），或者调用方自己拿 `traded_price × traded_volume` 去算。
 
   查询路径（`query_orders`）和推送路径（`normalize_order_event`）**同时**透出，否则走回调的调用方拿不到 cost；客户端 `xtquant_compat._order_from_dict` 同步传递。
 
@@ -17,7 +17,11 @@
 
   **动手前先查了这台终端到底带不带这个字段。** 只读调 `describe_trade_detail_fields`（0.3.19，当日 14 笔委托）：ORDER 行共 120 个属性，`m_dTradeAmount` 在其中；掩码形状显示 13 笔是四到五位数的金额，唯一一笔 `0.0` 正是 `m_nVolumeTraded` 为 0 的未成交委托。所以它不是一个「存在但恒为空」的字段 —— #133 里的 `m_strShareholderID` 就是那个下场（属性表里根本没有）。
 
-  **未验证**：这是服务端改动，需要部署 + 重启策略后才能实盘确认。本次只验证了字段**存在且有真值**，没验证新代码真的把它发到了客户端；分笔成交时柜台金额与估算值的差异只有构造用例，没有真实分笔成交样本；期货（金额 = 均价×数量×合约乘数）和港股通的 `m_dTradeAmountRMB` 未测。
+  **已实盘验证**（0.3.19 部署 + `reload_deployment`，只读查询）：当日 14 笔委托全部带上 `trade_amount`，且与按 `order_sysid` 聚合的 DEAL 金额 **14/14 逐笔相等** —— 这是一个独立来源，验的是这个数**确实是成交金额**，不只是"字段出现了"。客户端对象路径（ccxt 取 `cost` 的那条）同样确认：14 个 order 对象都有 `.trade_amount`，合计 117546.00。
+
+  **有一条 issue 里的前提没能复现，如实记下**：「分笔成交时成交均价有舍入，会和柜台差几分」在这台终端上**不成立**。`m_dTradedPrice` 不是两位小数，它带完整精度 —— 当日唯一一笔分价成交（55.14 / 55.13 两笔）报的是 `55.13666666666666`，所以 `traded_price × traded_volume` 与柜台金额**差值为 0**。取这个字段的理由因此不是「修好了差几分」，而是它是**柜台的原值**：不依赖某台终端的 `m_dTradedPrice` 精度，也不用多发一次 RPC 去聚合 DEAL。别的券商的 QMT 若把均价截成两位，估算才会开始漂。
+
+  **未验证**：期货（金额 = 均价×数量×合约乘数）和港股通的 `m_dTradeAmountRMB` 未测；推送路径（`normalize_order_event` 的 `trade_amount`）只有离线用例，当日收盘后没有新委托回调可看，没有实盘样本。
 
 ### 修复
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@
 
 ## [未发布]
 
+### 新增
+
+- **ORDER 委托行透出成交金额 `trade_amount`**（#173，@feel-think 请求）：ccxt 适配层（QmtExchange）要 order dict 的 `cost`。ORDER 行原生带 `m_dTradeAmount`，但 `OrderSnapshot` 取了 `price_type` / `traded_price`，唯独没取成交金额 —— 金额此前只在 DEAL 行以 `amount` 透出。
+
+  于是拿一笔委托的 cost 只有两条路，都不好：按 `order_sysid` 聚合 DEAL 行（多一次 RPC），或用 `traded_price × traded_volume` 估算 —— 单笔成交两者相等，分笔成交时成交均价有舍入，会和柜台差几分。
+
+  查询路径（`query_orders`）和推送路径（`normalize_order_event`）**同时**透出，否则走回调的调用方拿不到 cost；客户端 `xtquant_compat._order_from_dict` 同步传递。
+
+  **取不到时留 0.0，不拿 `traded_price × traded_volume` 兜底。** 让估算值冒充柜台金额正好是这个 issue 要避开的事，而且 0.0 对未成交委托本来就是对的。旧部署不发这个键时客户端也给 0.0 而不是 AttributeError（#133 就是那个形态）。
+
+  **动手前先查了这台终端到底带不带这个字段。** 只读调 `describe_trade_detail_fields`（0.3.19，当日 14 笔委托）：ORDER 行共 120 个属性，`m_dTradeAmount` 在其中；掩码形状显示 13 笔是四到五位数的金额，唯一一笔 `0.0` 正是 `m_nVolumeTraded` 为 0 的未成交委托。所以它不是一个「存在但恒为空」的字段 —— #133 里的 `m_strShareholderID` 就是那个下场（属性表里根本没有）。
+
+  **未验证**：这是服务端改动，需要部署 + 重启策略后才能实盘确认。本次只验证了字段**存在且有真值**，没验证新代码真的把它发到了客户端；分笔成交时柜台金额与估算值的差异只有构造用例，没有真实分笔成交样本；期货（金额 = 均价×数量×合约乘数）和港股通的 `m_dTradeAmountRMB` 未测。
+
 ### 修复
 
 - **周线（1w）的 preClose 不再恒为 0.0**（#166，@yucejade 报告）：大 QMT 对 `1w` 的每一根 bar 都返回 `preClose = 0.0`。实测（国金 2.1.19.0 / 0.3.19，只读）受影响的**只有 1w**：

--- a/docs/BIG_QMT_REDIS_RPC.md
+++ b/docs/BIG_QMT_REDIS_RPC.md
@@ -285,7 +285,7 @@ bigqmt:order_events:{account_id}
 bigqmt:trade_events:{account_id}
 ```
 
-成交事件字段（由 `deal_callback` 的 `m_*` 映射）：`stock_code`(`m_strInstrumentID`)、`trade_id`(`m_strTradeID`)、`order_sys_id`(`m_strOrderSysID`)、`volume`(`m_nVolume`)、`price`(`m_dPrice`)、`amount`(`m_dTradeAmount`)、`commission`(`m_dComssion`)、`direction`(`m_nDirection`) 及 `action`(尽力映射 BUY/SELL)、`traded_at`(`m_strTradeTime`)。委托事件类似（`m_nOrderStatus`→`status`、`m_nVolumeTotal`→`order_volume`、`m_nVolumeTraded`→`traded_volume`、`m_dLimitPrice`→`price`、`m_dTradedPrice`→`traded_price`）。
+成交事件字段（由 `deal_callback` 的 `m_*` 映射）：`stock_code`(`m_strInstrumentID`)、`trade_id`(`m_strTradeID`)、`order_sys_id`(`m_strOrderSysID`)、`volume`(`m_nVolume`)、`price`(`m_dPrice`)、`amount`(`m_dTradeAmount`)、`commission`(`m_dComssion`)、`direction`(`m_nDirection`) 及 `action`(尽力映射 BUY/SELL)、`traded_at`(`m_strTradeTime`)。委托事件类似（`m_nOrderStatus`→`status`、`m_nVolumeTotal`→`order_volume`、`m_nVolumeTraded`→`traded_volume`、`m_dLimitPrice`→`price`、`m_dTradedPrice`→`traded_price`、`m_dTradeAmount`→`trade_amount`）。委托的 `trade_amount` 是柜台的精确成交金额；取不到时为 0.0，不会用 `traded_price × traded_volume` 估算顶替（#173）。
 
 客户端用法（MiniQMT 风格，回调实时触发）：
 

--- a/qmt-trader/scripts/qmt.py
+++ b/qmt-trader/scripts/qmt.py
@@ -206,6 +206,10 @@ def _order_to_dict(o):
         "account_id", "stock_code", "order_type", "order_status",
         "order_volume", "traded_volume", "price", "order_sysid", "order_id",
         "strategy_name", "order_remark", "order_time",
+        # 柜台成交金额 (#173)。旧部署不发它, getattr 兜底成 None ——
+        # 这里给 None 而不是 0.0 是有意的: "服务端没告诉我" 和
+        # "成交金额确实是 0" 是两回事, 前者该看得出来。
+        "trade_amount",
     ]:
         d[attr] = getattr(o, attr, None)
     # 语义化
@@ -355,7 +359,7 @@ def cmd_orders(args):
         _err("查询委托失败", detail=str(e), code="QUERY_FAIL")
     rows = [_order_to_dict(o) for o in (orders or [])]
     _ok({"orders": rows, "count": len(rows)}, table=args.table,
-        headers=["stock_code", "order_type_name", "order_status_name", "order_volume", "traded_volume", "price", "order_sysid", "cancelable"])
+        headers=["stock_code", "order_type_name", "order_status_name", "order_volume", "traded_volume", "price", "trade_amount", "order_sysid", "cancelable"])
 
 
 def cmd_trades(args):

--- a/src/bigqmt_signal_trader/adapters/order_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/order_bigqmt.py
@@ -595,6 +595,18 @@ class BigQmtOrderGateway:
                     traded_price=float(
                         _attr(row, ("m_dTradedPrice", "traded_price", "avg_traded_price"), 0.0) or 0.0
                     ),
+                    # 柜台的精确成交金额 (issue #173). ccxt 的 order["cost"]
+                    # 要的就是它。以前只有 DEAL 行透出 amount, 所以拿委托的
+                    # cost 得按 order_sysid 聚合成交 (多一次 RPC), 或者用
+                    # traded_price * traded_volume 估 -- 单笔成交两者相等,
+                    # 分笔成交时成交均价有舍入, 会和柜台差几分。
+                    # 这个终端的 ORDER 行确实带 m_dTradeAmount: 实盘
+                    # describe_trade_detail_fields 查 14 笔委托, 13 笔是四到
+                    # 五位数的金额, 唯一为 0.0 的那笔正是 traded_volume 为 0
+                    # 的未成交委托。
+                    trade_amount=float(
+                        _attr(row, ("m_dTradeAmount", "trade_amount", "amount"), 0.0) or 0.0
+                    ),
                     # MiniQMT XtOrder carries these and this bridge never sent
                     # them, so every client saw AttributeError (issue #133).
                     account_type=account_type_code,

--- a/src/bigqmt_signal_trader/adapters/order_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/order_bigqmt.py
@@ -595,15 +595,20 @@ class BigQmtOrderGateway:
                     traded_price=float(
                         _attr(row, ("m_dTradedPrice", "traded_price", "avg_traded_price"), 0.0) or 0.0
                     ),
-                    # 柜台的精确成交金额 (issue #173). ccxt 的 order["cost"]
+                    # 柜台自己给的成交金额 (issue #173). ccxt 的 order["cost"]
                     # 要的就是它。以前只有 DEAL 行透出 amount, 所以拿委托的
-                    # cost 得按 order_sysid 聚合成交 (多一次 RPC), 或者用
-                    # traded_price * traded_volume 估 -- 单笔成交两者相等,
-                    # 分笔成交时成交均价有舍入, 会和柜台差几分。
-                    # 这个终端的 ORDER 行确实带 m_dTradeAmount: 实盘
-                    # describe_trade_detail_fields 查 14 笔委托, 13 笔是四到
-                    # 五位数的金额, 唯一为 0.0 的那笔正是 traded_volume 为 0
-                    # 的未成交委托。
+                    # cost 得按 order_sysid 聚合成交 (多一次 RPC), 或者自己
+                    # 拿 traded_price * traded_volume 去算。
+                    #
+                    # 实盘验过 (0.3.19, 当日 14 笔委托): trade_amount 与按
+                    # order_sysid 聚合的 DEAL 金额 14/14 逐笔相等。
+                    #
+                    # 注意 issue 里"分笔成交时成交均价舍入会差几分"这条,
+                    # 在这台终端上**没有复现**: m_dTradedPrice 不是两位小数,
+                    # 它带完整精度 (唯一一笔分价成交 55.14/55.13 报的是
+                    # 55.13666666666666), 所以估算值当天一分不差。取这个
+                    # 字段的理由是它是柜台的原值 -- 不依赖某台终端的
+                    # m_dTradedPrice 精度, 也不用多发一次 RPC。
                     trade_amount=float(
                         _attr(row, ("m_dTradeAmount", "trade_amount", "amount"), 0.0) or 0.0
                     ),

--- a/src/bigqmt_signal_trader/exec_events.py
+++ b/src/bigqmt_signal_trader/exec_events.py
@@ -372,6 +372,11 @@ def normalize_order_event(order, account_id=""):
         "traded_price": _attr(
             order, ["m_dTradedPrice", "traded_price", "avg_traded_price"]
         ),
+        # 成交金额。查询路径 (query_orders) 和推送路径要给出同一个
+        # 字段，否则走回调的调用方拿不到 cost (issue #173)。
+        "trade_amount": _attr(
+            order, ["m_dTradeAmount", "trade_amount"]
+        ),
         "status": _attr(order, ["m_nOrderStatus", "order_status", "status"]),
         "direction": direction,
         "action": _action_from_direction(direction),

--- a/src/bigqmt_signal_trader/models.py
+++ b/src/bigqmt_signal_trader/models.py
@@ -408,8 +408,7 @@ class OrderSnapshot:
         self.offset_flag = offset_flag
         self.direction = direction
         # 官方 Order 字段 m_dTradeAmount(成交金额; 期货 = 均价×数量×合约乘数)。
-        # 柜台给的精确成交金额。traded_price × traded_volume 只在单笔成交时
-        # 与它相等；分笔成交的成交均价有舍入，估算会差几分 (issue #173)。
+        # 柜台自己给的成交金额, 不用调用方拿价格乘数量去算 (issue #173)。
         # 追加在末尾并给默认值, 保持既有位置参数调用不受影响。
         # 0.0 = 未成交, 或该终端的 ORDER 行不带这个字段。
         self.trade_amount = trade_amount

--- a/src/bigqmt_signal_trader/models.py
+++ b/src/bigqmt_signal_trader/models.py
@@ -376,6 +376,7 @@ class OrderSnapshot:
         secu_account="",
         offset_flag=None,
         direction=None,
+        trade_amount=0.0,
     ):
         self.order_sys_id = order_sys_id
         self.user_order_id = user_order_id
@@ -406,6 +407,12 @@ class OrderSnapshot:
         self.secu_account = secu_account
         self.offset_flag = offset_flag
         self.direction = direction
+        # 官方 Order 字段 m_dTradeAmount(成交金额; 期货 = 均价×数量×合约乘数)。
+        # 柜台给的精确成交金额。traded_price × traded_volume 只在单笔成交时
+        # 与它相等；分笔成交的成交均价有舍入，估算会差几分 (issue #173)。
+        # 追加在末尾并给默认值, 保持既有位置参数调用不受影响。
+        # 0.0 = 未成交, 或该终端的 ORDER 行不带这个字段。
+        self.trade_amount = trade_amount
 
 
 class TradeSnapshot:

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -4409,6 +4409,13 @@ class BigQmtXtTrader:
             traded_price=_safe_float(
                 item.get("traded_price", item.get("avg_traded_price", item.get("m_dTradedPrice")))
             ),
+            # 柜台的精确成交金额 (issue #173) -- ccxt 适配层的
+            # order["cost"]。旧部署不发这个键，那就是 0.0；不在这里
+            # 拿 traded_price × traded_volume 兑，因为那是估算值，让它
+            # 冒充柜台金额正好是这个 issue 要避开的事。
+            trade_amount=_safe_float(
+                item.get("trade_amount", item.get("m_dTradeAmount"))
+            ),
             order_sysid=order_sysid,
             # MiniQMT: order_id is the int 委托编号, order_sysid the string
             # 柜台编号. Both, from one 合同编号 (issue #113).

--- a/tests/bigqmt_signal_trader/test_order_trade_amount.py
+++ b/tests/bigqmt_signal_trader/test_order_trade_amount.py
@@ -5,11 +5,16 @@
 原生带 ``m_dTradeAmount``，但 ``OrderSnapshot`` 取了 ``price_type`` /
 ``traded_price``，唯独没取成交金额 —— 金额此前只在 DEAL 行以 ``amount`` 透出。
 
-于是拿一笔委托的 cost 只有两条路，都不好：
+于是拿一笔委托的 cost 只有两条路，都不好：按 order_sysid 聚合 DEAL 行（多一次
+RPC），或者调用方自己拿 traded_price * traded_volume 去算。
 
-  * 按 order_sysid 聚合 DEAL 行     -> 多一次 RPC
-  * traded_price * traded_volume   -> 单笔成交时相等, 分笔成交时成交均价有
-                                      舍入, 和柜台的精确金额差几分
+**issue 里"分笔成交时成交均价舍入会差几分"这条，在这台终端上没有复现。**
+部署后实盘查了当日 14 笔委托：`trade_amount` 与按 order_sysid 聚合的 DEAL
+金额 14/14 逐笔相等，而 `traded_price * traded_volume` 也一分不差 —— 因为
+`m_dTradedPrice` 不是两位小数，它带完整精度（唯一一笔分价成交 55.14/55.13
+报的是 55.13666666666666）。所以取这个字段的理由不是"修好了差几分"，而是
+它是**柜台的原值**：不依赖某台终端的 m_dTradedPrice 精度，也不用多发一次
+RPC。别的券商的 QMT 要是真把均价截成两位，估算就会开始漂。
 
 **这个终端的 ORDER 行确实带这个字段。** 动手前先用只读的
 ``describe_trade_detail_fields`` 在实盘验过 (0.3.19, 账户当日 14 笔委托):
@@ -84,12 +89,14 @@ class OrderTradeAmountTest(unittest.TestCase):
 
         self.assertEqual(order.trade_amount, 692.0)
 
-    def test_a_partial_fill_reports_the_counter_amount_not_the_estimate(self):
-        """The whole point: 成交均价 rounds, the counter amount does not.
+    def test_the_counter_amount_wins_over_price_times_volume(self):
+        """Read the field; never recompute it from price and volume.
 
-        800 shares filled across two prints, 3.414 average -- QMT rounds
-        m_dTradedPrice to 3.41, so price * volume says 2728.00 while the
-        counter says 2731.20. Estimating loses 3.20 yuan.
+        This terminal reports m_dTradedPrice at full precision, so the two
+        agree here (verified live: 14/14). A terminal that truncates 成交均价
+        to two decimals would not -- 800 shares averaging 3.414 reported as
+        3.41 gives 2728.00 against the counter's 2731.20. This pins that the
+        answer comes off the row either way.
         """
         row = _order_row(m_nVolumeTraded=800, m_dTradedPrice=3.41,
                          m_dTradeAmount=2731.2)

--- a/tests/bigqmt_signal_trader/test_order_trade_amount.py
+++ b/tests/bigqmt_signal_trader/test_order_trade_amount.py
@@ -1,0 +1,216 @@
+# coding: utf-8
+"""issue #173: ORDER 行没有透出成交金额 (m_dTradeAmount)。
+
+@feel-think 在 ccxt 适配层 (QmtExchange) 要 order dict 的 ``cost``。ORDER 行
+原生带 ``m_dTradeAmount``，但 ``OrderSnapshot`` 取了 ``price_type`` /
+``traded_price``，唯独没取成交金额 —— 金额此前只在 DEAL 行以 ``amount`` 透出。
+
+于是拿一笔委托的 cost 只有两条路，都不好：
+
+  * 按 order_sysid 聚合 DEAL 行     -> 多一次 RPC
+  * traded_price * traded_volume   -> 单笔成交时相等, 分笔成交时成交均价有
+                                      舍入, 和柜台的精确金额差几分
+
+**这个终端的 ORDER 行确实带这个字段。** 动手前先用只读的
+``describe_trade_detail_fields`` 在实盘验过 (0.3.19, 账户当日 14 笔委托):
+ORDER 行共 120 个属性, ``m_dTradeAmount`` 在其中; 掩码形状显示 13 笔是四到
+五位数的金额, 唯一一笔 ``0.0`` 正是 ``m_nVolumeTraded`` 为 0 的未成交委托。
+所以它不是一个"存在但恒为空"的字段 —— 那正是 #133 里 ``m_strShareholderID``
+的下场 (属性表里根本没有), 也是这里必须先查一遍的原因。
+
+取不到时留 0.0，**不拿 traded_price * traded_volume 兜底** —— 让估算值冒充
+柜台金额，正好是这个 issue 要避开的那件事。
+"""
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.adapters.order_bigqmt import BigQmtOrderGateway
+from bigqmt_signal_trader.exec_events import normalize_order_event
+from bigqmt_signal_trader.xtquant_compat import BigQmtXtTrader, StockAccount
+
+
+ACCOUNT = "8886800503"
+
+
+class Row(object):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def _order_row(**overrides):
+    base = dict(
+        m_strOrderSysID="635030450",
+        m_strRemark="",
+        m_strInstrumentID="600722",
+        m_strExchangeID="SH",
+        m_strInstrumentName="金隅集团",
+        m_nOffsetFlag=49,
+        m_nVolumeTotalOriginal=100,
+        m_nVolumeTraded=100,
+        m_nOrderStatus=56,
+        m_dLimitPrice=6.92,
+        m_dTradedPrice=6.92,
+        m_dTradeAmount=692.0,
+        m_strStrategyName="alpha",
+    )
+    base.update(overrides)
+    return Row(**base)
+
+
+def _gateway(order_rows=()):
+    def query(account_id, acct_type, detail_type, strategy_name=""):
+        return list(order_rows) if detail_type == "ORDER" else []
+
+    return BigQmtOrderGateway(
+        context_info=None,
+        account_id=ACCOUNT,
+        get_trade_detail_data_func=query,
+        account_type="STOCK",
+    )
+
+
+# ----------------------------------------------------------------- server
+
+
+class OrderTradeAmountTest(unittest.TestCase):
+    def test_it_comes_off_the_row(self):
+        order = _gateway([_order_row()]).query_orders_strict(ACCOUNT, "")[0]
+
+        self.assertEqual(order.trade_amount, 692.0)
+
+    def test_a_partial_fill_reports_the_counter_amount_not_the_estimate(self):
+        """The whole point: 成交均价 rounds, the counter amount does not.
+
+        800 shares filled across two prints, 3.414 average -- QMT rounds
+        m_dTradedPrice to 3.41, so price * volume says 2728.00 while the
+        counter says 2731.20. Estimating loses 3.20 yuan.
+        """
+        row = _order_row(m_nVolumeTraded=800, m_dTradedPrice=3.41,
+                         m_dTradeAmount=2731.2)
+
+        order = _gateway([row]).query_orders_strict(ACCOUNT, "")[0]
+
+        self.assertEqual(order.trade_amount, 2731.2)
+        self.assertNotEqual(order.trade_amount,
+                            order.traded_price * order.traded_volume)
+
+    def test_an_unfilled_order_is_zero(self):
+        row = _order_row(m_nVolumeTraded=0, m_dTradedPrice=0.0,
+                         m_dTradeAmount=0.0)
+
+        order = _gateway([row]).query_orders_strict(ACCOUNT, "")[0]
+
+        self.assertEqual(order.trade_amount, 0.0)
+
+    def test_a_row_without_the_field_is_zero_never_an_estimate(self):
+        """A broker whose QMT omits it must not get a fabricated amount."""
+        row = _order_row()
+        del row.m_dTradeAmount
+
+        order = _gateway([row]).query_orders_strict(ACCOUNT, "")[0]
+
+        self.assertEqual(order.trade_amount, 0.0)
+
+    def test_the_other_order_fields_are_unchanged(self):
+        order = _gateway([_order_row()]).query_orders_strict(ACCOUNT, "")[0]
+
+        self.assertEqual(order.traded_price, 6.92)
+        self.assertEqual(order.traded_volume, 100)
+        self.assertEqual(order.instrument_name, "金隅集团")
+
+
+class OrderEventTradeAmountTest(unittest.TestCase):
+    """The push path has to carry it too, or callback users still lack cost."""
+
+    def test_the_order_event_carries_it(self):
+        event = normalize_order_event(_order_row(), ACCOUNT)
+
+        self.assertEqual(event["trade_amount"], 692.0)
+
+    def test_a_callback_object_without_it_still_builds(self):
+        row = _order_row()
+        del row.m_dTradeAmount
+
+        event = normalize_order_event(row, ACCOUNT)
+
+        self.assertIn("trade_amount", event)
+        self.assertIsNone(event["trade_amount"])
+
+
+# ----------------------------------------------------------------- client
+
+
+class FakeClient(object):
+    def __init__(self, orders=()):
+        self.account_id = ACCOUNT
+        self.local_cache_config = {}
+        self.full_tick_cache_config = {}
+        self.orders = list(orders)
+
+    def call(self, method, params=None, account_id=None, timeout_seconds=None):
+        if method == "ping":
+            return {"pong": True, "account_id": ACCOUNT, "account_type": "STOCK"}
+        if method == "query_stock_orders":
+            return self.orders
+        return {}
+
+    def _redis(self):
+        raise AssertionError("redis not expected here")
+
+
+def _trader(orders=()):
+    trader = BigQmtXtTrader(account_id=ACCOUNT)
+    trader.client = FakeClient(orders)
+    trader.connect()
+    return trader
+
+
+ORDER_PAYLOAD = {
+    "order_sys_id": "635030450", "stock_code": "600722.SH", "action": "BUY",
+    "volume": 100, "traded_volume": 100, "status": "56", "price": 6.92,
+    "traded_price": 6.92, "trade_amount": 692.0,
+}
+
+
+class ClientOrderTradeAmountTest(unittest.TestCase):
+    def test_query_stock_orders_passes_it_through(self):
+        order = _trader([ORDER_PAYLOAD]).query_stock_orders(
+            StockAccount(ACCOUNT))[0]
+
+        self.assertEqual(order.trade_amount, 692.0)
+
+    def test_an_older_deployment_leaves_it_zero_without_attributeerror(self):
+        """Client upgrades first; the QMT side is not synced and restarted yet.
+
+        The key is simply absent then. The attribute must still exist -- that
+        is what #133 was, and trading one AttributeError for another is not a
+        fix.
+        """
+        bare = dict(ORDER_PAYLOAD)
+        del bare["trade_amount"]
+
+        order = _trader([bare]).query_stock_orders(StockAccount(ACCOUNT))[0]
+
+        self.assertEqual(order.trade_amount, 0.0)
+
+    def test_it_is_not_backfilled_from_price_times_volume(self):
+        """0.0 means "the counter did not tell us", and must stay legible as
+        that. Filling in 692.0 here would make an estimate indistinguishable
+        from the real amount, which is the bug this issue is avoiding."""
+        bare = dict(ORDER_PAYLOAD)
+        del bare["trade_amount"]
+
+        order = _trader([bare]).query_stock_orders(StockAccount(ACCOUNT))[0]
+
+        self.assertEqual(order.traded_price * order.traded_volume, 692.0)
+        self.assertEqual(order.trade_amount, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #173.

@feel-think 在 ccxt 适配层（QmtExchange）要 order dict 的 `cost`。ORDER 行原生带 `m_dTradeAmount`，但 `OrderSnapshot` 取了 `price_type` / `traded_price`，唯独没取成交金额 —— 金额此前只在 DEAL 行以 `amount` 透出。

## 改了什么

| 文件 | 改动 |
|---|---|
| `src/bigqmt_signal_trader/models.py` | `OrderSnapshot` 末尾追加 `trade_amount=0.0`（保持既有位置参数调用不受影响） |
| `src/bigqmt_signal_trader/adapters/order_bigqmt.py` | `query_orders_strict` 按 `("m_dTradeAmount", "trade_amount", "amount")` 提取 |
| `src/bigqmt_signal_trader/exec_events.py` | `normalize_order_event` 同步透出，走回调的调用方也拿得到 |
| `src/bigqmt_signal_trader/xtquant_compat.py` | `_order_from_dict` 传递（查询和推送两条路径共用它） |

**取不到时留 0.0，不拿 `traded_price × traded_volume` 兜底。** 0.0 对未成交委托本来就是对的；旧部署不发这个键时客户端也给 0.0，不是 AttributeError（#133 就是那个形态）。

## 已实盘验证（部署 + reload 后）

部署了三个服务端文件到 `D:\国金证券QMT交易端_lemo\python\`，`reload_deployment()` 成功（purged=31，0.88s，无错误），然后只读查询验证：

**1. 字段到了** —— 当日 14 笔委托，`trade_amount` 全部出现在 RPC 响应里。

**2. 这个数确实是成交金额** —— 拿一个独立来源交叉验证：按 `order_sysid` 聚合 DEAL 行的金额，**14/14 逐笔相等**：

```
order_sys_id  trade_amt  sum(DEAL)  deals  verdict
635005110      10398.00   10398.00      1  MATCH
635071745          0.00          -      0  unfilled, 0.0 correct
635109712       8528.00    8528.00      2  MATCH
635116474      10377.00   10377.00      2  MATCH
635122506      21220.00   21220.00      2  MATCH
635122727      16541.00   16541.00      2  MATCH
...                                        (14 行全 MATCH)

agree=14 disagree=0 unverifiable=0
```

响应格式正确什么都不说明，所以验的是**含义**：这个数和券商成交记录算出来的金额一致。

**3. 客户端对象路径（ccxt 真正会读的那条）** —— 14 个 order 对象都有 `.trade_amount`，合计 `117546.00`。

**4. 无回归** —— 只读实盘门禁 10/10 PASS。Litao 正在做的 #104 reply-residency 探针（`redis_rpc.py` / `zmq_transport.py`，未进 main）**没有被动过**，reload 后仍在采样（`available: true`）。

## ⚠️ issue 里有一条前提没能复现，如实记下

**「分笔成交时成交均价有舍入，会和柜台差几分」在这台终端上不成立。**

`m_dTradedPrice` 不是两位小数，**它带完整精度**。当日唯一一笔分价成交（55.14 / 55.13 两笔，共 300 股）报的是：

```
traded_price  = 55.13666666666666
traded_volume = 300.0
estimate      = 16541
trade_amount  = 16541
difference    = 0.000e+00
```

14 笔全部如此，`traded_price × traded_volume` 一分不差。

所以这条改动的理由**不是**「修好了差几分」，而是：它是**柜台的原值** —— 不依赖某台终端的 `m_dTradedPrice` 精度，也不用多发一次 RPC 去聚合 DEAL 行。别的券商的 QMT 若把均价截成两位，估算才会开始漂。代码注释、测试 docstring 和 CHANGELOG 都已按实测改过措辞（commit `de0b34c`）。

## 门禁

- **门禁 1**：`1466 passed`；`109` 个测试文件 = `109` 个模块被收集
- **新测试确实会红**：`git stash` 掉 `src/` 后，10 条新测试里 **9 条失败**（第 10 条是回归保护）
- **门禁 2**：见上，这次是**真的验证了改动本身**，不只是桥还活着
- **Preflight**：用终端自己的 `xtquant`（`xtconstant` 91 个名字，不是 shim 的 538）导入整套服务端模块通过

## 还没验证的

- **期货**（金额 = 均价×数量×合约乘数）和**港股通** `m_dTradeAmountRMB` 未测
- **推送路径**（`normalize_order_event` 的 `trade_amount`）只有离线用例 —— 收盘后没有新的委托回调，拿不到实盘样本

## 部署状态

**线上终端现在跑的是这个分支的三个服务端文件**，不是 main。合了就一致了；不合请回滚（每个被替换的文件旁边都有 `.bak_bot173_20260904_153812`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
