### PR TITLE
fix: qmt.py --table 只画一行空白，不是数据

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,22 @@
 
 ### 修复
 
+- **`qmt.py --table` 不再只画一行空白**（读 CLI，随 #173 的实盘确认一起发现）：`orders --table` 画出表头、分隔线，然后一行纯空格 —— 不管返回了多少数据。同一个查询不加 `--table` 是好的（`count=14`，字段齐全），所以数据没问题，坏的只有渲染。
+
+  子命令交给 `_ok` 的是**为 JSON 设计的形状**，而那通常是个包装：
+
+  ```python
+  _ok({"orders": rows, "count": 14}, table=..., headers=[...])
+  ```
+
+  而 `_ok` 里是 `_print_table(data if isinstance(data, list) else [data], headers)` —— 包装是 dict 不是 list，于是被再包一层当成**一行**，每个表头（`stock_code` …）在它身上都查不到，全渲染成空字符串。
+
+  实测受影响的是 **positions / orders / trades / tick / kline 五个**；**account 和 instrument 本来就是对的**，它们确实只返回一条扁平记录，一行才是正确答案。所以修法不能是"永远取 values"，那会把这两个也弄坏。
+
+  现在 `_ok` 多一个 `table_key` 参数指明包装里哪个键是表格数据（`positions` / `orders` / `trades` / `bars`）；没给 `table_key` 时，**值全是 dict** 的字典按"按键索引"处理、行取 values（`tick` 是 `{code: {...}}`），其余仍当作单条扁平记录。
+
+  已实盘验证（只读）：account 1 行、positions 10 行、orders 14 行、trades 17 行、tick 2 行、kline 3 行，行数与实际数据逐一对上。新测试 10 条，修复前 8 条红 —— 另外 2 条正是 account / instrument 的回归保护，修复前后都该绿。
+
 - **周线（1w）的 preClose 不再恒为 0.0**（#166，@yucejade 报告）：大 QMT 对 `1w` 的每一根 bar 都返回 `preClose = 0.0`。实测（国金 2.1.19.0 / 0.3.19，只读）受影响的**只有 1w**：
 
   ```

--- a/qmt-trader/scripts/qmt.py
+++ b/qmt-trader/scripts/qmt.py
@@ -162,10 +162,36 @@ def _print_table(rows, headers=None):
             print(r)
 
 
-def _ok(data, table=False, headers=None):
+def _table_rows(data, table_key=None):
+    """The rows a --table render should show.
+
+    A command's payload is shaped for JSON, and that shape is usually a
+    wrapper: ``{"orders": [...], "count": 14}``. This used to hand the wrapper
+    itself to _print_table as a single row, so every header lookup missed and
+    the output was the header, the separator, and one line of spaces -- for
+    any amount of data. Five commands rendered that way (positions, orders,
+    trades, tick, kline).
+
+    ``table_key`` names the tabular list inside the wrapper. Without one:
+    a dict whose values are ALL dicts is keyed by something (tick is
+    ``{code: {...}}``) and its rows are the values; anything else is a single
+    flat record and stays one row -- account and instrument really are that,
+    and were correct before.
+    """
+    if table_key and isinstance(data, dict) and table_key in data:
+        data = data[table_key]
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict) and data and all(
+            isinstance(value, dict) for value in data.values()):
+        return list(data.values())
+    return [data]
+
+
+def _ok(data, table=False, headers=None, table_key=None):
     out = {"ok": True, "data": data, "ts": datetime.now().isoformat(timespec="seconds")}
     if table:
-        _print_table(data if isinstance(data, list) else [data], headers)
+        _print_table(_table_rows(data, table_key), headers)
     else:
         _print_json(out)
 
@@ -342,7 +368,7 @@ def cmd_positions(args):
         "total_market_value": round(sum(r.get("market_value") or 0 for r in rows), 2),
         "total_profit": round(sum(r.get("profit") or 0 for r in rows), 2),
     }
-    _ok({"positions": rows, "summary": summary}, table=args.table,
+    _ok({"positions": rows, "summary": summary}, table=args.table, table_key="positions",
         headers=["stock_code", "stock_name", "volume", "can_use_volume", "avg_price", "price", "market_value", "profit", "profit_pct"])
 
 
@@ -358,7 +384,7 @@ def cmd_orders(args):
     except Exception as e:
         _err("查询委托失败", detail=str(e), code="QUERY_FAIL")
     rows = [_order_to_dict(o) for o in (orders or [])]
-    _ok({"orders": rows, "count": len(rows)}, table=args.table,
+    _ok({"orders": rows, "count": len(rows)}, table=args.table, table_key="orders",
         headers=["stock_code", "order_type_name", "order_status_name", "order_volume", "traded_volume", "price", "trade_amount", "order_sysid", "cancelable"])
 
 
@@ -370,7 +396,7 @@ def cmd_trades(args):
     except Exception as e:
         _err("查询成交失败", detail=str(e), code="QUERY_FAIL")
     rows = [_trade_to_dict(t) for t in (trades or [])]
-    _ok({"trades": rows, "count": len(rows)}, table=args.table,
+    _ok({"trades": rows, "count": len(rows)}, table=args.table, table_key="trades",
         headers=["stock_code", "order_type_name", "traded_volume", "traded_price", "traded_at", "order_sysid"])
 
 
@@ -463,7 +489,8 @@ def cmd_kline(args):
         if len(closes) >= 60:
             stats["ma60"] = round(sum(closes[-60:]) / 60, 3)
     _ok({"code": args.code, "period": args.period, "bars": records, "stats": stats},
-        table=args.table, headers=["time", "open", "high", "low", "close", "volume"])
+        table=args.table, table_key="bars",
+        headers=["time", "open", "high", "low", "close", "volume"])
 
 
 def cmd_instrument(args):

--- a/tests/bigqmt_signal_trader/test_qmt_cli_table.py
+++ b/tests/bigqmt_signal_trader/test_qmt_cli_table.py
@@ -1,0 +1,278 @@
+# coding: utf-8
+"""--table printed headers and then one blank row, for any amount of data.
+
+Found while confirming #173 through the CLI: `qmt.py orders --table` drew the
+header row, the dashed separator, and a single line of spaces, while the same
+query without --table returned count=14 with fully populated dicts. So the
+data was fine and only the rendering was wrong.
+
+Cause: a command's payload is shaped for JSON, and that shape is usually a
+wrapper --
+
+    _ok({"orders": rows, "count": 14}, table=..., headers=[...])
+
+while _ok did::
+
+    _print_table(data if isinstance(data, list) else [data], headers)
+
+The wrapper is a dict, not a list, so it was wrapped again into ONE row, and
+every header lookup (`stock_code`, ...) missed on it and rendered "". One
+blank row, regardless of how many orders came back.
+
+Measured before fixing, against the live bridge: positions, orders, trades,
+tick and kline were all broken this way; account and instrument were correct,
+because those really do pass a single flat record and one row is the right
+answer. Both behaviours are pinned below -- the fix has to repair five
+commands without turning the other two into something else.
+
+tick is the odd shape: {code: {...}} keyed by code, so its rows are the
+values rather than a named list.
+"""
+
+import argparse
+import importlib.util
+import io
+import os
+import sys
+import types
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+QMT_PY = os.path.join(ROOT, "qmt-trader", "scripts", "qmt.py")
+
+
+def _load_qmt_cli():
+    spec = importlib.util.spec_from_file_location("qmt_cli_table", QMT_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TableTestBase(unittest.TestCase):
+    """Same isolation as test_qmt_cli_behavior: qmt.py reorders sys.path."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._saved_path = sys.path[:]
+        cls._saved_modules = set(sys.modules)
+        cls.cli = _load_qmt_cli()
+
+    @classmethod
+    def tearDownClass(cls):
+        sys.path[:] = cls._saved_path
+        for name in set(sys.modules) - cls._saved_modules:
+            mod = sys.modules.get(name)
+            f = getattr(mod, "__file__", None)
+            if f and "QMT" in f.upper():
+                sys.modules.pop(name, None)
+
+    def _render(self, fn, args):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            fn(args)
+        return buf.getvalue().splitlines()
+
+    def _body(self, lines):
+        """Rows below the header and the dashed separator."""
+        return [l for l in lines[2:] if l.strip()]
+
+
+def _order(**kw):
+    base = dict(
+        account_id="ACC", stock_code="601398.SH", order_type=23,
+        order_status=56, order_volume=100, traded_volume=100, price=8.08,
+        order_sysid="xt123", order_id=1, strategy_name="", order_remark="",
+        order_time=1788329111, trade_amount=808.0,
+    )
+    base.update(kw)
+    return types.SimpleNamespace(**base)
+
+
+def _position(**kw):
+    base = dict(
+        account_id="ACC", stock_code="600000.SH", stock_name="浦发银行",
+        volume=1000, can_use_volume=1000, avg_price=9.0, price=9.43,
+        market_value=9430.0, open_price=9.0, cost_price=9.0,
+        frozen_volume=0, yesterday_volume=1000, direction=48,
+        available_amount=1000, enable_amount=1000,
+    )
+    base.update(kw)
+    return types.SimpleNamespace(**base)
+
+
+def _trade(**kw):
+    base = dict(
+        account_id="ACC", stock_code="601398.SH", order_type=23,
+        order_sysid="xt123", order_id=1, trade_id="t1", traded_volume=100,
+        traded_price=8.08, traded_at="2026-09-04 10:00:00", order_remark="",
+    )
+    base.update(kw)
+    return types.SimpleNamespace(**base)
+
+
+class OrdersTableTest(TableTestBase):
+    def test_one_row_per_order_with_values(self):
+        trader = mock.Mock()
+        trader.query_stock_orders.return_value = [
+            _order(stock_code="601398.SH"), _order(stock_code="600000.SH")]
+        args = argparse.Namespace(account=None, table=True, cancelable=False,
+                                  strategy=None)
+        with mock.patch.object(self.cli, "_init", return_value=(trader, None, None)), \
+             mock.patch.object(self.cli, "_acc_or", return_value="ACC"):
+            lines = self._render(self.cli.cmd_orders, args)
+
+        rows = self._body(lines)
+        self.assertEqual(len(rows), 2)
+        self.assertIn("601398.SH", rows[0])
+        self.assertIn("600000.SH", rows[1])
+
+    def test_the_row_is_not_blank(self):
+        """The exact reported symptom: a row of nothing but spaces."""
+        trader = mock.Mock()
+        trader.query_stock_orders.return_value = [_order()]
+        args = argparse.Namespace(account=None, table=True, cancelable=False,
+                                  strategy=None)
+        with mock.patch.object(self.cli, "_init", return_value=(trader, None, None)), \
+             mock.patch.object(self.cli, "_acc_or", return_value="ACC"):
+            lines = self._render(self.cli.cmd_orders, args)
+
+        self.assertTrue(any(l.strip() for l in lines[2:]),
+                        "every data row was blank: %r" % (lines[2:],))
+
+
+class PositionsTableTest(TableTestBase):
+    def test_one_row_per_position(self):
+        trader = mock.Mock()
+        trader.query_stock_positions.return_value = [
+            _position(stock_code="600000.SH"), _position(stock_code="000001.SZ")]
+        args = argparse.Namespace(account=None, table=True, code=None)
+        with mock.patch.object(self.cli, "_init", return_value=(trader, None, None)), \
+             mock.patch.object(self.cli, "_acc_or", return_value="ACC"):
+            lines = self._render(self.cli.cmd_positions, args)
+
+        rows = self._body(lines)
+        self.assertEqual(len(rows), 2)
+        self.assertIn("600000.SH", rows[0])
+
+    def test_the_summary_is_not_rendered_as_a_row(self):
+        """positions ships {"positions": [...], "summary": {...}} -- only the
+        list is tabular; the summary must not become a phantom row."""
+        trader = mock.Mock()
+        trader.query_stock_positions.return_value = [_position()]
+        args = argparse.Namespace(account=None, table=True, code=None)
+        with mock.patch.object(self.cli, "_init", return_value=(trader, None, None)), \
+             mock.patch.object(self.cli, "_acc_or", return_value="ACC"):
+            lines = self._render(self.cli.cmd_positions, args)
+
+        self.assertEqual(len(self._body(lines)), 1)
+
+
+class TradesTableTest(TableTestBase):
+    def test_one_row_per_trade(self):
+        trader = mock.Mock()
+        trader.query_stock_trades.return_value = [_trade(), _trade(trade_id="t2")]
+        args = argparse.Namespace(account=None, table=True, strategy=None)
+        with mock.patch.object(self.cli, "_init", return_value=(trader, None, None)), \
+             mock.patch.object(self.cli, "_acc_or", return_value="ACC"):
+            lines = self._render(self.cli.cmd_trades, args)
+
+        self.assertEqual(len(self._body(lines)), 2)
+
+
+class TickTableTest(TableTestBase):
+    """{code: {...}} -- keyed by code, so the rows are the values."""
+
+    def test_one_row_per_code(self):
+        xtdata = mock.Mock()
+        xtdata.get_full_tick.return_value = {
+            "600000.SH": {"lastPrice": 9.43, "lastClose": 9.40, "volume": 100,
+                          "bidPrice": [9.42], "askPrice": [9.44]},
+            "000001.SZ": {"lastPrice": 11.89, "lastClose": 11.80, "volume": 200,
+                          "bidPrice": [11.88], "askPrice": [11.90]},
+        }
+        args = argparse.Namespace(codes=["600000.SH", "000001.SZ"], table=True)
+        with mock.patch.object(self.cli, "_init", return_value=(None, xtdata, None)):
+            lines = self._render(self.cli.cmd_tick, args)
+
+        rows = self._body(lines)
+        self.assertEqual(len(rows), 2)
+        self.assertTrue(any("600000.SH" in r for r in rows))
+        self.assertTrue(any("000001.SZ" in r for r in rows))
+
+
+class KlineTableTest(TableTestBase):
+    def test_one_row_per_bar(self):
+        import pandas
+
+        df = pandas.DataFrame(
+            {"open": [9.0, 9.1, 9.2], "high": [9.5, 9.6, 9.7],
+             "low": [8.9, 9.0, 9.1], "close": [9.4, 9.5, 9.6],
+             "volume": [100, 200, 300]},
+            index=["20260902", "20260903", "20260904"])
+        xtdata = mock.Mock()
+        xtdata.get_market_data_ex.return_value = {"600000.SH": df}
+        args = argparse.Namespace(
+            code="600000.SH", table=True, fields=None, period="1d",
+            start=None, end=None, count=3, dividend="none", no_fill=False)
+        with mock.patch.object(self.cli, "_init", return_value=(None, xtdata, None)):
+            lines = self._render(self.cli.cmd_kline, args)
+
+        self.assertEqual(len(self._body(lines)), 3)
+
+
+class SingleRecordCommandsStayOneRowTest(TableTestBase):
+    """account and instrument really do return one flat record.
+
+    These were CORRECT before the fix. Repairing the five broken commands
+    must not turn these into an empty table or explode their fields into
+    rows -- which is what a naive "always take the values" rule would do.
+    """
+
+    def test_account_is_one_row_with_values(self):
+        trader = mock.Mock()
+        trader.query_stock_asset.return_value = types.SimpleNamespace(
+            account_id="ACC", cash=109904.38, available_cash=109904.38,
+            frozen_cash=0.0, total_asset=120224.38, market_value=10320.0)
+        args = argparse.Namespace(account=None, table=True)
+        with mock.patch.object(self.cli, "_init", return_value=(trader, None, None)), \
+             mock.patch.object(self.cli, "_acc_or", return_value="ACC"):
+            lines = self._render(self.cli.cmd_account, args)
+
+        rows = self._body(lines)
+        self.assertEqual(len(rows), 1)
+        self.assertIn("120224.38", rows[0])
+
+    def test_instrument_is_one_row(self):
+        xtdata = mock.Mock()
+        xtdata.get_instrument_detail.return_value = {
+            "ExchangeID": "SH", "InstrumentID": "600000",
+            "InstrumentName": "浦发银行", "PriceTick": 0.01}
+        args = argparse.Namespace(code="600000.SH", table=True)
+        with mock.patch.object(self.cli, "_init", return_value=(None, xtdata, None)):
+            lines = self._render(self.cli.cmd_instrument, args)
+
+        rows = self._body(lines)
+        self.assertEqual(len(rows), 1)
+        self.assertIn("600000", rows[0])
+
+
+class EmptyResultTest(TableTestBase):
+    def test_no_orders_says_empty_rather_than_drawing_a_blank_row(self):
+        trader = mock.Mock()
+        trader.query_stock_orders.return_value = []
+        args = argparse.Namespace(account=None, table=True, cancelable=False,
+                                  strategy=None)
+        with mock.patch.object(self.cli, "_init", return_value=(trader, None, None)), \
+             mock.patch.object(self.cli, "_acc_or", return_value="ACC"):
+            lines = self._render(self.cli.cmd_orders, args)
+
+        self.assertEqual(lines, ["(empty)"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`qmt.py orders --table` 画出表头、分隔线，然后**一行纯空格** —— 不管返回多少数据。同一个查询不加 `--table` 是好的（`count=14`，字段齐全），所以数据没问题，坏的只有渲染。

发现于用 CLI 确认 #173 的时候，但**跟它无关**：把 `qmt.py` 退回那之前的提交照样复现。

## 原因

子命令交给 `_ok` 的是**为 JSON 设计的形状**，而那通常是个包装：

```python
_ok({"orders": rows, "count": 14}, table=..., headers=[...])
```

而 `_ok` 里是：

```python
_print_table(data if isinstance(data, list) else [data], headers)
```

包装是 dict 不是 list，于是被**再包一层当成一行**，每个表头（`stock_code` …）在它身上都查不到，全渲染成 `""`。

## 修之前先量了一遍哪些坏了

对着实盘桥逐个跑：

| 子命令 | 修复前 |
|---|---|
| `positions` | ✗ 一行空白 |
| `orders` | ✗ 一行空白 |
| `trades` | ✗ 一行空白 |
| `tick` | ✗ 一行空白 |
| `kline` | ✗ 一行空白 |
| `account` | ✓ **本来就对** |
| `instrument` | ✓ **本来就对** |

`account` / `instrument` 确实只返回**一条扁平记录**，一行才是正确答案。所以修法**不能是「永远取 values」** —— 那会修好五个、弄坏两个。

## 改法

`_ok` 多一个 `table_key`，指明包装里哪个键是表格数据（`positions` / `orders` / `trades` / `bars`）。没给 `table_key` 时：

- **值全是 dict** 的字典 → 按「按键索引」处理，行取 values（`tick` 是 `{code: {...}}`）
- 其余 → 仍当作单条扁平记录，一行

## 验证

**实盘只读**，行数与实际数据逐一对上：

```
account     --table   1 行
positions   --table  10 行
orders      --table  14 行
trades      --table  17 行
tick        --table   2 行   (两个代码)
kline       --table   3 行   (count=3)
```

内容也是真的，不是占位：

```
stock_code  order_type_name  order_status_name  order_volume  traded_volume  price  trade_amount
600722.SH   BUY              SUCCEEDED          600           600            19.06  10397.999999999998
002297.SZ   SELL             SUCCEEDED          400           400            21.0   8528.0
```

**门禁 1**：`1476 passed`（+10 新用例），110 个测试文件 = 110 个模块被收集。
**门禁 2**：只读实盘门禁 10/10 PASS。
**新测试确实会红**：修复前 10 条里 **8 条失败** —— 另外 2 条正是 `account` / `instrument` 的回归保护，修复前后都该绿。

## 没验证到的

只覆盖了带 `--table` 且有 `headers` 的子命令。`option-greeks` / `snapshot` / `rpc` 也接受 `--table`，但它们不传 `headers`、形状各异，这次没有逐个实测 —— 它们走的是「单条扁平记录」那条老路径，行为与修复前一致。

顺带一个**没有改**的观感问题：`trade_amount` 在表里印成 `10397.999999999998`（柜台给的就是这个 float）。JSON 输出保持原值是对的；表格要不要为了好看做四舍五入，是另一个决定，没在这里顺手做。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
