### PR TITLE
回复入队即唤醒 router 线程：交易查询 1500ms -> 605ms (#104)

### DIFF
--- a/src/bigqmt_signal_trader/transports/zmq_transport.py
+++ b/src/bigqmt_signal_trader/transports/zmq_transport.py
@@ -143,6 +143,17 @@ class ZmqTransport(RpcTransport):
         self._router_thread = None
         self._actual_bind_address = None  # set after start_receiving()
         self._reply_residency = {"count": 0, "sum_ms": 0.0, "max_ms": 0.0}
+        # Wake pipe: a reply produced on the adjust thread is queued, and the
+        # router thread only drains the queue at the top of its loop -- after a
+        # recv that blocks up to RCVTIMEO. Measured residency was 1149ms avg on
+        # a 1s RCVTIMEO, which is most of a 1500ms trade query (#104). Signalling
+        # here lets the loop come round at once instead of polling, so idle costs
+        # nothing -- the router thread shares the GIL with QMT's strategy thread
+        # and must not spin.
+        self._wake_endpoint = "inproc://bigqmt-wake-%d" % id(self)
+        self._wake_recv = None
+        self._wake_send = None
+        self._wake_lock = threading.Lock()
         self._pending_identities = {}  # request_id -> client identity bytes
         self._identity_lock = threading.Lock()
         self._response_queue = queue.Queue()
@@ -199,6 +210,43 @@ class ZmqTransport(RpcTransport):
         return self._zmq, self._ctx
 
     # -- server side ------------------------------------------------------
+    def _open_wake_pipe(self):
+        """PULL end for the router loop, PUSH end for whoever queues a reply.
+
+        inproc, so it never touches the network and needs no port. Failure is
+        non-fatal: without it the loop still drains on its own timeout, just
+        slowly -- which is exactly the behaviour this replaces.
+        """
+        try:
+            zmq, ctx = self._ensure_zmq()
+            recv = ctx.socket(zmq.PULL)
+            recv.setsockopt(zmq.LINGER, 0)
+            recv.bind(self._wake_endpoint)
+            self._wake_recv = recv
+        except Exception as exc:
+            print("%s zmq wake pipe unavailable: %s" % (self.print_prefix, exc))
+            self._wake_recv = None
+
+    def _signal_wake(self):
+        """Nudge the router loop. Called from the adjust thread.
+
+        zmq sockets are not thread safe, so the PUSH end is created once here
+        and used only under the lock; the PULL end belongs to the router thread.
+        """
+        if self._wake_recv is None:
+            return
+        try:
+            with self._wake_lock:
+                if self._wake_send is None:
+                    zmq, ctx = self._ensure_zmq()
+                    send = ctx.socket(zmq.PUSH)
+                    send.setsockopt(zmq.LINGER, 0)
+                    send.connect(self._wake_endpoint)
+                    self._wake_send = send
+                self._wake_send.send(b"1", self._zmq.DONTWAIT)
+        except Exception:
+            pass          # a missed nudge costs latency, never correctness
+
     def _bind_configured_address(self):
         """Bind exactly one configured address and reject duplicate servers."""
         zmq, ctx = self._ensure_zmq()
@@ -271,6 +319,7 @@ class ZmqTransport(RpcTransport):
                 % (self.print_prefix, bound)
             )
             return
+        self._open_wake_pipe()
         self._router_thread = threading.Thread(
             target=self._router_loop, name="bigqmt-zmq-rpc", daemon=True
         )
@@ -285,12 +334,39 @@ class ZmqTransport(RpcTransport):
         )
 
     def _router_loop(self):
+        poller = None
+        if self._wake_recv is not None:
+            try:
+                poller = self._zmq.Poller()
+                poller.register(self._router, self._zmq.POLLIN)
+                poller.register(self._wake_recv, self._zmq.POLLIN)
+            except Exception:
+                poller = None
+        timeout_ms = int(self.recv_timeout_seconds * 1000)
         try:
             while self._running:
                 self._drain_response_queue()
-                request = self._receive_request()
-                if request is not None:
-                    self._deliver_request(request)
+                if poller is None:
+                    request = self._receive_request()
+                    if request is not None:
+                        self._deliver_request(request)
+                    continue
+                # Waiting on both ends means a reply queued by the adjust
+                # thread wakes this loop immediately instead of after RCVTIMEO.
+                try:
+                    events = dict(poller.poll(timeout=timeout_ms))
+                except Exception:
+                    events = {}
+                if self._wake_recv in events:
+                    try:
+                        while True:
+                            self._wake_recv.recv(self._zmq.DONTWAIT)
+                    except Exception:
+                        pass
+                if self._router in events:
+                    request = self._receive_request(flags=self._zmq.NOBLOCK)
+                    if request is not None:
+                        self._deliver_request(request)
         finally:
             # Close the ROUTER socket on the thread that owns it. On Windows,
             # closing a ZMQ socket from a different thread trips a signaler
@@ -424,6 +500,7 @@ class ZmqTransport(RpcTransport):
         # loop -- after a recv_multipart that blocks up to RCVTIMEO. That
         # residency, not the handler, is where the round trip goes (#104).
         self._response_queue.put((identity, payload, time.perf_counter()))
+        self._signal_wake()
         if self._response_queue.qsize() > self._max_queued_responses:
             try:
                 self._response_queue.get_nowait()

--- a/tests/bigqmt_signal_trader/test_zmq_reply_wakeup.py
+++ b/tests/bigqmt_signal_trader/test_zmq_reply_wakeup.py
@@ -1,0 +1,168 @@
+# coding: utf-8
+"""A finished reply must not wait for the router's receive timeout (#104).
+
+Handlers for trade queries run on the adjust thread, because
+get_trade_detail_data returns empty anywhere else. send_response therefore sees
+a thread that is not the router thread and queues the reply -- and the queue is
+only drained at the top of the router loop, after a recv that blocks up to
+RCVTIMEO (1s).
+
+Measured on the live bridge before this change:
+
+    get_positions   wait 201ms | handle 1.0ms | return 1300ms | total 1500ms
+    reply residency 1149ms average over 10 calls
+
+So the handler cost 1ms and the reply then sat for more than a second. ping did
+not show it at all -- ping is handled on the router thread itself and its reply
+goes straight out -- which is why an earlier ping-only experiment made this look
+refuted.
+
+The fix signals an inproc wake pipe when a reply is queued, and the router loop
+waits on the router socket and that pipe together. After it:
+
+    get_positions   1500ms -> 605ms      reply residency 1149ms -> 117ms
+
+The trade-off is real and was accepted deliberately: ping went 297ms -> 404ms,
+because the loop now does poll + non-blocking recv instead of one blocking recv,
+and that extra work lands on the thread ping is answered from.
+"""
+
+import os
+import sys
+import threading
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.transports import zmq_transport as zt
+
+
+def _transport():
+    return zt.ZmqTransport(account_id="8886800503",
+                           bind_address="tcp://127.0.0.1:15999")
+
+
+class SignalIsSafeTest(unittest.TestCase):
+    """A missed nudge costs latency; a raised one costs the bridge."""
+
+    def test_signalling_without_a_pipe_is_a_no_op(self):
+        transport = _transport()
+        transport._wake_recv = None
+
+        transport._signal_wake()          # must not raise
+
+    def test_a_broken_pipe_is_swallowed(self):
+        transport = _transport()
+
+        class Angry(object):
+            def send(self, *a, **k):
+                raise RuntimeError("socket is gone")
+
+        transport._wake_recv = object()
+        transport._wake_send = Angry()
+
+        transport._signal_wake()          # must not raise
+
+    def test_the_endpoint_is_per_instance(self):
+        """Two bridges in one process must not fight over one inproc name."""
+        a, b = _transport(), _transport()
+
+        self.assertNotEqual(a._wake_endpoint, b._wake_endpoint)
+        self.assertTrue(a._wake_endpoint.startswith("inproc://"))
+
+
+class QueueingSignalsTest(unittest.TestCase):
+    def test_queueing_a_reply_nudges_the_loop(self):
+        """Without this the reply waits out RCVTIMEO -- the whole bug."""
+        transport = _transport()
+        transport._wake_recv = None
+        nudges = []
+        transport._signal_wake = lambda: nudges.append(1)
+
+        transport._queue_response(b"peer", b"payload", reason="off-thread")
+
+        self.assertEqual(len(nudges), 1)
+
+    def test_the_reply_is_still_queued(self):
+        transport = _transport()
+        transport._wake_recv = None
+        transport._signal_wake = lambda: None
+
+        transport._queue_response(b"peer", b"payload", reason="off-thread")
+
+        self.assertEqual(transport._response_queue.qsize(), 1)
+
+    def test_the_queued_entry_carries_a_timestamp(self):
+        """Residency is what made this measurable rather than arguable."""
+        transport = _transport()
+        transport._wake_recv = None
+        transport._signal_wake = lambda: None
+
+        transport._queue_response(b"peer", b"payload", reason="off-thread")
+        identity, payload, queued_at = transport._response_queue.get_nowait()
+
+        self.assertEqual(identity, b"peer")
+        self.assertEqual(payload, b"payload")
+        self.assertIsInstance(queued_at, float)
+
+
+class ResidencyStatsTest(unittest.TestCase):
+    def test_it_starts_empty(self):
+        stats = _transport().reply_residency_stats()
+
+        self.assertEqual(stats["count"], 0)
+        self.assertEqual(stats["avg_ms"], 0.0)
+
+    def test_it_averages_what_it_was_told(self):
+        transport = _transport()
+
+        transport._note_reply_residency(100.0)
+        transport._note_reply_residency(300.0)
+        stats = transport.reply_residency_stats()
+
+        self.assertEqual(stats["count"], 2)
+        self.assertEqual(stats["avg_ms"], 200.0)
+        self.assertEqual(stats["max_ms"], 300.0)
+
+    def test_draining_records_residency(self):
+        transport = _transport()
+        transport._wake_recv = None
+        transport._signal_wake = lambda: None
+        sent = []
+
+        class Router(object):
+            def send_multipart(self, frames):
+                sent.append(frames)
+
+        transport._router = Router()
+        transport._queue_response(b"peer", b"payload", reason="off-thread")
+
+        transport._drain_response_queue()
+
+        self.assertEqual(len(sent), 1)
+        self.assertEqual(transport.reply_residency_stats()["count"], 1)
+
+
+class LoopStillWorksWithoutAPipeTest(unittest.TestCase):
+    """If the inproc pipe cannot be opened the loop must still serve requests,
+    just at the old latency -- degrading, never failing."""
+
+    def test_open_wake_pipe_tolerates_failure(self):
+        transport = _transport()
+
+        def boom():
+            raise RuntimeError("no inproc today")
+
+        transport._ensure_zmq = boom
+        try:
+            transport._open_wake_pipe()
+        except Exception as exc:
+            self.fail("must not propagate: %r" % (exc,))
+
+        self.assertIsNone(transport._wake_recv)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

交易查询端到端 **1500ms**。用两侧墙钟时间戳分解（同机，时钟可直接比）：

```
get_positions   等待 201ms | 处理 1.0ms | 回程 1300ms | 总 1500ms
query_orders    等待 201ms | 处理 1.0ms | 回程 1306ms | 总 1499ms
get_asset       等待 201ms | 处理 0.0ms | 回程 1308ms | 总 1500ms
```

`get_trade_detail_data` 本身只要 **1 毫秒**。**1300ms 全在回复构造完之后。**

## 原因

交易查询必须在 adjust 线程上跑（`get_trade_detail_data` 离开主策略线程返回空）。于是 `send_response` 看到「当前线程不是 router 线程」→ **回复入队**；而这个队列**只在 router 循环顶部**被排空，那之前隔着一个最多 `RCVTIMEO`（1 秒）的阻塞 `recv`。

实测滞留：**10 次调用平均 1149ms**。

`ping` 完全看不到这个问题 —— 它在 router 线程上就地处理、回复直接发出。我一开始只用 ping 做实验，据此以为这个机制被证伪了。**计数验证**：10 次交易查询 + 10 次 ping，入队回复正好 **10** 条。

## 改动

一条 inproc 唤醒管道：回复入队时发一个字节，router 循环同时等 router socket 和这条管道。

- 唤醒失败被吞掉 —— **漏一次唤醒损失延迟，不损失正确性**
- 管道开不起来就保留原来的阻塞路径，降级而不是失败
- inproc，不占端口、不走网络；端点带实例 id，同进程两座桥不会打架

## 实盘结果

| | 改前 | 改后 |
|---|---|---|
| `get_positions` | 1500ms | **605ms** |
| `query_orders` | 1499ms | **607ms** |
| `get_asset` | 1500ms | **608ms** |
| 回复入队滞留 | 1149ms | **117ms** |

## 需要评审时特别看的：一个真实的回归

**`ping` 从 297ms 变成 404ms**（p50，n=40）。

原因是 router 循环从「一次阻塞 recv」变成「poll + 非阻塞 recv」，每轮多的字节码落在**正是 ping 被应答的那条线程**上，而它和 QMT 策略线程共享 GIL。

**这是有意接受的取舍**：交易路径省 ~900ms，ping 多花 ~107ms；而绝大多数只读方法本来就走 FormulaServer 直连（0.2ms），不经过这条路。但它是真回归，不是噪声，所以写在这里而不是埋在提交信息里。

## 顺带修掉的一个 bug

`_open_wake_pipe` 里 `_ensure_zmq()` 原本在 `try` **外面** —— 它失败会一路抛出 `start_receiving`，**把整座桥带下去**，而不是降级回老路径。是新测试抓到的。

## 验证

- **1476 通过，110/110 模块收集**
- 10 个新测试（唤醒安全性、入队即唤醒、滞留统计、无管道时降级）
- QMT 自带 xtquant 预检通过
- 已部署实盘并 reload，桥正常（上面那组数字就是改后实测）
