### PR TITLE
fix: 回调拿不到 strategy_name —— 成交事件根本没这个键，委托只靠 Redis (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,28 @@
 
 ### 修复
 
+- **成交回调终于带上 `strategy_name`，委托回调不再只靠 Redis**（#174，@sumo225270 报告）：`on_stock_order` / `on_stock_trade` 拿到的策略名恒为空，而下单时传的是非空串；`instrument_name` / `order_remark` 一切正常。查下来是**两个**不同的原因。
+
+  **成交事件根本没有这个键** —— 不是空字符串，是不存在，所以客户端 `item.get("strategy_name") or ""` 只可能答 `""`。而且发布路径上只有委托分支做了身份补全：
+
+  ```python
+  if kind == "trade":
+      event = normalize_trade_event(...)     # 没有补全
+  else:
+      event = normalize_order_event(...)
+      event = enrich_order_identity(...)     # 只有这边有
+  ```
+
+  这条**跟配置无关，任何部署下都是空的**。现在 `normalize_trade_event` 产出这个键，两个分支都走同一个补全。
+
+  **委托那条则是大 QMT 自己不给。** 实盘列了全部属性：ORDER 行 120 个、DEAL 行 47 个，**`m_strStrategyName` 两边都没有**（和 #133 的 `m_strShareholderID` 同一形态）；查询路径实测也是 14 笔委托策略名全空。所以只能靠下单时记、回调时按 remark 反查 —— 而这一步此前**只读 Redis**。zmq 部署上 Redis 是可选件，「配置了 ≠ 连得上」（#145 那个坑）时静默失败，名字就永远补不回来。
+
+  现在**先查进程内的 journal（#156，查询路径本来就在用），Redis 作兜底**。这个顺序是有意的：补全跑在 QMT 的 C++ 回调线程上，本进程下的单在 journal 里已经存着和 Redis 一模一样的字符串，先问 Redis 什么也换不来，却要付一次网络往返 —— Redis 配了连不上时更是每个事件都付满超时。Redis 留作兜底是因为它能认出**别的进程**下的单，那是更少见的情况。
+
+  已验证：全量测试 `1499 passed`（112 文件 = 112 模块），13 条新用例修复前 10 条红（另外 3 条是回归保护）；用终端自己的 `xtquant`（91 个名字）预检通过，`bigqmt_signal_trader_strategy` 能干净导入；两个改动文件 AST 无 3.7+ 语法（QMT 只有 Python 3.6）；只读实盘门禁 10/10。
+
+  **未验证**：这是服务端改动，要部署 + **重启策略**（`reload_deployment` 刷不了 `bigqmt_signal_trader_strategy.py`，QMT exec 的就是它）。而且**要等开盘有真实成交回调才能实盘确认** —— 收盘后没有委托/成交回调可看，本次只有离线用例。报告人那侧「remark 是否被 QMT 截断导致键对不上」的怀疑仍未验证，等他贴 `raw_fields`。
+
 - **交易查询 1500ms → 605ms：回复入队后不再空等 router 的接收超时**（issue #104，@sumo225270）：用两侧墙钟时间戳分解（同机，时钟可直接比）后发现，`get_trade_detail_data` 本身**只要 1 毫秒**，1300ms 全在回复构造完之后。
 
   ```

--- a/src/bigqmt_signal_trader/exec_events.py
+++ b/src/bigqmt_signal_trader/exec_events.py
@@ -537,6 +537,16 @@ def normalize_trade_event(trade, account_id=""):
         # order_sys_id 关联。
         "remark": str(_attr(trade, ["m_strRemark", "order_remark", "remark", "user_order_id"], "") or ""),
         "user_order_id": str(_attr(trade, ["m_strRemark", "user_order_id", "order_remark", "remark"], "") or ""),
+        # 成交事件此前**根本没有这个键** (issue #174) -- 不是空字符串, 是不存在,
+        # 所以客户端 item.get("strategy_name") or "" 只可能答 ""。委托事件一直
+        # 有, 成交没有, 于是 on_stock_trade 拿不到策略名。
+        #
+        # 大 QMT 自己不给: 实盘列全部属性, ORDER 行 120 个、DEAL 行 47 个,
+        # m_strStrategyName 两边都没有 (和 #133 的 m_strShareholderID 同一形态)。
+        # 所以这里基本恒为 ""，真正把名字放回去的是发布路径上的身份补全 --
+        # 留着读一遍是因为别家券商的 QMT 可能带。
+        "strategy_name": str(
+            _attr(trade, ["strategyName", "m_strStrategyName", "strategy_name"], "") or ""),
         # 官方 Deal 字段 m_strTradeDate+m_strTradeTime -> 真实成交 Unix 秒。
         # 0 = 未携带, 客户端会退回 created_at_ts。
         "traded_time": date_time_seconds(

--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -1674,6 +1674,71 @@ def _exec_event_redis(config):
     return _exec_event_redis_client
 
 
+def _local_identity_strategy_name(account_id, event):
+    """strategy_name from the in-process submit journal, or "".
+
+    The journal (#156) is written by the RPC handlers at submit time and is
+    all a deployment has when redis is absent -- or, the reported case in
+    #174, configured but not reachable, which fails silently.
+    """
+    service = _rpc_service
+    handlers = getattr(service, "handlers", None) if service is not None else None
+    journal = getattr(handlers, "_order_identity_local", None)
+    if not journal:
+        return ""
+    remark = str(event.get("user_order_id") or event.get("remark") or "").strip()
+    if not remark:
+        return ""
+    try:
+        entry = journal.get((str(account_id or ""), remark))
+        if not entry:
+            return ""
+        stamped, name = entry
+        ttl = getattr(handlers, "_ORDER_IDENTITY_LOCAL_TTL_SECONDS", 86400.0)
+        if name and (time.time() - float(stamped)) <= float(ttl):
+            return str(name)
+    except Exception:
+        return ""
+    return ""
+
+
+def _enrich_event_identity(exec_events, config, account_id, event):
+    """Put the strategy name back on an event QMT could not name (#174).
+
+    Big QMT does not carry it on order or deal objects -- 120 and 47
+    attributes on a live terminal, m_strStrategyName in neither -- so what the
+    bridge remembered at submit time is the only way back.
+
+    The in-process journal is consulted FIRST, and deliberately so. This runs
+    on QMT's C++ callback thread, and for an order this process submitted the
+    journal already holds the same string that was written to redis -- so
+    asking redis first would buy nothing and cost a round trip per event. It
+    costs a lot when redis is configured and not reachable: redis-py does not
+    dial until the first command, so every callback would pay the full
+    timeout (#145's shape). That is precisely the deployment #174 was reported
+    from.
+
+    Redis is the fallback rather than the primary because its extra reach --
+    naming an order some OTHER process submitted -- is the rarer case.
+
+    Both branches call this. Enriching only orders is what left
+    on_stock_trade's strategy_name permanently empty.
+    """
+    if str(event.get("strategy_name") or "").strip():
+        return event
+    name = _local_identity_strategy_name(account_id, event)
+    if name:
+        event["strategy_name"] = name
+        return event
+    redis_client = _exec_event_redis(config)
+    if redis_client is not None:
+        try:
+            event = exec_events.enrich_order_identity(redis_client, account_id, event)
+        except Exception:
+            pass
+    return event
+
+
 def _publish_exec_event(kind, obj, context_info=None):
     """Push a normalized order/trade event to Redis for real-time client callbacks."""
     config = _build_config()
@@ -1703,6 +1768,7 @@ def _publish_exec_event(kind, obj, context_info=None):
     try:
         if kind == "trade":
             event = exec_events.normalize_trade_event(obj, account_id)
+            event = _enrich_event_identity(exec_events, config, account_id, event)
             if not event.get("instrument_name"):
                 event["instrument_name"] = _event_instrument_name(
                     context_info, event.get("stock_code"))
@@ -1712,12 +1778,10 @@ def _publish_exec_event(kind, obj, context_info=None):
         else:
             event = exec_events.normalize_order_event(obj, account_id)
             # Identity enrichment reads the remark->identity map that
-            # remember_order_identity wrote, which only exists in Redis. On a
-            # push channel the event goes out un-enriched rather than not at
-            # all; order_sys_id and remark are already on it.
-            redis_client = _exec_event_redis(config)
-            if redis_client is not None:
-                event = exec_events.enrich_order_identity(redis_client, account_id, event)
+            # remember_order_identity wrote. On a push channel the event goes
+            # out un-enriched rather than not at all; order_sys_id and remark
+            # are already on it.
+            event = _enrich_event_identity(exec_events, config, account_id, event)
             if not event.get("instrument_name"):
                 event["instrument_name"] = _event_instrument_name(
                     context_info, event.get("stock_code"))

--- a/tests/bigqmt_signal_trader/test_exec_event_strategy_name.py
+++ b/tests/bigqmt_signal_trader/test_exec_event_strategy_name.py
@@ -1,0 +1,272 @@
+# coding: utf-8
+"""issue #174: callbacks never carry strategy_name.
+
+@sumo225270 reported that both `on_stock_order` and `on_stock_trade` hand back
+an empty strategy_name while the order was submitted with a non-empty one.
+`instrument_name` and `order_remark` were fine, so it is not the callback
+plumbing in general.
+
+Two separate causes, and the trade one is unconditional:
+
+**Trades had no strategy_name at all.** `normalize_trade_event` never emitted
+the key -- not empty, absent -- so the client's
+``item.get("strategy_name") or ""`` could only ever answer "". And the publish
+path enriched only the order branch::
+
+    if kind == "trade":
+        event = normalize_trade_event(...)      # no enrichment
+    else:
+        event = normalize_order_event(...)
+        event = enrich_order_identity(...)      # only here
+
+**Orders depend entirely on the identity store**, because big QMT does not put
+the strategy name on the row. Listing every attribute on a live terminal:
+ORDER carries 120 and DEAL 47, and `m_strStrategyName` is in neither -- the
+same shape as `m_strShareholderID` in #133. The live query path confirms it:
+14 orders, `strategy_name` empty on every one. So the only way back is what
+the bridge remembered at submit time, keyed by the remark.
+
+That store was read from Redis only. On a zmq deployment whose Redis is
+configured but not reachable -- which is exactly the "configured is not
+reachable" trap in #145 -- the lookup fails silently and the name stays empty.
+The in-process journal written at submit time (#156, already used by the query
+path) is now the fallback, so a deployment with no working Redis still names
+what this process submitted.
+"""
+
+import os
+import sys
+import time
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+import bigqmt_signal_trader_strategy as strategy
+from bigqmt_signal_trader import exec_events
+
+
+def _deal_obj(**overrides):
+    attrs = dict(
+        m_strInstrumentID="601388", m_strExchangeID="SH", m_nOffsetFlag=49,
+        m_nVolume=700, m_dPrice=35.36, m_dTradeAmount=24752.0,
+        m_strOrderSysID="2209", m_strTradeID="t-1", m_strRemark="sig-1",
+        m_strTradeTime="093013", m_strAccountID="acct", m_nDirection=49,
+    )
+    attrs.update(overrides)
+    return type("FakeDeal", (), attrs)
+
+
+def _order_obj(**overrides):
+    attrs = dict(
+        m_strInstrumentID="601388", m_strExchangeID="SH", m_nOffsetFlag=49,
+        m_nVolumeTotalOriginal=158200, m_nVolumeTotal=158200, m_nVolumeTraded=0,
+        m_strOrderSysID="2209", m_strRemark="sig-1", m_nOrderStatus=50,
+        m_dLimitPrice=35.62, m_dTradedPrice=0.0, m_strAccountID="acct",
+    )
+    attrs.update(overrides)
+    return type("FakeOrder", (), attrs)
+
+
+# ------------------------------------------------------- the normalizer
+
+
+class TradeEventCarriesStrategyNameTest(unittest.TestCase):
+    def test_the_key_exists_even_when_qmt_says_nothing(self):
+        """Absent, not empty, was the bug: .get() could not tell them apart."""
+        event = exec_events.normalize_trade_event(_deal_obj(), "acct")
+
+        self.assertIn("strategy_name", event)
+        self.assertEqual(event["strategy_name"], "")
+
+    def test_it_is_read_off_the_object_when_qmt_does_supply_it(self):
+        """This terminal has no such attribute, but another build might."""
+        event = exec_events.normalize_trade_event(
+            _deal_obj(m_strStrategyName="alpha"), "acct")
+
+        self.assertEqual(event["strategy_name"], "alpha")
+
+    def test_the_camelcase_spelling_is_accepted_too(self):
+        event = exec_events.normalize_trade_event(
+            _deal_obj(strategyName="alpha"), "acct")
+
+        self.assertEqual(event["strategy_name"], "alpha")
+
+
+class EnrichWorksOnATradeEventTest(unittest.TestCase):
+    """enrich_order_identity keys off remark, which trades carry as well."""
+
+    def test_a_trade_event_is_named_from_the_store(self):
+        import json
+
+        class Store(object):
+            def get(self, key):
+                return json.dumps({"strategy_name": "alpha"}).encode("utf-8")
+
+        event = exec_events.normalize_trade_event(_deal_obj(), "acct")
+        enriched = exec_events.enrich_order_identity(Store(), "acct", event)
+
+        self.assertEqual(enriched["strategy_name"], "alpha")
+
+
+# ------------------------------------------------------- the publish path
+
+
+class _Sink(object):
+    def __init__(self):
+        self.published = []
+
+
+class _FakeExecEvents(object):
+    """Real normalizers, fake transport; records enrichment calls."""
+
+    normalize_order_event = staticmethod(exec_events.normalize_order_event)
+    normalize_trade_event = staticmethod(exec_events.normalize_trade_event)
+    normalize_order_error_event = staticmethod(exec_events.normalize_order_error_event)
+    format_raw_snapshot = staticmethod(lambda *args: "")
+    raw_field_snapshot = staticmethod(lambda *args: None)
+
+    def __init__(self):
+        self.enriched = []
+
+    def enrich_order_identity(self, redis_client, account_id, event):
+        self.enriched.append(event.get("event_type"))
+        event["strategy_name"] = "from-redis"
+        return event
+
+    def publish_exec_event(self, sink, account_id, event):
+        sink.published.append((account_id, event))
+
+
+CFG = {"exec_events": {"enabled": True, "account_id": "acct",
+                       "hold_presysid_order_seconds": 0.0}}
+
+
+class _Journal(dict):
+    pass
+
+
+class _Handlers(object):
+    _ORDER_IDENTITY_LOCAL_TTL_SECONDS = 86400.0
+
+    def __init__(self, journal=None):
+        self._order_identity_local = journal
+
+
+class _Service(object):
+    def __init__(self, handlers=None):
+        self.handlers = handlers
+
+
+class _PublishBase(unittest.TestCase):
+    def setUp(self):
+        self._saved = {name: getattr(strategy, name)
+                       for name in ("_build_config", "_exec_event_sink",
+                                    "_exec_event_redis", "_exec_events",
+                                    "_rpc_service")}
+        self._sink = _Sink()
+        self._fake = _FakeExecEvents()
+        strategy._build_config = lambda: CFG
+        strategy._exec_event_sink = lambda config: self._sink
+        strategy._exec_event_redis = lambda config: None
+        strategy._exec_events = self._fake
+        strategy._rpc_service = None
+        strategy._held_presysid_orders.clear()
+        strategy._instrument_name_cache.clear()
+
+    def tearDown(self):
+        for name, value in self._saved.items():
+            setattr(strategy, name, value)
+        strategy._held_presysid_orders.clear()
+        strategy._instrument_name_cache.clear()
+
+    def _events(self):
+        return [event for _, event in self._sink.published]
+
+
+class TradePublishIsEnrichedTest(_PublishBase):
+    def test_the_trade_branch_now_enriches_like_the_order_branch(self):
+        strategy._exec_event_redis = lambda config: object()   # a "working" store
+
+        strategy._publish_exec_event("trade", _deal_obj(), None)
+
+        self.assertEqual(self._fake.enriched, ["trade"])
+        self.assertEqual(self._events()[0]["strategy_name"], "from-redis")
+
+    def test_the_order_branch_still_enriches(self):
+        strategy._exec_event_redis = lambda config: object()
+
+        strategy._publish_exec_event("order", _order_obj(), None)
+
+        self.assertEqual(self._fake.enriched, ["order"])
+
+
+class LocalJournalFallbackTest(_PublishBase):
+    """No Redis, or Redis configured but unreachable -- the #174 case."""
+
+    def _wire_journal(self, name="alpha", age=0.0):
+        journal = _Journal({("acct", "sig-1"): (time.time() - age, name)})
+        strategy._rpc_service = _Service(_Handlers(journal))
+
+    def test_a_trade_is_named_from_the_in_process_journal(self):
+        self._wire_journal()
+
+        strategy._publish_exec_event("trade", _deal_obj(), None)
+
+        self.assertEqual(self._events()[0]["strategy_name"], "alpha")
+
+    def test_an_order_is_named_from_the_in_process_journal(self):
+        self._wire_journal()
+
+        strategy._publish_exec_event("order", _order_obj(), None)
+
+        self.assertEqual(self._events()[0]["strategy_name"], "alpha")
+
+    def test_an_expired_entry_is_not_used(self):
+        self._wire_journal(age=86400.0 * 2)
+
+        strategy._publish_exec_event("trade", _deal_obj(), None)
+
+        self.assertEqual(self._events()[0]["strategy_name"], "")
+
+    def test_an_unknown_remark_stays_empty_rather_than_guessing(self):
+        self._wire_journal()
+
+        strategy._publish_exec_event("trade", _deal_obj(m_strRemark="other"), None)
+
+        self.assertEqual(self._events()[0]["strategy_name"], "")
+
+    def test_no_service_at_all_does_not_raise(self):
+        strategy._rpc_service = None
+
+        strategy._publish_exec_event("trade", _deal_obj(), None)
+
+        self.assertEqual(self._events()[0]["strategy_name"], "")
+
+    def test_the_journal_answers_without_touching_redis(self):
+        """This runs on QMT's C++ callback thread. For an order this process
+        submitted the journal already holds what redis holds, so a round trip
+        per event buys nothing -- and costs the full timeout when redis is
+        configured but unreachable, which is the reported deployment."""
+        strategy._exec_event_redis = lambda config: object()
+        self._wire_journal()
+
+        strategy._publish_exec_event("trade", _deal_obj(), None)
+
+        self.assertEqual(self._events()[0]["strategy_name"], "alpha")
+        self.assertEqual(self._fake.enriched, [])   # redis never consulted
+
+    def test_redis_is_the_fallback_when_the_journal_misses(self):
+        """Another process's order: nothing local, so redis still answers."""
+        strategy._exec_event_redis = lambda config: object()
+        self._wire_journal()
+
+        strategy._publish_exec_event("trade", _deal_obj(m_strRemark="other"), None)
+
+        self.assertEqual(self._events()[0]["strategy_name"], "from-redis")
+        self.assertEqual(self._fake.enriched, ["trade"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
修 #174。@sumo225270 报告 `on_stock_order` / `on_stock_trade` 的 `strategy_name` 恒为空，而下单时传的是非空串，`instrument_name` / `order_remark` 一切正常。

**查下来是两个不同的原因**，正好各占一半。**跟报告人怀疑的那几个配置（`rpc_background_threads` 等）都没有关系。**

## 一、成交事件根本没有这个键 —— 无条件坏

`normalize_trade_event` 从来不产出 `strategy_name`。**不是空字符串，是键不存在**，所以客户端 `item.get("strategy_name") or ""` 只可能答 `""`。

而且发布路径上只有委托分支做了身份补全：

```python
if kind == "trade":
    event = normalize_trade_event(...)     # 没有补全
else:
    event = normalize_order_event(...)
    event = enrich_order_identity(...)     # 只有这边有
```

**这半边任何配置都救不回来。** 现在 `normalize_trade_event` 产出这个键，两个分支共用同一个补全函数。

## 二、委托那半边：大 QMT 自己不给

实盘只读列了全部属性：

```
ORDER 行 120 个属性 —— 没有 m_strStrategyName
DEAL  行  47 个属性 —— 也没有
```

和 #133 里 `m_strShareholderID` 同一形态（官方字段表有，这台终端没有）。查询路径实测也印证：当日 14 笔委托，`strategy_name` 全空。

所以唯一的恢复途径是「下单时记一笔、回调时按 remark 反查」，而这一步**此前只读 Redis**。zmq 部署上 Redis 只是可选件，**「配置了 ≠ 连得上」**（#145 那个坑：redis-py 懒连接，配置块在、服务不通时静默超时）—— 补全是 `try/except` 吞掉的，名字就永远回不来。**这正是报告人的部署形态。**

### 为什么把进程内 journal 排在 Redis 前面

现在**先查进程内 journal（#156，查询路径本来就在用），Redis 作兜底**。这个顺序是刻意的：

- 补全跑在 **QMT 的 C++ 回调线程**上；
- 本进程下的单，journal 里存着和 Redis **一模一样**的字符串 —— 先问 Redis 什么也换不来，却要付一次网络往返；
- Redis 配了连不上时，更是**每个事件都付满超时**；
- Redis 留作兜底，是因为它多出来的那点能力（认出**别的进程**下的单）是更少见的情况。

## 门禁

- **门禁 1**：`1499 passed`，**112 个测试文件 = 112 个模块**被收集
- **新测试确实会红**：13 条里修复前 **10 条失败**，另外 3 条是回归保护（`enrich_order_identity` 本来就能作用于成交事件、委托分支本来就有补全）
- **Preflight**：用终端自己的 `xtquant` 抢在 `sys.path` 最前（`xtconstant` 91 个名字，不是 shim 的 538），`adapter_factory` 和 `bigqmt_signal_trader_strategy` 都能干净导入；两个改动文件 AST 里**没有任何 3.7+ 节点**（QMT 只有 `python36.dll`）
- **门禁 2**：只读实盘 10/10 PASS —— 但**这只证明桥还健康**，证明不了改动本身

## ⚠️ 没验证的部分

**这是服务端改动，而且必须 deploy + 重启策略** —— `reload_deployment()` 刷不了 `bigqmt_signal_trader_strategy.py`，QMT exec 的就是它（CLAUDE.md 写明）。

**更要紧的：要等开盘有真实的委托/成交回调才能实盘确认。** 今天收盘后没有回调可看，本次**只有离线用例**。按这个仓库的规矩，单元测试全绿本身不算证据 —— 所以这条**没有合并**，等开盘验过再说。

另外，报告人那侧还有一个**我没法验证的怀疑**：他们的备注是 `卖出: PriceType.PEER_PRICE_FIRST(上交所 / 深交所对手方最优价格委托)`，40 多字符带中文。如果 QMT 的投资备注有长度上限、回来时被截断，存的键和查的键就对不上 —— 那样这个 PR 也救不了他们。要验证得真下单，已请他们贴 `raw_fields`（他们配置里已开 `exec_events_debug_raw_fields`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
