### PR TITLE
修复：恢复 MiniQMT 历史数据与 ZMQ 回调行为

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ### 修复
 
+- **MiniQMT 历史数据语义与纯 ZMQ 交易回调不再意外缩水**：客户端本地缓存填充时保留 MiniQMT K 线字段中的 `time` / `openInterest`，并默认允许“下载原始数据后按另一复权方式读取”时回源 Big QMT；缓存同时存在日期索引和毫秒 `time` 列时，优先用日期索引做窗口过滤。这些都是 MiniQMT 可观察行为，不绑定某个上层框架。
+
+  纯 ZMQ 入口不再强制关闭 `exec_events`：现有 ZMQ PUB 通道可承载 `on_stock_order` / `on_stock_trade` / `on_order_error` MiniQMT 风格回调。仍无 Redis Stream 的短时回放，且 `download_jobs` / `full_tick_cache` 依然在纯 ZMQ 入口中关闭。
+
 - **`qmt.py trades` 现在带上 `strategy_name`**（#174 的后续，客户端工具）：#174 给的绕行办法是「回调拿不到策略名时用查询兜一下」—— 查询路径确实是补全过的（`_attribute_to_strategies`），可照着这个办法用本仓库自己的 CLI 去查成交的人，看到的是查询路径**也**没有策略名。
 
   字段是在最后一步被丢掉的，不是没送到：只读核对了实盘应答，服务端发的成交行**带** `strategy_name` 这个键（当日 17 笔，17 项俱全），是 CLI 的 `_trade_to_dict` 没把它列进去 —— 委托那侧的 `_order_to_dict` 一直列着。

--- a/README.md
+++ b/README.md
@@ -948,7 +948,7 @@ src/BIGQMT_ZMQ_DRYRUN.py           （★ 同机 ZMQ 专用入口，强制 ZMQ �
 
 > 同机 ZMQ 在 QMT“模型研究”中新建 Python 模型并加载 `BIGQMT_ZMQ_DRYRUN.py`；其它 transport 继续使用 `BIGQMT_REDIS_DRYRUN.py`。ZMQ 入口只复用原入口的加载逻辑，不会创建 Redis client。
 >
-> **纯 ZMQ 模式的能力边界**：入口会自动关闭所有依赖 Redis 的功能——`download_jobs`（下载任务队列）、`exec_events`（`on_stock_order`/`on_stock_trade`/`on_order_error` 推送）、`full_tick_cache`（全市场快照缓存）。即纯 ZMQ 下**没有执行回报推送**，委托状态需主动 `query_stock_orders` 轮询。行情查询、下单/撤单、持仓查询等 RPC 全部正常。
+> **纯 ZMQ 模式的能力边界**：入口会关闭确实依赖 Redis 的 `download_jobs`（下载任务队列）和 `full_tick_cache`（全市场快照缓存）。`on_stock_order` / `on_stock_trade` / `on_order_error` 执行回报通过 ZMQ PUB 推送，MiniQMT 风格回调可以正常使用，但没有 Redis Stream 的短时回放能力。行情查询、下单/撤单、持仓查询等 RPC 全部正常。
 
 ### 第 2 步：创建 QMT 端私有配置
 

--- a/docs/XTQUANT_COMPAT_REPLACEMENT.md
+++ b/docs/XTQUANT_COMPAT_REPLACEMENT.md
@@ -78,6 +78,15 @@ BIGQMT_FULL_TICK_CACHE_CONFIG = {
     "cache_ttl_seconds": 10,
     "wait_seconds": 3.5,
 }
+
+# 保持 True 以还原 MiniQMT 的历史数据行为：先下载原始数据，
+# 再通过 get_local_data(..., dividend_type="front_ratio") 读取前复权数据。
+BIGQMT_LOCAL_CACHE_CONFIG = {
+    "enabled": True,
+    "dir": None,
+    "fallback_rpc": True,
+    "format": "auto",
+}
 ```
 
 然后启动前只需要确认本仓库的 `src` 在 `PYTHONPATH` 最前面：

--- a/src/BIGQMT_REDIS_DRYRUN.py
+++ b/src/BIGQMT_REDIS_DRYRUN.py
@@ -297,7 +297,9 @@ try:
         if str(forced_transport).lower() == "zmq":
             BIGQMT_REDIS_CONFIG["rpc_background_threads"] = True
             BIGQMT_REDIS_CONFIG["download_jobs_enabled"] = False
-            BIGQMT_REDIS_CONFIG["exec_events_enabled"] = False
+            # Execution events have a native ZMQ PUB path.  Preserve the
+            # configured/default switch so MiniQMT-compatible order and trade
+            # callbacks keep working without Redis.
             BIGQMT_REDIS_CONFIG["full_tick_cache_enabled"] = False
     print("[bigqmt_shell] local rpc config loaded transport=%s keys=%s" % (
         (BIGQMT_REDIS_CONFIG or {}).get("transport", "redis"),

--- a/src/bigqmt_signal_trader/init_config.py
+++ b/src/bigqmt_signal_trader/init_config.py
@@ -205,7 +205,7 @@ def render_client_config(answers):
         "BIGQMT_LOCAL_CACHE_CONFIG = {",
         '    "enabled": True,',
         '    "dir": None,',
-        '    "fallback_rpc": False,',
+        '    "fallback_rpc": True,  # MiniQMT-compatible adjusted reads; False = offline only',
         '    "format": "auto",',
         "}",
         "",

--- a/src/bigqmt_signal_trader/local_cache.py
+++ b/src/bigqmt_signal_trader/local_cache.py
@@ -32,10 +32,12 @@ def _time_axis(df):
     otherwise a MiniQMT-shaped write silently disables date filtering, so
     get_local_data returns every cached day regardless of the window
     (issue #54 follow-up).
+
+    A MiniQMT-compatible frame can also have *both* a date-shaped index and an
+    epoch-ms ``time`` column.  Prefer the index in that case: parquet must keep
+    it, and date-window comparisons must not compare ``20260818`` with
+    ``1786982400000`` as strings.
     """
-    name = _time_col(df)
-    if name:
-        return name, False
     index = getattr(df, "index", None)
     try:
         if index is not None and len(index):
@@ -44,6 +46,9 @@ def _time_axis(df):
                 return "__index__", True
     except Exception:
         pass
+    name = _time_col(df)
+    if name:
+        return name, False
     return None, False
 
 

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -52,7 +52,13 @@ del _const_name
 
 
 # Default OHLCV fields pulled + cached by get_local_data fallback_rpc.
-DEFAULT_DOWNLOAD_FIELDS = ["open", "high", "low", "close", "volume", "amount"]
+# MiniQMT documents an empty field list as "all fields", including ``time`` and
+# ``openInterest`` for K-lines.  Cache fills deliberately use a bounded subset
+# instead, but omitting those two standard fields leaves the resulting frame
+# observably incompatible with MiniQMT consumers.
+DEFAULT_DOWNLOAD_FIELDS = [
+    "time", "open", "high", "low", "close", "volume", "amount", "openInterest",
+]
 # Codes per get_market_data_ex request. One request carries a single RPC timeout,
 # so a wide stock_list either fits or loses everything (issue #47).
 DEFAULT_MARKET_DATA_CHUNK = 100
@@ -760,7 +766,10 @@ class BigQmtRpcClient:
             ),
         }
         # Client-side local market-data cache. get_market_data_ex is cache-through;
-        # fallback_rpc=True lets get_local_data fetch+cache a cache miss.
+        # get_local_data falls back to Big QMT by default so a MiniQMT-style
+        # download of raw history can be followed by a read in another
+        # adjustment mode. Set fallback_rpc=False only for an explicitly
+        # offline, cache-only client.
         local_cache_config = dict(client_config.get("local_cache_config") or {})
         self.local_cache_config = {
             "enabled": _bool_value(
@@ -775,7 +784,7 @@ class BigQmtRpcClient:
             ),
             "fallback_rpc": _bool_value(
                 local_cache_config.get("fallback_rpc", merged_redis_config.get("local_cache_fallback_rpc")),
-                _env_bool("BIGQMT_LOCAL_CACHE_FALLBACK_RPC", False),
+                _env_bool("BIGQMT_LOCAL_CACHE_FALLBACK_RPC", True),
             ),
             "format": str(
                 local_cache_config.get("format")

--- a/src/bigqmt_signal_trader_client_config.example.py
+++ b/src/bigqmt_signal_trader_client_config.example.py
@@ -49,12 +49,14 @@ BIGQMT_FULL_TICK_CACHE_CONFIG = {
 #   then reads them locally with NO RPC to Big QMT (for offline / repeated local
 #   analysis). download_history_data* submits a server-side Big QMT download job.
 #   - dir: cache folder (default ~/.bigqmt_cache), one pickle per (period, code).
-#   - fallback_rpc: if True, get_local_data auto-fetches+caches a cache miss;
-#     if False (default), a cache-missed code is simply omitted (download first).
+#   - fallback_rpc: if True (default), get_local_data auto-fetches+caches a
+#     cache miss.  This preserves MiniQMT's visible behaviour when a caller
+#     downloads raw data and then reads a different adjustment mode.
+#     Set False only when this client must be strictly offline/cache-only.
 BIGQMT_LOCAL_CACHE_CONFIG = {
     "enabled": True,
     "dir": None,            # None -> ~/.bigqmt_cache
-    "fallback_rpc": False,
+    "fallback_rpc": True,
     # Storage format: "auto" (parquet if pyarrow installed, else pickle),
     # "parquet" (columnar/compressed/cross-language — recommended), or "pkl".
     # One file per (period, dividend_type, code); switching format auto-migrates.

--- a/tests/bigqmt_signal_trader/test_entry_encoding.py
+++ b/tests/bigqmt_signal_trader/test_entry_encoding.py
@@ -58,6 +58,7 @@ class EntryEncodingTest(unittest.TestCase):
         with open(legacy_path, "r", encoding="gbk") as source_file:
             legacy_source = source_file.read()
         self.assertIn('BIGQMT_REDIS_CONFIG["download_jobs_enabled"] = False', legacy_source)
+        self.assertNotIn('BIGQMT_REDIS_CONFIG["exec_events_enabled"] = False', legacy_source)
 
     def test_legacy_entry_supports_qmt_without_standard_importlib(self):
         """裁剪过的 QMT Python 缺少 importlib 时仍可加载 Bridge。"""

--- a/tests/bigqmt_signal_trader/test_init_config.py
+++ b/tests/bigqmt_signal_trader/test_init_config.py
@@ -86,6 +86,7 @@ class RenderedConfigTest(unittest.TestCase):
         self.assertEqual(loaded["BIGQMT_ACCOUNT_ID"], "8886800503")
         self.assertEqual(loaded["BIGQMT_REDIS_CONFIG"]["transport"], "redis")
         self.assertEqual(loaded["BIGQMT_REDIS_CONFIG"]["host"], "10.0.0.5")
+        self.assertIs(loaded["BIGQMT_LOCAL_CACHE_CONFIG"]["fallback_rpc"], True)
 
     def test_server_and_client_agree_on_the_connection(self):
         """Two files, one deployment: a mismatch here is a silent no-connect."""

--- a/tests/bigqmt_signal_trader/test_local_cache.py
+++ b/tests/bigqmt_signal_trader/test_local_cache.py
@@ -291,7 +291,14 @@ class FakeClient:
             import pandas as pd
 
             codes = (params or {}).get("stock_list") or []
-            return {c: pd.DataFrame({"stime": ["20260626", "20260629"], "close": [8.76, 8.73]}) for c in codes}
+            return {
+                c: pd.DataFrame({
+                    "stime": ["20260626", "20260629"],
+                    "close": [8.76, 8.73],
+                    "openInterest": [0.0, 0.0],
+                })
+                for c in codes
+            }
         if method == "download_history_data2":
             # Server-side raw download (raw bars + dividend factors).
             return True
@@ -355,6 +362,31 @@ class LocalCacheClientTest(unittest.TestCase):
         n = len(xt.client.calls)
         xt.get_local_data(stock_list=["600000.SH"], period="1d")
         self.assertEqual(len(xt.client.calls), n)
+
+    def test_download_then_different_adjustment_read_falls_back(self):
+        """A MiniQMT-style raw download can be read as front_ratio data."""
+        xt = self._xt(fallback_rpc=True)
+
+        xt.download_history_data("600000.SH", "1d", "20260601", "20260630")
+        calls_after_download = len(xt.client.calls)
+        data = xt.get_local_data(
+            [], ["600000.SH"], "1d", "20260601", "20260630", -1,
+            "front_ratio", False,
+        )
+
+        self.assertIn("600000.SH", data)
+        self.assertGreater(len(xt.client.calls), calls_after_download)
+        frame = data["600000.SH"]
+        self.assertIn("time", frame.columns)
+        self.assertIn("openInterest", frame.columns)
+        self.assertGreater(int(frame.iloc[0]["time"]), 0)
+        method, params = xt.client.call_params[-1]
+        self.assertEqual(method, "get_market_data_ex")
+        self.assertEqual(params["dividend_type"], "front_ratio")
+        self.assertEqual(
+            params["field_list"],
+            ["time", "open", "high", "low", "close", "volume", "amount", "openInterest"],
+        )
 
 
 class CompatReadMatrixTest(unittest.TestCase):

--- a/tests/bigqmt_signal_trader/test_xtquant_compat.py
+++ b/tests/bigqmt_signal_trader/test_xtquant_compat.py
@@ -569,6 +569,7 @@ class XtquantCompatTest(unittest.TestCase):
         self.assertEqual(client.redis_config["username"], "cfg-user")
         self.assertEqual(client.redis_config["password"], "cfg-pass")
         self.assertEqual(client.timeout_seconds, 9)
+        self.assertIs(client.local_cache_config["fallback_rpc"], True)
 
     def test_explicit_client_params_override_private_config(self):
         module_name, old_env = self._with_fake_config()


### PR DESCRIPTION
## 改动内容

- 纯 ZMQ 部署下复用现有 ZMQ PUB 通道，保持 MiniQMT 风格的委托、成交和错误回调可用
- 默认启用缓存缺失时的 RPC 回退，使原始历史数据下载后仍可按其他复权模式读取
- 在受限的缓存填充字段中保留 MiniQMT 标准 K 线字段 `time` 和 `openInterest`
- 切片与合并缓存 K 线时，优先使用日期格式的索引

## 修改原因

这些问题最初由上层接入暴露，但本次修改恢复的是 MiniQMT 对外可观察行为。原生 `xtdata` 文档说明：K 线字段列表为空时，返回结果应包含 `time` 和 `openInterest`；调用方也可能先下载未复权历史数据，再读取 `front` / `front_ratio` 数据。

桥接层仍有意限制缓存填充字段，严格离线客户端仍可设置 `fallback_rpc=False`。纯 ZMQ 模式仍不支持 Redis Stream 事件重放，`download_jobs` 和 `full_tick_cache` 也继续保持关闭。

## 测试

- `python run_all_tests.py`
- 1465 passed，1 skipped，0 failed
- 覆盖 ZMQ PUB/SUB 执行事件往返、缓存窗口与复权模式、配置生成和入口编码测试