### PR TITLE
perf: opt zmq/mysql into the adjust-thread drain, ping log off the hot path (#104)

### DIFF
--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -2587,15 +2587,6 @@ class RedisPubSubRpcService:
             _t1 = time.perf_counter() if method == "ping" else 0.0
             response["data"] = to_jsonable(result)
             response["ok"] = True
-            if method == "ping":
-                try:
-                    from .logging_setup import get_logger
-                    get_logger("rpc").info(
-                        "ping breakdown handle=%.1fms jsonable=%.1fms",
-                        (_t1 - _t0) * 1000.0,
-                        (time.perf_counter() - _t1) * 1000.0)
-                except Exception:
-                    pass
             # Surface server-side diagnostics when the handler recorded one.
             server_error = getattr(self.handlers, "_last_server_error", None)
             if server_error:
@@ -2615,6 +2606,7 @@ class RedisPubSubRpcService:
         except Exception as exc:
             response["error"] = "%s: %s" % (exc.__class__.__name__, exc)
         response["_t_reply"] = time.time()
+        _t_pub0 = time.perf_counter() if method == "ping" else 0.0
         try:
             self._publish_response(request, response)
         except Exception:
@@ -2627,6 +2619,20 @@ class RedisPubSubRpcService:
                 get_logger("rpc").error(
                     "publish response failed method=%s:\n%s", method, _tb.format_exc()
                 )
+            except Exception:
+                pass
+        if method == "ping":
+            # Logged AFTER publish: this print goes to the QMT output panel,
+            # which costs ~1 adjust tick of GIL wait on the serving thread --
+            # between the handler and the send it inflated ping's round trip
+            # by ~100ms and made the breakdown lie (#104).
+            try:
+                from .logging_setup import get_logger
+                get_logger("rpc").info(
+                    "ping breakdown handle=%.1fms jsonable=%.1fms publish=%.1fms",
+                    (_t1 - _t0) * 1000.0,
+                    (_t_pub0 - _t1) * 1000.0,
+                    (time.perf_counter() - _t_pub0) * 1000.0)
             except Exception:
                 pass
         self._processed_count += 1

--- a/src/bigqmt_signal_trader_redis_rpc_runtime.py
+++ b/src/bigqmt_signal_trader_redis_rpc_runtime.py
@@ -257,6 +257,10 @@ RPC_PROCESS_IN_LISTENER = bool(
     BIGQMT_REDIS_CONFIG.get("rpc_process_in_listener", RPC_PROCESS_IN_LISTENER and not RPC_ALLOW_ORDER_METHODS)
 )
 RPC_BACKGROUND_THREADS = bool(BIGQMT_REDIS_CONFIG.get("rpc_background_threads", RPC_BACKGROUND_THREADS))
+# The strategy side only honors an EXPLICIT rpc_background_threads on non-redis
+# transports (absent = historical default, receiver threads on). Remember
+# whether the local config named it so _apply_config can forward accordingly.
+RPC_BACKGROUND_THREADS_EXPLICIT = "rpc_background_threads" in BIGQMT_REDIS_CONFIG
 RPC_LISTENER_METHODS = tuple(BIGQMT_REDIS_CONFIG.get("rpc_listener_methods", RPC_LISTENER_METHODS))
 SCHEDULE_ADJUST_ENABLED = bool(BIGQMT_REDIS_CONFIG.get("schedule_adjust", SCHEDULE_ADJUST_ENABLED))
 if not RPC_BACKGROUND_THREADS:
@@ -324,6 +328,30 @@ def _apply_config(account_id):
     account_id = str(account_id or "")
     if account_id:
         set_account_id(account_id)
+    rpc_block = {
+        "enabled": True,
+        "account_id": account_id,
+        "allow_order_methods": RPC_ALLOW_ORDER_METHODS,
+        "default_strategy_name": RPC_DEFAULT_STRATEGY_NAME,
+        "request_channel_template": "bigqmt:rpc:req:{account_id}",
+        "response_channel_template": "bigqmt:rpc:resp:{account_id}:{request_id}",
+        "response_key_template": "bigqmt:rpc:resp:{account_id}:{request_id}",
+        "response_ttl_seconds": 60,
+        "drain_max_items": 20,
+        "process_in_listener": RPC_PROCESS_IN_LISTENER,
+        "listener_methods": RPC_LISTENER_METHODS,
+        # Transport selection (default redis). Forwarded from the local
+        # config so the factory can pick zmq/mysql/shm.
+        "transport": RPC_TRANSPORT,
+        "zmq": RPC_ZMQ_CONFIG,
+        "mysql": RPC_MYSQL_CONFIG,
+    }
+    # Forward background_threads ONLY when the local config named it: on
+    # non-redis transports the strategy treats an absent key as "historical
+    # default" (receiver threads on) and an explicit False as the opt-in to
+    # the adjust-driven drain (#104).
+    if RPC_BACKGROUND_THREADS_EXPLICIT:
+        rpc_block["background_threads"] = RPC_BACKGROUND_THREADS
     configure(
         mode="bigqmt",
         account_id=account_id,
@@ -333,25 +361,7 @@ def _apply_config(account_id):
         schedule_adjust=SCHEDULE_ADJUST_ENABLED,
         schedule_adjust_interval=SCHEDULE_ADJUST_INTERVAL,
         redis=_redis_block(),
-        rpc={
-            "enabled": True,
-            "account_id": account_id,
-            "allow_order_methods": RPC_ALLOW_ORDER_METHODS,
-            "default_strategy_name": RPC_DEFAULT_STRATEGY_NAME,
-            "request_channel_template": "bigqmt:rpc:req:{account_id}",
-            "response_channel_template": "bigqmt:rpc:resp:{account_id}:{request_id}",
-            "response_key_template": "bigqmt:rpc:resp:{account_id}:{request_id}",
-            "response_ttl_seconds": 60,
-            "drain_max_items": 20,
-            "process_in_listener": RPC_PROCESS_IN_LISTENER,
-            "listener_methods": RPC_LISTENER_METHODS,
-            "background_threads": RPC_BACKGROUND_THREADS,
-            # Transport selection (default redis). Forwarded from the local
-            # config so the factory can pick zmq/mysql/shm.
-            "transport": RPC_TRANSPORT,
-            "zmq": RPC_ZMQ_CONFIG,
-            "mysql": RPC_MYSQL_CONFIG,
-        },
+        rpc=rpc_block,
         full_tick_cache={
             "enabled": FULL_TICK_CACHE_ENABLED,
             "account_id": account_id,
@@ -383,8 +393,9 @@ def configure_runtime_account(account_id):
 
 
 def configure_runtime_redis(redis_config):
-    global REDIS_ENABLED, REDIS_HOST, REDIS_PORT, REDIS_DB, REDIS_USERNAME, REDIS_PASSWORD, RPC_ALLOW_ORDER_METHODS, RPC_DEFAULT_STRATEGY_NAME, RPC_PROCESS_IN_LISTENER, RPC_BACKGROUND_THREADS, RPC_LISTENER_METHODS, SCHEDULE_ADJUST_ENABLED, SCHEDULE_ADJUST_INTERVAL, FULL_TICK_CACHE_ENABLED, FULL_TICK_DEMAND_TTL_SECONDS, FULL_TICK_CACHE_TTL_SECONDS, FULL_TICK_REFRESH_INTERVAL_SECONDS, FULL_TICK_MARKET_REFRESH_INTERVAL_SECONDS, FULL_TICK_REFRESH_MAX_WALL_SECONDS, FULL_TICK_MAX_REQUESTS, RPC_TRANSPORT, RPC_ZMQ_CONFIG, RPC_MYSQL_CONFIG, DOWNLOAD_JOBS_ENABLED, DOWNLOAD_JOB_CHUNK_SIZE, DOWNLOAD_JOB_MAX_WALL_SECONDS, DOWNLOAD_JOB_TTL_SECONDS, EXEC_EVENTS_ENABLED, EXEC_EVENTS_DEBUG_RAW_FIELDS, EXEC_EVENTS_HOLD_PRESYSID_SECONDS
+    global REDIS_ENABLED, REDIS_HOST, REDIS_PORT, REDIS_DB, REDIS_USERNAME, REDIS_PASSWORD, RPC_ALLOW_ORDER_METHODS, RPC_DEFAULT_STRATEGY_NAME, RPC_PROCESS_IN_LISTENER, RPC_BACKGROUND_THREADS, RPC_LISTENER_METHODS, SCHEDULE_ADJUST_ENABLED, SCHEDULE_ADJUST_INTERVAL, FULL_TICK_CACHE_ENABLED, FULL_TICK_DEMAND_TTL_SECONDS, FULL_TICK_CACHE_TTL_SECONDS, FULL_TICK_REFRESH_INTERVAL_SECONDS, FULL_TICK_MARKET_REFRESH_INTERVAL_SECONDS, FULL_TICK_REFRESH_MAX_WALL_SECONDS, FULL_TICK_MAX_REQUESTS, RPC_TRANSPORT, RPC_ZMQ_CONFIG, RPC_MYSQL_CONFIG, DOWNLOAD_JOBS_ENABLED, DOWNLOAD_JOB_CHUNK_SIZE, DOWNLOAD_JOB_MAX_WALL_SECONDS, DOWNLOAD_JOB_TTL_SECONDS, EXEC_EVENTS_ENABLED, EXEC_EVENTS_DEBUG_RAW_FIELDS, EXEC_EVENTS_HOLD_PRESYSID_SECONDS, RPC_BACKGROUND_THREADS_EXPLICIT
     redis_config = dict(redis_config or {})
+    RPC_BACKGROUND_THREADS_EXPLICIT = "rpc_background_threads" in redis_config
     REDIS_ENABLED = bool(redis_config.get("redis_enabled", REDIS_ENABLED))
     REDIS_HOST = redis_config.get("host", REDIS_HOST)
     REDIS_PORT = int(redis_config.get("port", REDIS_PORT))

--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -567,14 +567,28 @@ def _is_redis_transport(transport_name):
 def _resolve_background_threads(transport_name, configured):
     """Decide whether the RPC service runs its own background receive threads.
 
-    Redis honors the configured value because it has a blocking brpop path AND
-    an adjust-driven lpop drain. ZMQ and all other transports MUST run their
-    receiver threads — without the background router loop, requests are never
-    received (ZMQ's start_receiving(background_threads=False) only binds the
-    socket and does not poll it).
+    ``configured`` is None when the local config never set
+    ``rpc_background_threads`` (the runtime only forwards the key when it was
+    given explicitly) -- that case keeps the historical default: background
+    receiver threads on for every transport.
+
+    An explicit False opts into the adjust-driven drain instead: the transport
+    is polled with a non-blocking recv from drain_request_queue on each adjust
+    tick, and the reply is sent on the adjust thread too. That removes every
+    cross-thread handoff from the round trip -- measured on the live terminal,
+    each time a background thread acquires the GIL costs ~1 adjust tick
+    (~100ms), which is where the round trip actually goes (#104).
+
+    Only zmq/mysql implement drain_request_queue, so only they honor the
+    override; anything else keeps the receiver thread it needs to be polled by.
+    Redis honors either value (blocking brpop path AND an adjust lpop drain).
     """
     normalized = str(transport_name or "redis").lower()
     if _is_redis_transport(normalized):
+        return bool(configured)
+    if configured is None:
+        return True
+    if normalized in ("zmq", "mysql"):
         return bool(configured)
     return True
 
@@ -744,7 +758,11 @@ def _build_rpc_service(context_info, app, config):
     handlers.download_job_ttl_seconds = int((config.get("download_jobs") or {}).get("job_ttl_seconds") or 3600)
     process_in_listener = _config_bool(rpc_config.get("process_in_listener"), True)
     listener_methods = rpc_config.get("listener_methods") or ("*",)
-    configured_bg = _config_bool(rpc_config.get("background_threads"), False)
+    # None when the runtime did not forward the key (local config never set
+    # rpc_background_threads): the resolver then keeps the historical default.
+    configured_bg = rpc_config.get("background_threads")
+    if configured_bg is not None:
+        configured_bg = _config_bool(configured_bg, False)
     background_threads = _resolve_background_threads(transport_name, configured_bg)
     if background_threads and not configured_bg:
         print("[bigqmt_rpc] transport=%s -> background_threads auto-enabled" % transport_name)

--- a/tests/bigqmt_signal_trader/test_background_threads_forwarding.py
+++ b/tests/bigqmt_signal_trader/test_background_threads_forwarding.py
@@ -1,0 +1,90 @@
+# coding: utf-8
+"""The runtime forwards rpc.background_threads only when the local config
+named rpc_background_threads explicitly.
+
+Why it has to work this way: on non-redis transports the strategy side treats
+an ABSENT key as "historical default" (background receiver threads on) and an
+explicit False as the opt-in to the adjust-driven drain that drops the
+cross-thread GIL handoffs from the round trip (#104). If the runtime emitted
+its default False unconditionally, every zmq deployment would silently flip
+into drain mode on restart -- the mode change must be opt-in.
+"""
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+import bigqmt_signal_trader_redis_rpc_runtime as runtime
+
+
+class ForwardingTest(unittest.TestCase):
+    def setUp(self):
+        self._saved = {
+            "RPC_BACKGROUND_THREADS": runtime.RPC_BACKGROUND_THREADS,
+            "RPC_BACKGROUND_THREADS_EXPLICIT": runtime.RPC_BACKGROUND_THREADS_EXPLICIT,
+            "configure": runtime.configure,
+            "set_account_id": runtime.set_account_id,
+        }
+        self._captured = {}
+        runtime.configure = lambda **kwargs: self._captured.update(kwargs)
+        runtime.set_account_id = lambda account_id: None
+
+    def tearDown(self):
+        for key, value in self._saved.items():
+            setattr(runtime, key, value)
+
+    def _rpc_block(self):
+        runtime._apply_config("TESTACCOUNT")
+        return self._captured["rpc"]
+
+    def test_absent_when_not_explicit(self):
+        runtime.RPC_BACKGROUND_THREADS = False
+        runtime.RPC_BACKGROUND_THREADS_EXPLICIT = False
+
+        self.assertNotIn("background_threads", self._rpc_block())
+
+    def test_absent_when_not_explicit_even_if_true(self):
+        runtime.RPC_BACKGROUND_THREADS = True
+        runtime.RPC_BACKGROUND_THREADS_EXPLICIT = False
+
+        self.assertNotIn("background_threads", self._rpc_block())
+
+    def test_forwarded_when_explicit(self):
+        runtime.RPC_BACKGROUND_THREADS = False
+        runtime.RPC_BACKGROUND_THREADS_EXPLICIT = True
+
+        self.assertIs(self._rpc_block().get("background_threads"), False)
+
+    def test_forwarded_true_when_explicit(self):
+        runtime.RPC_BACKGROUND_THREADS = True
+        runtime.RPC_BACKGROUND_THREADS_EXPLICIT = True
+
+        self.assertIs(self._rpc_block().get("background_threads"), True)
+
+
+class ExplicitFlagTest(unittest.TestCase):
+    def setUp(self):
+        self._saved = {
+            "RPC_BACKGROUND_THREADS": runtime.RPC_BACKGROUND_THREADS,
+            "RPC_BACKGROUND_THREADS_EXPLICIT": runtime.RPC_BACKGROUND_THREADS_EXPLICIT,
+        }
+
+    def tearDown(self):
+        for key, value in self._saved.items():
+            setattr(runtime, key, value)
+
+    def test_key_present_marks_explicit(self):
+        runtime.configure_runtime_redis({"rpc_background_threads": False})
+        self.assertTrue(runtime.RPC_BACKGROUND_THREADS_EXPLICIT)
+        self.assertFalse(runtime.RPC_BACKGROUND_THREADS)
+
+    def test_key_absent_marks_not_explicit(self):
+        runtime.configure_runtime_redis({"transport": "zmq"})
+        self.assertFalse(runtime.RPC_BACKGROUND_THREADS_EXPLICIT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_transport_selection.py
+++ b/tests/bigqmt_signal_trader/test_transport_selection.py
@@ -18,18 +18,36 @@ class BackgroundThreadResolutionTest(unittest.TestCase):
         self.assertFalse(_resolve_background_threads("default", False))
         self.assertFalse(_resolve_background_threads(None, False))
 
-    def test_zmq_transport_forces_background_threads_on(self):
-        # ZMQ must run its background router thread regardless of config —
-        # without it, requests are never received (start_receiving(False)
-        # only binds the socket, never polls it).
-        self.assertTrue(_resolve_background_threads("zmq", False))
-        self.assertTrue(_resolve_background_threads("ZMQ", False))
+    def test_zmq_transport_defaults_background_threads_on(self):
+        # None = the local config never named rpc_background_threads (the
+        # runtime only forwards the key when explicit): keep the historical
+        # receiver-thread default.
+        self.assertTrue(_resolve_background_threads("zmq", None))
+        self.assertTrue(_resolve_background_threads("ZMQ", None))
         self.assertTrue(_resolve_background_threads("zmq", True))
 
-    def test_other_non_redis_transports_force_background_threads_on(self):
-        for name in ("mysql", "shm"):
-            self.assertTrue(_resolve_background_threads(name, False), name)
-            self.assertTrue(_resolve_background_threads(name, True), name)
+    def test_zmq_explicit_false_opts_into_adjust_drain(self):
+        # An explicit rpc_background_threads=False selects the adjust-driven
+        # drain: drain_request_queue polls the bound socket with a non-blocking
+        # recv on each adjust tick, so requests ARE received without the
+        # router thread -- and the round trip drops its cross-thread GIL
+        # handoffs (~1 adjust tick each, #104).
+        self.assertFalse(_resolve_background_threads("zmq", False))
+        self.assertFalse(_resolve_background_threads("ZMQ", False))
+
+    def test_mysql_explicit_false_opts_into_adjust_drain(self):
+        # mysql also implements drain_request_queue, so the override stands.
+        self.assertTrue(_resolve_background_threads("mysql", None))
+        self.assertFalse(_resolve_background_threads("mysql", False))
+        self.assertTrue(_resolve_background_threads("mysql", True))
+
+    def test_drainless_transports_ignore_the_override(self):
+        # shm has no drain_request_queue: without the receiver thread requests
+        # would never be picked up, so even an explicit False cannot turn it
+        # off here.
+        self.assertTrue(_resolve_background_threads("shm", None))
+        self.assertTrue(_resolve_background_threads("shm", False))
+        self.assertTrue(_resolve_background_threads("shm", True))
 
     def test_is_redis_transport(self):
         for name in ("redis", "", "default", None, "REDIS", "Default"):


### PR DESCRIPTION
# 背景

#104 的 wake-pipe（#177）把交易查询从 1500ms 拉到 ~600ms 后，实盘探针继续分解发现剩余延迟**全部按 ~100ms adjust tick 量化**：

| 方法 | wait | handle | reply→wire | 总计 p50 |
|---|---|---|---|---|
| ping | 151ms | 94ms | 96ms | 353ms |
| get_positions | 151ms | 1ms | 405ms | ~555ms |
| query_orders | 151ms | 2ms | 406ms | ~647ms |

裸 pyzmq 客户端把收包单独打点后确认：**客户端/线路只占 0.2ms**，延迟全在 QMT 进程内。机制是 GIL 墙——QMT 主线程在 tick 之间几乎不放 GIL，router 后台线程每次拿 GIL 都要等约一个 tick，一次往返需要 2-5 次跨线程交接。

同时发现 d059c34 的关键误读：它以为「config 设了 background_threads=False，zmq 无 router 线程」，但 `_resolve_background_threads` 对非 redis 传输**强制 True**——所以 zmq 的 drain 模式（adjust 线程直接从 socket 收/处理/发）从未被实测过。

# 改动

1. **runtime**：`rpc.background_threads` 只在本地配置显式写了 `rpc_background_threads` 时才转发给策略侧（缺省 = 历史默认，任何部署升级后不会静默换模式）。
2. **strategy**：`_resolve_background_threads` 对 zmq/mysql（有 `drain_request_queue` 的传输）放行显式 False；shm 等无 drain 的传输忽略该覆盖，保持接收线程。
3. **redis_rpc**：ping 的 breakdown 日志挪到 publish **之后**——在 handler 和发送之间 print 到 QMT 面板要丢 GIL ~1 tick，让 ping 虚高 ~100ms 且使 breakdown 说谎。日志增加 publish 耗时字段。

# drain 模式行为

请求躺在内核缓冲区等下一个 tick（≤100ms），adjust 线程持 GIL 一次完成收/处理/发，回复直发（zmq socket 全程只被 adjust 线程触碰）。deferred 交易查询同 tick 被 `drain_pending` 捞起。`reload_deployment` 反而更干净（无响应队列要排干）。代价：失去 router 线程上的 stall watchdog；每 tick 最多 drain 20 条。

# 实盘验证（2026-09-04 盘后，国金 terminal，策略重启后）

启动日志确认 `background_threads=False`（reqid 后缀 00030010→00030011）。探针对比：

| 方法 | 之前 p50 | 之后 p50 | 之后 max |
|---|---|---|---|
| ping | 353ms | **44ms** | 96ms |
| get_asset | 558ms | **44ms** | 59ms |
| get_positions | 555ms | **44ms** | 60ms |
| query_orders | 647ms | **46ms** | 63ms |

服务端 reply residency：avg 318ms → **count=0**（drain 模式下没有任何回复再排队）。紧挨着连发（相位对齐最坏情况）~95-110ms/次，仍是原来的 1/6。tick 节奏保持健康（100ms，body ~1ms，CPU 1.5%），无报错。

# 测试

- 1509 通过，113/113 模块收集
- 新的 resolver/forwarding 测试已验证对改动前代码失败（6 failed pre-change）
- 终端自带 xtquant 预检通过

# 未做 / 后续

- `schedule_adjust_interval` 仍是 100ms——剩下的唯一一跳随它缩放，50ms 是下一个实验（需验证 run_time 守约与 CPU）。
- 本地配置注释里「100ms 会热循环烧一个核」「deferred 查询恒定 ~1s」两条已被实测证伪（后者是 wake-pipe 前的旧时代），合并后建议顺手清理文档。
- 下单/撤单路径未单独实测（盘后不下单）；其 RPC 段与交易查询同路，盘中最多少量验证。
