### PR TITLE
fix: 异步下单被批量端点的幂等契约吞掉，连第一单都下不出去 (#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,18 @@
 
   修法是让异步路径**显式退出**幂等契约，`order_stock_batch` 的默认行为一个字不动 —— 它的幂等是防重试重复下单的保险丝，不是可以顺手拆掉的东西。服务端接受 `idempotent`（默认 `True`）；为 `False` 时缺 tag 照单笔路径补 uuid、不去重、也不写 journal（异步的 remark 不是身份，记下来会压掉后面真正的批量单）。客户端 `_submit_async_batch` 传 `False`，并给每项补唯一 `signal_id` —— 对着还不认这个开关的旧服务端，无 remark 的情况也能靠 tag 回落到 signal_id 而不撞去重。
 
-  **实盘验证，未下任何单**：每项 `volume=0`，在 `_handle_submit_order` 的 `volume must be positive` 就退出，到不了 passorder。无 remark + `idempotent=False` 三笔全部答 volume 错误（不再是 `ORDER_TAG_REQUIRED`）；同一 remark + `idempotent=False` 三笔各自独立处理，无一被吞；无 remark 走默认契约仍然 `ORDER_TAG_REQUIRED`。
+  **实盘前后对照，未下任何单**：报告人的场景原样复现 —— 紧凑 while 循环调 `order_stock_async`、不插查询、不带 remark，每项 `order_volume=0`，在 `_handle_submit_order` 的 `volume must be positive` 就退出，到不了 passorder。同一台桥、同一个脚本，只换服务端与客户端版本：
 
-  **未验证**：没真下过单，所以证不到「循环里 N 笔异步单最终在委托列表里出现 N 行」，那要开盘经由本桥真下单。实盘证据证的是两道闸门都不再拦截、每一项都被单独送进提交路径。
+  | 场景 | 修复前 | 修复后 |
+  |---|---|---|
+  | 无 remark，8 笔 | **0/8 到达提交路径，8 笔全被 `ORDER_TAG_REQUIRED` 拦** | **8/8** |
+  | 无 remark 走默认契约 | `ORDER_TAG_REQUIRED` | `ORDER_TAG_REQUIRED`（未变） |
+
+  「连第一单都下不出去」在这里看得很清楚：批次里 index 0 和其余各笔一样被拒，不是「第一单成功、后面被去重」。
+
+  **去重那一半没有实盘证据，只有离线测试**。这个探针证不了它：幂等去重靠 `_submit_journal`，而 journal 只在提交成功之后才写；`volume=0` 让每笔都在写 journal 之前抛错，于是去重根本没机会触发 —— 修复前修复后同样是 8/8。要在实盘证它必须真下单。离线用 DryRun gateway 提交会成功、journal 会写，那里 3 笔同 remark 修复前只下 1 笔、修复后 3 笔全下。
+
+  **未验证**：没真下过单，所以证不到「循环里 N 笔异步单最终在委托列表里出现 N 行」。
 
   **影响范围**：`66c344a`（#181）不在任何 tag 里，这个 bug 从未发布到 PyPI，只影响从源码部署 main 的人。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,22 @@
 
 ### 修复
 
+- **异步下单被批量端点吞掉，而且吞掉的单返回 success**（#190，实盘报告，#181 的回归）：0.3.20 正常，之后的 main 上「循环里单独调用下单一单也下不出去，插一个别的调用就又能下」，以及「同时下很多单、回调回来一堆、委托列表里只有一单」。两条是同一个根因。
+
+  #181 让 `order_stock_async` 的积压走 `order_stock_batch` 省往返，于是异步下单继承了一份它从没答应过的契约。`_handle_submit_order` 在没有 remark 时自动补 `bqrpc:<uuid>` 且从不去重；`_handle_submit_orders_batch` 两样都相反 —— 缺 tag 直接答 `ORDER_TAG_REQUIRED`（**没写 remark 是异步的常态**，于是一单不下），tag 见过就答 `success: True, idempotent: True` 却根本不到 gateway（**remark 重复对异步完全合法**，于是只下一单）。「插一个别的调用就能下」是批量阈值：队列里只剩一笔时走单笔路径，把循环放慢就把 bug 藏起来了。
+
+  最危险的是被吞掉的单**返回 success**，调用方无从分辨。离线复现的原文是 `reported 2 successes for 1 placed orders`。
+
+  修法是让异步路径**显式退出**幂等契约，`order_stock_batch` 的默认行为一个字不动 —— 它的幂等是防重试重复下单的保险丝，不是可以顺手拆掉的东西。服务端接受 `idempotent`（默认 `True`）；为 `False` 时缺 tag 照单笔路径补 uuid、不去重、也不写 journal（异步的 remark 不是身份，记下来会压掉后面真正的批量单）。客户端 `_submit_async_batch` 传 `False`，并给每项补唯一 `signal_id` —— 对着还不认这个开关的旧服务端，无 remark 的情况也能靠 tag 回落到 signal_id 而不撞去重。
+
+  **实盘验证，未下任何单**：每项 `volume=0`，在 `_handle_submit_order` 的 `volume must be positive` 就退出，到不了 passorder。无 remark + `idempotent=False` 三笔全部答 volume 错误（不再是 `ORDER_TAG_REQUIRED`）；同一 remark + `idempotent=False` 三笔各自独立处理，无一被吞；无 remark 走默认契约仍然 `ORDER_TAG_REQUIRED`。
+
+  **未验证**：没真下过单，所以证不到「循环里 N 笔异步单最终在委托列表里出现 N 行」，那要开盘经由本桥真下单。实盘证据证的是两道闸门都不再拦截、每一项都被单独送进提交路径。
+
+  **影响范围**：`66c344a`（#181）不在任何 tag 里，这个 bug 从未发布到 PyPI，只影响从源码部署 main 的人。
+
+  新增 `tests/bigqmt_signal_trader/test_async_batch_swallows_orders.py`，下单/批量放在文件最前面 —— 这里答错要花真钱，别的用例都没有这个性质。10 例里 5 例在修复前是红的（`git stash` 验证过）。#181 原有的批量测试从来测不到这个：它的 `_order_kwargs` 每笔都带 remark，还把 `order_stock_batch` 整个打了桩，服务端处理器根本没被跑到。
+
 - **策略名一直就在回调里，读错字段了**（#174，@sumo225270 提供 raw_fields）：#174 此前的结论是「大 QMT 的委托/成交行不带策略名，只能靠下单时记、回调时反查」。那是从一个**正确的观察**得出的**错误结论** —— `m_strStrategyName` 确实不存在（实盘列全部属性：ORDER 120 个、DEAL 47 个，两边都没有），但名字在 `m_strSource`（**报单来源**）里，就是 `passorder` 第 8 个参数 `strategyName` 原样回来。
 
   仓库自己早就记着这件事，只是从来没读回来：`docs/MiniQMT_2_BigQMT-Skill/api_mapping.md` 里 `order.strategy_name` 就映射到 `o.m_strSource`；#154 更是在实盘量过 —— 手工下的 13 行 `m_strSource` 为空，本桥下的 3 行带着策略名，而 `m_strStrategyName` 16 行全空。`rpc_default_strategy_name` 这个配置项存在的理由就是它会显示在 QMT 的报单来源列里。

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -1865,9 +1865,24 @@ class BigQmtRpcHandlers:
             or (orders[0] or {}).get("strategy_name")
             or self.default_strategy_name
         )
+        # order_stock_async routes a queued backlog through here (#181), but it
+        # never promised order_stock_batch's idempotency contract, and
+        # inheriting it swallowed orders while answering success (#190):
+        # no remark is normal for async (the single path invents
+        # "bqrpc:<uuid>"), and repeating one is legal there. Under this batch
+        # endpoint the first meant ORDER_TAG_REQUIRED and placed nothing, the
+        # second meant "already submitted" and placed one of N.
+        #
+        # Default True so deliberate order_stock_batch callers -- who supply
+        # tags precisely to be protected against a retry double-ordering --
+        # keep exactly today's behaviour. Only a caller that opts out gets the
+        # single path's semantics.
+        idempotent = params.get("idempotent")
+        idempotent = True if idempotent is None else bool(idempotent)
         existing_by_tag = {}
         lookup_ok = True
-        requires_lookup = any(bool((item or {}).get("require_idempotency_check")) for item in orders)
+        requires_lookup = idempotent and any(
+            bool((item or {}).get("require_idempotency_check")) for item in orders)
         if requires_lookup:
             try:
                 identity_query = getattr(self.order_gateway, "query_submission_identities_strict", None)
@@ -1911,6 +1926,11 @@ class BigQmtRpcHandlers:
             # keyed to one reply, which is the "把单槽改成队列" half of #181.
             item["wait_settlement"] = False
             order_tag = str(item.get("order_remark") or item.get("remark") or item.get("signal_id") or "")
+            if not order_tag and not idempotent:
+                # Same invention as _handle_submit_order, so an async order
+                # with no remark reaches the broker instead of being rejected.
+                order_tag = "bqrpc:%s" % uuid.uuid4().hex
+                item.setdefault("signal_id", order_tag)
             if not order_tag:
                 results.append({
                     "index": index,
@@ -1923,9 +1943,9 @@ class BigQmtRpcHandlers:
                     "user_order_id": "",
                 })
                 continue
-            known = existing_by_tag.get(order_tag)
+            known = existing_by_tag.get(order_tag) if idempotent else None
             journal_key = (account_id, strategy_name, order_tag)
-            journal = self._submit_journal.get(journal_key)
+            journal = self._submit_journal.get(journal_key) if idempotent else None
             if known is not None or journal is not None:
                 results.append({
                     "index": index,
@@ -1964,7 +1984,11 @@ class BigQmtRpcHandlers:
                     "order_sys_id": str(getattr(result, "order_sys_id", None) or ""),
                     "user_order_id": str(getattr(result, "user_order_id", None) or ""),
                 }
-                if order_tag:
+                # Not journalled when the caller opted out: those tags are not
+                # identities (async may repeat a remark for genuinely different
+                # orders), so recording them would let one suppress a later
+                # deliberate order_stock_batch item that reuses the string.
+                if order_tag and idempotent:
                     self._submit_journal[journal_key] = dict(response)
                 results.append(response)
             except Exception as exc:

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -1929,8 +1929,12 @@ class BigQmtRpcHandlers:
             if not order_tag and not idempotent:
                 # Same invention as _handle_submit_order, so an async order
                 # with no remark reaches the broker instead of being rejected.
-                order_tag = "bqrpc:%s" % uuid.uuid4().hex
-                item.setdefault("signal_id", order_tag)
+                # Only the signal_id is set: _handle_submit_order derives the
+                # remark from it as "bqrpc:rpc-<hex>", and pre-building the
+                # remark here would double the prefix and change the string QMT
+                # shows in 备注 (which #152's settlement lookup matches on).
+                item.setdefault("signal_id", "rpc-%s" % uuid.uuid4().hex)
+                order_tag = "bqrpc:%s" % item["signal_id"]
             if not order_tag:
                 results.append({
                     "index": index,

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -3939,9 +3939,17 @@ class BigQmtXtTrader:
             item = {name: value for name, value in fields.items()
                     if name != "account" and value is not None}
             item["wait_settlement"] = False
+            # A unique per-item signal_id, for the same reason the single path
+            # invents one (#190). It also makes the no-remark case safe against
+            # a server that predates the idempotent flag: the batch tag falls
+            # back to signal_id, so distinct ids cannot collide into a dedup.
+            # An explicit order_remark still wins, and still reaches QMT as the
+            # user wrote it.
+            item.setdefault("signal_id", "bqrpc:%s" % uuid.uuid4().hex)
             payload.append(item)
         try:
-            results = self.order_stock_batch(account_id, payload) or []
+            results = self.order_stock_batch(account_id, payload,
+                                             idempotent=False) or []
         except Exception:
             log.exception("async batch of %d failed; submitting one at a time",
                           len(group))
@@ -4164,7 +4172,15 @@ class BigQmtXtTrader:
                 time.sleep(0.005)
         return True
 
-    def order_stock_batch(self, account, orders, batch_id=""):
+    def order_stock_batch(self, account, orders, batch_id="", idempotent=True):
+        """Submit N orders in one RPC.
+
+        ``idempotent`` (default True, unchanged) is the batch contract: every
+        item needs a tag, and a tag already submitted answers success without
+        placing again, so a retried batch cannot double-order. Pass False for
+        callers that never agreed to that -- order_stock_async routes its
+        backlog through here (#181) and lost orders to it (#190).
+        """
         account_id = _account_id(account, self.client.account_id)
         payload = []
         for item in orders or []:
@@ -4172,6 +4188,8 @@ class BigQmtXtTrader:
             entry.setdefault("account_id", account_id)
             payload.append(entry)
         params = {"account_id": account_id, "orders": payload}
+        if not idempotent:
+            params["idempotent"] = False
         if batch_id:
             params["batch_id"] = str(batch_id)
         return self.client.call(

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -3945,7 +3945,13 @@ class BigQmtXtTrader:
             # back to signal_id, so distinct ids cannot collide into a dedup.
             # An explicit order_remark still wins, and still reaches QMT as the
             # user wrote it.
-            item.setdefault("signal_id", "bqrpc:%s" % uuid.uuid4().hex)
+            #
+            # "rpc-<hex>", character for character what _handle_submit_order
+            # invents, so the remark QMT shows for a no-remark async order is
+            # the same "bqrpc:rpc-<hex>" it was on 0.3.20 -- that string is
+            # visible in 备注 and is what the settlement lookup matches on
+            # (#152), so its shape is not free to drift.
+            item.setdefault("signal_id", "rpc-%s" % uuid.uuid4().hex)
             payload.append(item)
         try:
             results = self.order_stock_batch(account_id, payload,

--- a/tests/bigqmt_signal_trader/test_async_batch_swallows_orders.py
+++ b/tests/bigqmt_signal_trader/test_async_batch_swallows_orders.py
@@ -221,6 +221,37 @@ class AsyncPathSendsTheOptOutTest(unittest.TestCase):
         self.assertIs(seen["idempotent"], False)
         self.assertEqual(len(set(seen["signal_ids"])), 3, seen["signal_ids"])
         self.assertTrue(all(seen["signal_ids"]), seen["signal_ids"])
+        # "rpc-" so the server derives the same "bqrpc:rpc-<hex>" remark the
+        # single path does; see RemarkShapeUnchangedTest.
+        self.assertTrue(all(s.startswith("rpc-") for s in seen["signal_ids"]),
+                        seen["signal_ids"])
+
+
+class RemarkShapeUnchangedTest(unittest.TestCase):
+    """A no-remark async order must carry the same remark it did on 0.3.20.
+
+    The string is visible in QMT's 备注 column and is what the settlement
+    lookup matches on (#152), so the auto-tag's shape is not free to drift --
+    an earlier draft of the #190 fix produced "bqrpc:bqrpc:<hex>".
+    """
+
+    def _remarks(self, gateway):
+        return [str(getattr(r, "remark", "") or "") for r in gateway.submitted]
+
+    def test_batch_auto_tag_matches_the_single_path(self):
+        single = DryRunOrderGateway()
+        _handlers(single)._handle_submit_order(
+            dict(_item("600000.SH"), wait_settlement=False))
+        batched = DryRunOrderGateway()
+        _handlers(batched)._handle_submit_orders_batch({
+            "account_id": "acct", "idempotent": False,
+            "orders": [_item("600000.SH")]})
+
+        one, many = self._remarks(single)[0], self._remarks(batched)[0]
+        self.assertTrue(one.startswith("bqrpc:rpc-"), one)
+        self.assertEqual(len(one), len(many), (one, many))
+        self.assertEqual(one.rsplit("-", 1)[0], many.rsplit("-", 1)[0], (one, many))
+        self.assertNotIn("bqrpc:bqrpc:", many)
 
 
 if __name__ == "__main__":

--- a/tests/bigqmt_signal_trader/test_async_batch_swallows_orders.py
+++ b/tests/bigqmt_signal_trader/test_async_batch_swallows_orders.py
@@ -1,0 +1,227 @@
+# coding: utf-8
+"""#181 rerouted order_stock_async through the batch endpoint, which has a
+different contract -- and orders got swallowed.
+
+Reported from live use: on 0.3.20 a loop of async orders places every order;
+after #181 the same loop places nothing unless another call is interleaved,
+and a burst of orders produces a callback per order while Big QMT's 委托 list
+shows one.
+
+Both symptoms are the same cause. _handle_submit_order (the single path)
+auto-tags an order that carries no remark and never dedups:
+
+    signal_id = str(params.get("signal_id") or "rpc-%s" % uuid.uuid4().hex)
+    order_tag = str(params.get("remark") or params.get("order_remark") or "").strip()
+    if not order_tag:
+        order_tag = "bqrpc:%s" % signal_id
+
+_handle_submit_orders_batch does the opposite on both counts: no tag is a hard
+rejection (ORDER_TAG_REQUIRED), and a tag seen before answers success without
+submitting. That idempotency is a deliberate order_stock_batch feature; it was
+never part of order_stock_async's contract, and a caller who repeats a remark
+-- or omits it -- silently loses orders while every callback reports success.
+
+The interleaving in the report is the batching threshold: one queued job takes
+the single path, so slowing the loop down hides the bug.
+
+The fix opts the async path out rather than weakening the batch endpoint:
+order_stock_batch callers supply tags precisely so a retry cannot double-order,
+and that default is pinned below.
+
+These are order-placement tests and they lead the file deliberately: a wrong
+answer here costs real money, unlike anything else in the suite.
+"""
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+from bigqmt_signal_trader.adapters.order_dryrun import DryRunOrderGateway
+from test_redis_rpc import FakeMarketData, FakePositionProvider
+
+
+def _handlers(gateway):
+    return BigQmtRpcHandlers(
+        account_id="acct", market_data=FakeMarketData(),
+        position_provider=FakePositionProvider(), order_gateway=gateway,
+        allow_order_methods=True,
+    )
+
+
+def _item(code, remark=None):
+    item = {"stock_code": code, "order_type": 23, "order_volume": 100,
+            "price_type": 11, "price": 10.0, "strategy_name": "s"}
+    if remark is not None:
+        item["order_remark"] = remark
+    return item
+
+
+class AsyncBacklogPlacesEveryOrderTest(unittest.TestCase):
+    """With idempotency opted out, the batch places one order per item."""
+
+    def test_batch_without_remark_places_every_order(self):
+        """No remark is the common async case -- it must not be a rejection.
+
+        The single path invents "bqrpc:<uuid>" for exactly this; the batch
+        endpoint answered ORDER_TAG_REQUIRED and placed nothing, which is the
+        reported "in a loop, ordering alone places no order".
+        """
+        gateway = DryRunOrderGateway()
+        results = _handlers(gateway)._handle_submit_orders_batch({
+            "account_id": "acct", "idempotent": False,
+            "orders": [_item("600000.SH"), _item("600001.SH"), _item("600002.SH")],
+        })
+        self.assertEqual(len(gateway.submitted), 3,
+                         "batch placed %d of 3 orders; results=%r"
+                         % (len(gateway.submitted), results))
+        self.assertTrue(all(r.get("success") for r in results), results)
+
+    def test_batch_with_repeated_remark_places_every_order(self):
+        """A repeated remark is legal for async and must not dedup.
+
+        This is the "many orders at once, one order in the UI" report: items
+        2..N matched _submit_journal on the shared tag and answered
+        success/idempotent without ever reaching the gateway.
+        """
+        gateway = DryRunOrderGateway()
+        results = _handlers(gateway)._handle_submit_orders_batch({
+            "account_id": "acct", "idempotent": False,
+            "orders": [_item("600000.SH", "same"), _item("600001.SH", "same"),
+                       _item("600002.SH", "same")],
+        })
+        self.assertEqual(len(gateway.submitted), 3,
+                         "batch placed %d of 3 orders; results=%r"
+                         % (len(gateway.submitted), results))
+
+    def test_reported_success_never_exceeds_orders_actually_placed(self):
+        """The dangerous half: success is reported for orders that never ran.
+
+        A caller reading these results has no way to tell a placed order from a
+        swallowed one, so this holds even if the counts above are allowed to
+        differ for some other reason.
+        """
+        gateway = DryRunOrderGateway()
+        results = _handlers(gateway)._handle_submit_orders_batch({
+            "account_id": "acct", "idempotent": False,
+            "orders": [_item("600000.SH", "same"), _item("600001.SH", "same")],
+        })
+        claimed = sum(1 for r in results if r.get("success"))
+        self.assertLessEqual(claimed, len(gateway.submitted),
+                             "reported %d successes for %d placed orders: %r"
+                             % (claimed, len(gateway.submitted), results))
+
+
+class SinglePathControlTest(unittest.TestCase):
+    """0.3.20's path, unchanged -- proves the batch endpoint is the deviation."""
+
+    def test_single_path_places_every_order_without_a_remark(self):
+        gateway = DryRunOrderGateway()
+        handlers = _handlers(gateway)
+        for code in ("600000.SH", "600001.SH", "600002.SH"):
+            handlers._handle_submit_order(dict(_item(code), wait_settlement=False))
+        self.assertEqual(len(gateway.submitted), 3)
+
+    def test_single_path_places_every_order_with_a_repeated_remark(self):
+        gateway = DryRunOrderGateway()
+        handlers = _handlers(gateway)
+        for code in ("600000.SH", "600001.SH", "600002.SH"):
+            handlers._handle_submit_order(
+                dict(_item(code, "same"), wait_settlement=False))
+        self.assertEqual(len(gateway.submitted), 3)
+
+
+class OldServerFallbackTest(unittest.TestCase):
+    """A new client against a server that predates the idempotent flag.
+
+    The flag is ignored there, so the client's unique per-item signal_id is
+    what keeps the no-remark case working: the batch tag falls back to
+    signal_id, and distinct ids cannot collide into a dedup.
+    """
+
+    def test_unique_signal_ids_survive_a_server_without_the_flag(self):
+        gateway = DryRunOrderGateway()
+        orders = []
+        for code in ("600000.SH", "600001.SH", "600002.SH"):
+            item = _item(code)
+            item["signal_id"] = "bqrpc:%s" % code
+            orders.append(item)
+        _handlers(gateway)._handle_submit_orders_batch({
+            "account_id": "acct", "orders": orders})   # no idempotent flag
+        self.assertEqual(len(gateway.submitted), 3)
+
+
+class BatchContractUnchangedTest(unittest.TestCase):
+    """order_stock_batch's own callers must see exactly the old behaviour.
+
+    Its idempotency is the guard against a retried batch double-ordering, so
+    the async fix must not reach it. Default = today.
+    """
+
+    def test_missing_tag_is_still_rejected_by_default(self):
+        gateway = DryRunOrderGateway()
+        results = _handlers(gateway)._handle_submit_orders_batch({
+            "account_id": "acct", "orders": [_item("600000.SH")]})
+        self.assertEqual(len(gateway.submitted), 0)
+        self.assertEqual(results[0]["error"], "ORDER_TAG_REQUIRED")
+        self.assertTrue(results[0]["explicit_failure"])
+
+    def test_repeated_tag_is_still_deduped_by_default(self):
+        gateway = DryRunOrderGateway()
+        results = _handlers(gateway)._handle_submit_orders_batch({
+            "account_id": "acct",
+            "orders": [_item("600000.SH", "tag"), _item("600001.SH", "tag")]})
+        self.assertEqual(len(gateway.submitted), 1)
+        self.assertFalse(results[0]["idempotent"])
+        self.assertTrue(results[1]["idempotent"])
+
+    def test_opting_out_does_not_journal_tags_for_later_batches(self):
+        """An async order must not suppress a later deliberate batch item."""
+        gateway = DryRunOrderGateway()
+        handlers = _handlers(gateway)
+        handlers._handle_submit_orders_batch({
+            "account_id": "acct", "idempotent": False,
+            "orders": [_item("600000.SH", "shared")]})
+        results = handlers._handle_submit_orders_batch({
+            "account_id": "acct",
+            "orders": [_item("600001.SH", "shared")]})
+        self.assertEqual(len(gateway.submitted), 2)
+        self.assertFalse(results[0]["idempotent"])
+
+
+class AsyncPathSendsTheOptOutTest(unittest.TestCase):
+    """The client half: the async backlog must actually opt out."""
+
+    def test_submit_async_batch_opts_out_and_tags_each_item(self):
+        from bigqmt_signal_trader.xtquant_compat import BigQmtXtTrader
+
+        trader = BigQmtXtTrader.__new__(BigQmtXtTrader)
+        seen = {}
+
+        def fake_batch(account, orders, batch_id="", idempotent=True):
+            seen["idempotent"] = idempotent
+            seen["signal_ids"] = [o.get("signal_id") for o in orders]
+            return [{"index": i, "success": True, "order_sys_id": "s%d" % i,
+                     "user_order_id": "", "code": 0, "error": ""}
+                    for i in range(len(orders))]
+
+        trader.order_stock_batch = fake_batch
+        trader._enqueue_batch_outcome = lambda seq, fields, entry: None
+        group = [((i, (), dict(stock_code="60000%d.SH" % i, order_type=23,
+                               order_volume=100, price_type=11, price=10.0)),
+                  {"stock_code": "60000%d.SH" % i, "order_type": 23,
+                   "order_volume": 100, "price_type": 11, "price": 10.0})
+                 for i in range(3)]
+        trader._submit_async_batch("acct", group)
+
+        self.assertIs(seen["idempotent"], False)
+        self.assertEqual(len(set(seen["signal_ids"])), 3, seen["signal_ids"])
+        self.assertTrue(all(seen["signal_ids"]), seen["signal_ids"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_async_order_batch.py
+++ b/tests/bigqmt_signal_trader/test_async_order_batch.py
@@ -41,7 +41,7 @@ def _order_kwargs(code, remark):
                 order_remark=remark)
 
 
-def _ok_batch(account, orders, batch_id=""):
+def _ok_batch(account, orders, batch_id="", idempotent=True):
     return [{
         "index": index, "success": True,
         "order_sys_id": "sys-%s" % item.get("order_remark"),
@@ -60,7 +60,7 @@ class BatchSelectionTest(unittest.TestCase):
             lambda *a, **k: calls["single"].append(a) or
             {"order_sys_id": "sys-single", "user_order_id": ""})
         trader.order_stock_batch = (
-            lambda account, orders, batch_id="":
+            lambda account, orders, batch_id="", idempotent=True:
             calls["batch"].append((account, orders)) or _ok_batch(account, orders))
         return trader, recorder, calls
 
@@ -93,7 +93,7 @@ class BatchSelectionTest(unittest.TestCase):
     def test_a_failing_batch_falls_back_to_single_submits(self):
         trader, rec, calls = self._trader()
         calls_log = []
-        def raising_batch(account, orders, batch_id=""):
+        def raising_batch(account, orders, batch_id="", idempotent=True):
             calls_log.append(len(orders))
             raise RuntimeError("network gone")
         trader.order_stock_batch = raising_batch
@@ -109,7 +109,7 @@ class BatchSelectionTest(unittest.TestCase):
 
     def test_an_empty_batch_result_falls_back_to_single_submits(self):
         trader, rec, calls = self._trader()
-        trader.order_stock_batch = lambda account, orders, batch_id="": []
+        trader.order_stock_batch = lambda account, orders, batch_id="", idempotent=True: []
         seqs = [trader.order_stock_async("acct", "60%04d.SH" % i, 23, 100, 11,
                                          10.0, "s", "r-%d" % i)
                 for i in range(2)]
@@ -125,7 +125,7 @@ class BatchSelectionTest(unittest.TestCase):
     def test_a_failed_item_errors_alone(self):
         trader, rec, _calls = self._trader()
 
-        def mixed_batch(account, orders, batch_id=""):
+        def mixed_batch(account, orders, batch_id="", idempotent=True):
             results = _ok_batch(account, orders)
             results[1] = {"index": 1, "success": False, "code": -1,
                           "error": "ORDER_REJECTED", "user_order_id": "r-1"}
@@ -148,7 +148,7 @@ class BatchSelectionTest(unittest.TestCase):
         batches = []
         singles = []
 
-        def tracking_batch(account, orders, batch_id=""):
+        def tracking_batch(account, orders, batch_id="", idempotent=True):
             batches.append((account, list(orders)))
             return _ok_batch(account, orders)
 


### PR DESCRIPTION
修复 #190。实盘报告：0.3.20 正常，之后的 main 上 while 循环里异步下单**连第一单都下不出去**，插一个 `query_stock_orders` / `query_stock_asset` 就又能下了；以及同时下很多单、回调回来一堆、大 QMT 委托列表里只有一单。

## 根因

#181 让 `order_stock_async` 的积压走 `order_stock_batch` 省往返，于是异步下单继承了一份它从没答应过的契约。两个端点在这两点上正好相反：

| | `_handle_submit_order`（单笔，0.3.20 的路径） | `_handle_submit_orders_batch` |
|---|---|---|
| 没有 remark | 自动补 `bqrpc:rpc-<hex>` | `ORDER_TAG_REQUIRED`，**不下单** |
| remark 重复 | 照下不误 | 答 `success: True, idempotent: True`，**不下单** |

没写 remark 是异步的常态，所以整批被拒 —— 包括 index 0，这就是「连第一单都下不出去」。remark 重复对异步完全合法，所以只下一单。插一个查询就好了不是查询有魔力，是它把批次打散：队列里只剩一笔时 `len(jobs) < ASYNC_BATCH_MIN` 走单笔路径，两道闸门都绕开了 —— 把循环放慢就把 bug 藏起来。

最坏的一点是被吞掉的单**返回 success**，调用方无从分辨。离线复现原文：`reported 2 successes for 1 placed orders`。

## 改法

让异步路径**显式退出**幂等契约，`order_stock_batch` 自己的默认行为一个字不动 —— 它的幂等是防重试重复下单的保险丝，不是可以顺手拆掉的东西（`test_missing_tag_is_still_rejected_by_default` / `test_repeated_tag_is_still_deduped_by_default` 钉住）。

- 服务端 `_handle_submit_orders_batch` 接受 `idempotent`（默认 `True`）。为 `False` 时：缺 tag 就照单笔路径补，不做 `existing_by_tag` / `_submit_journal` 去重，也**不写 journal** —— 异步的 remark 不是身份，记下来会压掉后面真正的批量单。
- 客户端 `order_stock_batch` 增加 `idempotent=True` 形参；`_submit_async_batch` 传 `False`，并给每项补唯一 `signal_id`。后者让**无 remark 的情况在还不认这个开关的旧服务端上也能工作**：批量的 tag 会回落到 signal_id，各不相同就撞不上去重。
- 补的 tag 是 `bqrpc:rpc-<hex>`，和 `_handle_submit_order` 一直产生的逐字一致。这个串会显示在 QMT 的备注列、也是 #152 结算查找的匹配键，形状不能随便飘（第一版写成了 `bqrpc:bqrpc:<hex>`，已修，并加了对比测试钉住）。

## 验证

**离线**：新增 `tests/bigqmt_signal_trader/test_async_batch_swallows_orders.py`，11 例，**下单/批量放在文件最前面** —— 这里答错要花真钱，别的用例都没有这个性质。其中 5 例在修复前是红的（`git stash` 验证）。全量 1554 通过，收集数 116/116。

#181 原有的批量测试测不到这个：它的 `_order_kwargs` 每笔都带 remark，还把 `order_stock_batch` 整个打了桩，服务端处理器根本没被跑到。

**实盘前后对照，未下任何单**：报告人的场景原样复现 —— 紧凑 while 循环调 `order_stock_async`、不插查询、不带 remark，每项 `order_volume=0`，在 `_handle_submit_order` 的 `volume must be positive` 就退出，到不了 passorder。同一台桥、同一个脚本，只换服务端与客户端版本：

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 无 remark，8 笔 | **0/8 到达提交路径，8 笔全被 `ORDER_TAG_REQUIRED` 拦** | **8/8** |
| 无 remark 走默认契约 | `ORDER_TAG_REQUIRED` | `ORDER_TAG_REQUIRED`（未变） |

**去重那一半没有实盘证据，只有离线测试。** 这个探针证不了它：去重靠 `_submit_journal`，而 journal 只在提交成功之后才写；`volume=0` 让每笔都在写 journal 之前抛错，去重根本没机会触发 —— 修复前修复后同样是 8/8。要在实盘证它必须真下单。离线用 DryRun gateway 提交会成功、journal 会写，那里 3 笔同 remark 修复前只下 1 笔、修复后 3 笔全下。

**未验证**：没真下过单，所以证不到「循环里 N 笔异步单最终在委托列表里出现 N 行」。

## 关于历史里的 revert

这个修复我先前直接提交到了 main（`a8af642`），之后才被要求走 PR。main 上的 `08aee25` 把它 revert 了，本 PR 用 cherry-pick 重新落地，合并后 main 的最终状态与直接提交一致。

## 影响范围

`66c344a`（#181）不在任何 tag 里，所以这个 bug 从未发布到 PyPI，只影响从源码部署 main 的人。
