### PR TITLE
test: pin the #190 reporter's tight async loop end to end (#191)

### DIFF
--- a/tests/bigqmt_signal_trader/test_async_batch_swallows_orders.py
+++ b/tests/bigqmt_signal_trader/test_async_batch_swallows_orders.py
@@ -193,6 +193,66 @@ class BatchContractUnchangedTest(unittest.TestCase):
         self.assertFalse(results[0]["idempotent"])
 
 
+class TightLoopEndToEndTest(unittest.TestCase):
+    """The reporter's scenario verbatim, offline: a tight order_stock_async
+    loop with NO remark, driven through the real worker/batcher/dispatcher and
+    answered by the real server handler (dry-run gateway standing in for
+    passorder).
+
+    Live on the fixed build (2026-09-04, after close, 20 limit-down buys):
+    20/20 orders reached the submit path and were recorded; before the fix the
+    same loop placed 0 (ORDER_TAG_REQUIRED swallowed the batch). Everything in
+    between -- queueing, batch selection, the idempotent=False opt-out, unique
+    per-item tagging, per-seq callbacks -- is what this pins.
+    """
+
+    def test_tight_loop_without_remarks_places_and_answers_every_order(self):
+        from bigqmt_signal_trader.xtquant_compat import (
+            BigQmtXtTrader, XtQuantTraderCallback)
+
+        gateway = DryRunOrderGateway()
+        handlers = _handlers(gateway)
+
+        class Recorder(XtQuantTraderCallback):
+            def __init__(self):
+                self.responses = []
+                self.errors = []
+
+            def on_order_stock_async_response(self, r):
+                self.responses.append(r)
+
+            def on_order_error(self, e):
+                self.errors.append(e)
+
+        trader = BigQmtXtTrader(account_id="acct")
+        recorder = Recorder()
+        trader.register_callback(recorder)
+
+        # The batch seam wired to the REAL server handler, the way the fixed
+        # bridge answers it.
+        def real_batch(account, orders, batch_id="", idempotent=True):
+            params = {"account_id": "acct", "orders": list(orders)}
+            params["idempotent"] = idempotent
+            return handlers._handle_submit_orders_batch(params)
+
+        trader.order_stock_batch = real_batch
+        n = 20
+        seqs = [trader.order_stock_async("acct", "601398.SH", 23, 100, 11, 7.32)
+                for _ in range(n)]
+
+        self.assertTrue(trader.wait_async_orders(timeout=5.0))
+        trader.stop()
+
+        self.assertEqual(len(gateway.submitted), n,
+                         "placed %d of %d orders" % (len(gateway.submitted), n))
+        self.assertEqual([e.error_msg for e in recorder.errors], [])
+        self.assertEqual(len(recorder.responses), n)
+        self.assertEqual([r.seq for r in recorder.responses], seqs)
+        order_ids = [str(r.order_id) for r in recorder.responses]
+        self.assertEqual(len(set(order_ids)), n,
+                         "order ids must not collapse: %r" % order_ids)
+
+
 class AsyncPathSendsTheOptOutTest(unittest.TestCase):
     """The client half: the async backlog must actually opt out."""
 


### PR DESCRIPTION
# 内容

把 #191 的实盘验证固化成离线端到端回归测试，加在 `test_async_batch_swallows_orders.py`（#190 的测试文件）里。

#190 修复自带的 11 个用例钉住了 handler 契约和 `_submit_async_batch` 单元行为，但没有一条从**公开 API** `order_stock_async` 紧凑循环驱动——而报告人踩的正是这条完整链路。

新用例 `TightLoopEndToEndTest::test_tight_loop_without_remarks_places_and_answers_every_order`：

- 20 笔**无 remark** 的 `order_stock_async` 紧凑循环（报告场景原样）
- 走真实的 worker / 批量选择 / 回调分发线程
- `order_stock_batch` seam 接到**真实** `_handle_submit_orders_batch`（DryRunOrderGateway 顶替 passorder）
- 断言：20/20 进入提交路径、0 个 error 回调、20/20 response 按 seq 序、order_id 两两不同（自动补的 tag 不塌缩）

测试体里记录了实盘对照：2026-09-04 盘后，20 笔跌停价买 601398.SH，修复后 20/20 到达提交路径并被记录（修复前同场景 0/8）。

# 验证

- 对修复前代码为红：worktree 检出 `986a136`（a8af642^），新用例失败（20 笔中 0 笔下出）
- 对当前 main 为绿；全量 **1555 通过，116/116 模块收集**
