### PR TITLE
fix: zmq 客户端每线程一个 DEALER，redis 关闭不再甩 traceback (#186, #189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/) 和 [语义化版本](https://semver.org/)。
 
 
+## [未发布]
+
+### 性能
+
+- **zmq 客户端不再把并发请求排成一队**（#186）：`send_request` 此前在**整个** send/poll/recv 周期内持 `_client_lock`，因为客户端只有一个 DEALER socket 而 zmq socket 不是线程安全的。于是多线程调用只能轮流来。实盘 4 并发实测：zmq 的 ping 从 2.4 只到 2.7 次每秒（drain 模式 10.2 到 10.2，纹丝不动），而没有这把锁的 redis 从 20.7 到 **143.3**。线程数在 zmq 上买不到任何东西。
+
+  改成 zmq 自己的答案 —— **每个调用线程一个 socket**，各自随机 IDENTITY，服务端 ROUTER 把回复路由回发起的那个线程 —— 而不是给共享 socket 加锁。`_client_lock` 现在只保护注册表。
+
+  一个线程一个 socket 的风险是泄漏：按请求开线程的调用方会给每个线程留一条到 ROUTER 的 TCP 连接。所以建新 socket 时顺带回收已退出线程的（它们的 owner 已经消失，不可能有人正在其中收发，这正是可以从别的线程关掉它们的理由），`stop()` 关掉全部。
+
+  **实盘未验证**：这是纯客户端改动，而当前部署跑的是 redis transport，根本不经过这段代码；要验它得把终端换成 zmq 再重启。离线用假 socket 钉住了真正的回归 —— 4 个并发调用在一次 0.3 秒往返里必须重叠而不是排队（修复前 4 例红）。
+
+### 修复
+
+- **redis transport 停止时不再甩完整 traceback**（#189）：`stop()` 在监听线程正停在 `get_message(timeout=1.0)` 时把 pubsub 关掉，socket 在它脚下失效 —— Windows 上是 `WinError 10038` 包在 `redis.exceptions.ConnectionError` 里，而循环的裸 `except Exception` 把整个栈打出来，实盘一次重启三条。
+
+  纯噪声，但代价是真的：**正常关闭和真故障长得一模一样**，读的人学会忽略这个 traceback 之后，真出问题那次也会被忽略。现在 `except` 里先看 `self._running`，已经在停就安静退出；队列循环同样处理。
+
+  **实盘前后对照**：同一台桥、同一个 reload 操作，只换代码 —— 拆旧代码的那次 **3 个 traceback**（正是报告里的数量），拆新代码的那次 **0 个**。离线四例覆盖两个循环的安静退出，以及**运行中仍然大声报错**的负面对照 —— 让关闭安静下来不能顺带让故障也安静。
+
 ## [0.3.21] - 2026-09-04
 
 ### 性能

--- a/src/bigqmt_signal_trader/transports/redis_transport.py
+++ b/src/bigqmt_signal_trader/transports/redis_transport.py
@@ -189,6 +189,14 @@ class RedisTransport(RpcTransport):
                         continue
                     self._handle_received_payload(message.get("data"), "pubsub")
             except Exception:
+                if not self._running:
+                    # stop() closes the pubsub while this thread is parked in
+                    # get_message, so the socket dies under it -- WinError
+                    # 10038 wrapped in a redis ConnectionError. That is the
+                    # normal shutdown path, and printing a full traceback for
+                    # it made every restart look like a failure and taught
+                    # readers to skip the one that is not (#189).
+                    break
                 print(
                     "%s listener failed:\n%s" % (self.print_prefix, traceback.format_exc())
                 )
@@ -221,6 +229,8 @@ class RedisTransport(RpcTransport):
                     )
                     self._handle_received_payload(raw, "queue")
             except Exception:
+                if not self._running:
+                    break          # shutdown, same as the pubsub loop (#189)
                 print(
                     "%s queue listener failed:\n%s"
                     % (self.print_prefix, traceback.format_exc())

--- a/src/bigqmt_signal_trader/transports/zmq_transport.py
+++ b/src/bigqmt_signal_trader/transports/zmq_transport.py
@@ -166,8 +166,18 @@ class ZmqTransport(RpcTransport):
         # Reported by the stall watchdog below; None when idle.
         self._in_flight = None
         self._stall_thread = None
-        # client state
-        self._dealer = None
+        # client state. One DEALER per calling thread (#186): a zmq socket is
+        # not thread-safe, and the single shared one had to be held for the
+        # whole send/poll/recv cycle -- so N threads took turns and concurrency
+        # bought nothing. Measured on the live terminal, 4 threads moved zmq
+        # from 2.4 to 2.7 requests/sec while redis, which has no such lock,
+        # went from 20.7 to 143.3.
+        #
+        # One socket per thread is zmq's own answer. Each gets its own random
+        # IDENTITY, so the server's ROUTER routes every reply back to the
+        # thread that asked. _client_lock now guards only the registry.
+        self._dealer_local = threading.local()
+        self._dealers = []          # [(thread, socket)] for shutdown + pruning
         self._client_lock = threading.Lock()
 
     # -- construction helper ----------------------------------------------
@@ -579,46 +589,75 @@ class ZmqTransport(RpcTransport):
             return None
         return text or None
 
+    def _reap_dead_dealers(self):
+        """Close sockets whose owning thread has exited. Caller holds the lock.
+
+        Without this a caller that spawns a thread per request would leak one
+        socket -- and one TCP connection to the ROUTER -- per thread until
+        stop(). The owner is gone by definition here, so nobody can be inside
+        a send or recv on it; that is what makes closing it from this thread
+        safe, unlike the router socket (see stop()).
+        """
+        alive = []
+        for owner, sock in self._dealers:
+            if owner.is_alive():
+                alive.append((owner, sock))
+                continue
+            try:
+                sock.close(linger=0)
+            except Exception:
+                pass
+        self._dealers = alive
+
     def _ensure_dealer(self):
+        """This thread's DEALER, created on first use."""
+        sock = getattr(self._dealer_local, "sock", None)
+        if sock is not None:
+            return sock
         zmq, ctx = self._ensure_zmq()
-        if self._dealer is None:
-            address = self._resolve_connect_address()
-            sock = ctx.socket(zmq.DEALER)
-            # Unique identity so ROUTER can route replies back to us.
-            sock.setsockopt(zmq.IDENTITY, uuid.uuid4().hex.encode("utf-8")[:16])
-            sock.setsockopt(zmq.LINGER, self.client_linger_ms)
-            sock.connect(address)
-            self._dealer = sock
+        address = self._resolve_connect_address()
+        sock = ctx.socket(zmq.DEALER)
+        # Unique identity so ROUTER can route replies back to us.
+        sock.setsockopt(zmq.IDENTITY, uuid.uuid4().hex.encode("utf-8")[:16])
+        sock.setsockopt(zmq.LINGER, self.client_linger_ms)
+        sock.connect(address)
+        self._dealer_local.sock = sock
+        with self._client_lock:
+            self._reap_dead_dealers()
+            self._dealers.append((threading.current_thread(), sock))
             self.connect_address = address
-        return self._dealer
+        return sock
 
     def send_request(self, request, timeout_seconds, **_kwargs):
+        # No lock around the round trip: this socket belongs to this thread
+        # and no other thread touches it (#186).
         zmq = self._zmq or self._ensure_zmq()[0]
-        with self._client_lock:
-            dealer = self._ensure_dealer()
-            request = dict(request)
-            request.setdefault("request_id", uuid.uuid4().hex)
-            request_id = request["request_id"]
-            payload = encode_rpc_request_payload(request)
-            try:
-                dealer.send(payload.encode("utf-8"))
-            except Exception as exc:
-                raise TransportError("zmq send failed: %s" % exc)
-            deadline = time.time() + float(timeout_seconds)
-            poller = self._zmq.Poller()
-            poller.register(dealer, self._zmq.POLLIN)
-            while True:
-                remaining = deadline - time.time()
-                if remaining <= 0:
-                    break
-                events = dict(poller.poll(timeout=int(remaining * 1000)))
-                if dealer in events:
-                    frames = dealer.recv_multipart()
-                    raw = frames[-1]
-                    response = _loads(raw)
-                    if response.get("request_id") == request_id:
-                        return response
-            raise TransportTimeout("zmq rpc timeout: %s" % request.get("method"))
+        dealer = self._ensure_dealer()
+        request = dict(request)
+        request.setdefault("request_id", uuid.uuid4().hex)
+        request_id = request["request_id"]
+        payload = encode_rpc_request_payload(request)
+        try:
+            dealer.send(payload.encode("utf-8"))
+        except Exception as exc:
+            raise TransportError("zmq send failed: %s" % exc)
+        deadline = time.time() + float(timeout_seconds)
+        poller = zmq.Poller()
+        poller.register(dealer, zmq.POLLIN)
+        while True:
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                break
+            events = dict(poller.poll(timeout=int(remaining * 1000)))
+            if dealer in events:
+                frames = dealer.recv_multipart()
+                raw = frames[-1]
+                response = _loads(raw)
+                # A late reply to a request that already timed out lands here;
+                # skipping it keeps this thread's socket usable afterwards.
+                if response.get("request_id") == request_id:
+                    return response
+        raise TransportTimeout("zmq rpc timeout: %s" % request.get("method"))
 
     # -- lifecycle --------------------------------------------------------
     def stop(self):
@@ -641,10 +680,18 @@ class ZmqTransport(RpcTransport):
             self._clear_discovery()
             self._actual_bind_address = None
         with self._client_lock:
-            if self._dealer is not None:
+            for _owner, sock in self._dealers:
                 try:
-                    self._dealer.close(linger=self.client_linger_ms)
+                    sock.close(linger=self.client_linger_ms)
                 except Exception:
                     pass
-                self._dealer = None
+            self._dealers = []
+        # The caller's own thread-local still points at a closed socket; drop
+        # it so a send_request after stop() builds a fresh one rather than
+        # raising on a dead handle. Other threads' locals are unreachable from
+        # here -- their sockets are closed above, and _ensure_dealer would hand
+        # back the closed one, so those threads must not reuse the transport
+        # after stop(). That was true of the single shared dealer too.
+        if getattr(self._dealer_local, "sock", None) is not None:
+            self._dealer_local.sock = None
         # Do NOT terminate the shared context — other sockets/users may rely on it.

--- a/tests/bigqmt_signal_trader/test_redis_shutdown_quiet.py
+++ b/tests/bigqmt_signal_trader/test_redis_shutdown_quiet.py
@@ -1,0 +1,123 @@
+# coding: utf-8
+"""#189: a normal redis shutdown must not print a failure traceback.
+
+stop() closes the pubsub while the listener thread is parked in
+get_message(timeout=1.0), so the socket dies under it. On Windows that surfaces
+as OSError WinError 10038 wrapped in redis.exceptions.ConnectionError, and the
+loop's bare `except Exception` printed the whole traceback -- three per restart
+on the live terminal.
+
+Nothing breaks, but the noise costs something real: a normal restart looks
+exactly like a failure, so a reader learns to skip the traceback -- including
+the one that means redis is actually down. That is the CLAUDE.md rule about a
+failed operation looking exactly like one that never ran, pointed the other way.
+
+The loop must stay loud while it is supposed to be running.
+"""
+import os
+import sys
+import threading
+import unittest
+
+try:
+    from io import StringIO
+except ImportError:                       # pragma: no cover - py2 safety
+    from StringIO import StringIO
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.transports.redis_transport import RedisTransport
+
+
+class DyingPubSub(object):
+    """get_message raises the way a closed socket does."""
+
+    def __init__(self, on_call):
+        self.on_call = on_call
+
+    def subscribe(self, channel):
+        pass
+
+    def get_message(self, timeout=None):
+        self.on_call()
+        raise IOError("Error while reading from socket: (10038, ...)")
+
+    def close(self):
+        pass
+
+
+class DyingRedis(object):
+    def __init__(self, on_call):
+        self.on_call = on_call
+
+    def pubsub(self, ignore_subscribe_messages=False):
+        return DyingPubSub(self.on_call)
+
+    def brpop(self, key, timeout=None):
+        self.on_call()
+        raise IOError("Error while reading from socket: (10038, ...)")
+
+
+def _run(loop_name, running_when_it_raises):
+    """Run one iteration of a listener loop and capture what it printed."""
+    calls = []
+
+    def on_call():
+        calls.append(1)
+        if not running_when_it_raises:
+            transport._running = False    # stop() got here first
+        elif len(calls) >= 2:
+            # Let the first raise happen while running (it must be reported),
+            # then end the loop so the test does not sit through its retries.
+            transport._running = False
+
+    transport = RedisTransport(DyingRedis(on_call), account_id="acct")
+    transport._running = True
+    captured = StringIO()
+    saved, sys.stdout = sys.stdout, captured
+    try:
+        thread = threading.Thread(target=getattr(transport, loop_name))
+        thread.start()
+        thread.join(8.0)
+        alive = thread.is_alive()
+        transport._running = False
+        thread.join(3.0)
+    finally:
+        sys.stdout = saved
+    return captured.getvalue(), alive, len(calls)
+
+
+class ShutdownIsQuietTest(unittest.TestCase):
+    def test_pubsub_loop_prints_nothing_when_stopping(self):
+        out, alive, _calls = _run("_listen_loop", running_when_it_raises=False)
+        self.assertNotIn("Traceback", out)
+        self.assertNotIn("listener failed", out)
+        self.assertFalse(alive, "the loop should have exited, not retried")
+
+    def test_queue_loop_prints_nothing_when_stopping(self):
+        out, alive, _calls = _run("_queue_loop", running_when_it_raises=False)
+        self.assertNotIn("Traceback", out)
+        self.assertNotIn("queue listener failed", out)
+        self.assertFalse(alive)
+
+
+class RealFailuresStayLoudTest(unittest.TestCase):
+    """The negative control -- silencing shutdown must not silence outages."""
+
+    def test_pubsub_loop_still_reports_a_failure_while_running(self):
+        out, _alive, calls = _run("_listen_loop", running_when_it_raises=True)
+        self.assertIn("listener failed", out)
+        self.assertIn("Traceback", out)
+        self.assertGreaterEqual(calls, 1)
+
+    def test_queue_loop_still_reports_a_failure_while_running(self):
+        out, _alive, calls = _run("_queue_loop", running_when_it_raises=True)
+        self.assertIn("queue listener failed", out)
+        self.assertIn("Traceback", out)
+        self.assertGreaterEqual(calls, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_zmq_client_concurrency.py
+++ b/tests/bigqmt_signal_trader/test_zmq_client_concurrency.py
@@ -1,0 +1,198 @@
+# coding: utf-8
+"""#186: the zmq client serialized every request on one DEALER socket.
+
+send_request held _client_lock for the whole send/poll/recv cycle, because a
+zmq socket is not thread-safe and there was exactly one. So concurrent callers
+took turns. Measured on the live terminal with 4 threads:
+
+    zmq   ping 2.4 -> 2.7 requests/sec      (drain mode: 10.2 -> 10.2)
+    redis ping 20.7 -> 143.3 requests/sec   (no such lock; a pool per thread)
+
+Threads bought nothing on zmq and 7x on redis. The fix is zmq's own answer --
+one socket per thread, each with its own IDENTITY so the ROUTER routes replies
+back to the right one -- rather than a lock around a shared one.
+"""
+import json
+import os
+import sys
+import threading
+import time
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.transports import zmq_transport as zt
+from bigqmt_signal_trader.redis_rpc import (
+    decode_rpc_request_payload, encode_rpc_request_payload)
+
+
+class FakeSocket(object):
+    """Answers whatever request_id it was sent, after ``delay`` seconds."""
+
+    def __init__(self, delay=0.0):
+        self.delay = delay
+        self.identity = None
+        self.closed = False
+        self.linger_on_close = None
+        self._pending = None
+
+    def setsockopt(self, option, value):
+        if option == "IDENTITY":
+            self.identity = value
+
+    def connect(self, address):
+        self.address = address
+
+    def send(self, payload):
+        # Same wire encoding the transport uses -- b64s-prefixed, not raw JSON.
+        text = decode_rpc_request_payload(payload.decode("utf-8"))
+        self._pending = json.loads(text)["request_id"]
+
+    def recv_multipart(self):
+        reply = encode_rpc_request_payload({"request_id": self._pending, "ok": True})
+        return [reply.encode("utf-8")]
+
+    def close(self, linger=0):
+        self.closed = True
+        self.linger_on_close = linger
+
+
+class FakePoller(object):
+    def __init__(self):
+        self._socks = []
+
+    def register(self, sock, flags):
+        self._socks.append(sock)
+
+    def poll(self, timeout=None):
+        sock = self._socks[0]
+        time.sleep(sock.delay)          # the wait a real round trip costs
+        return [(sock, 1)]
+
+
+class FakeZmq(object):
+    DEALER = "DEALER"
+    IDENTITY = "IDENTITY"
+    LINGER = "LINGER"
+    POLLIN = 1
+    Poller = FakePoller
+
+
+class FakeContext(object):
+    def __init__(self, delay=0.0):
+        self.delay = delay
+        self.sockets = []
+
+    def socket(self, kind):
+        sock = FakeSocket(self.delay)
+        self.sockets.append(sock)
+        return sock
+
+
+def _client(delay=0.0):
+    transport = zt.ZmqTransport(account_id="8886800503",
+                                connect_address="tcp://127.0.0.1:15999")
+    ctx = FakeContext(delay)
+    transport._ensure_zmq = lambda: (FakeZmq, ctx)
+    return transport, ctx
+
+
+class EachThreadGetsItsOwnSocketTest(unittest.TestCase):
+    def test_two_threads_do_not_share_a_dealer(self):
+        transport, ctx = _client()
+        seen = {}
+
+        def call(name):
+            transport.send_request({"method": "ping"}, 5.0)
+            seen[name] = transport._ensure_dealer()
+
+        threads = [threading.Thread(target=call, args=(i,)) for i in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(len(ctx.sockets), 2)
+        self.assertIsNot(seen[0], seen[1])
+        self.assertNotEqual(seen[0].identity, seen[1].identity,
+                            "same IDENTITY would make ROUTER misroute replies")
+
+    def test_one_thread_reuses_its_socket(self):
+        transport, ctx = _client()
+        transport.send_request({"method": "ping"}, 5.0)
+        transport.send_request({"method": "ping"}, 5.0)
+        self.assertEqual(len(ctx.sockets), 1)
+
+
+class ConcurrentCallsOverlapTest(unittest.TestCase):
+    """The actual regression: two calls must not take twice one call's time."""
+
+    def test_four_threads_overlap_instead_of_queueing(self):
+        delay = 0.3
+        transport, _ctx = _client(delay)
+        errors = []
+
+        def call():
+            try:
+                transport.send_request({"method": "ping"}, 5.0)
+            except Exception as exc:            # noqa: BLE001 - reported below
+                errors.append(exc)
+
+        threads = [threading.Thread(target=call) for _ in range(4)]
+        started = time.time()
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        elapsed = time.time() - started
+
+        self.assertEqual(errors, [])
+        # Serialized would be 4 * 0.3 = 1.2s; overlapped is ~0.3s.
+        self.assertLess(elapsed, delay * 2,
+                        "4 concurrent calls took %.2fs for a %.2fs round trip "
+                        "-- they are still serialized" % (elapsed, delay))
+
+
+class SocketLifecycleTest(unittest.TestCase):
+    def test_stop_closes_every_thread_s_socket(self):
+        transport, ctx = _client()
+        done = threading.Event()
+
+        def call():
+            transport.send_request({"method": "ping"}, 5.0)
+            done.set()
+
+        worker = threading.Thread(target=call)
+        worker.start()
+        worker.join()
+        transport.send_request({"method": "ping"}, 5.0)   # this thread's own
+
+        self.assertTrue(done.is_set())
+        self.assertEqual(len(ctx.sockets), 2)
+        transport.stop()
+        self.assertTrue(all(s.closed for s in ctx.sockets),
+                        [s.closed for s in ctx.sockets])
+
+    def test_a_dead_thread_s_socket_is_reaped_not_leaked(self):
+        """One socket per thread must not mean one leak per thread.
+
+        A caller that spawns a thread per request would otherwise hold a TCP
+        connection to the ROUTER for every thread it ever created.
+        """
+        transport, ctx = _client()
+        for _ in range(5):
+            worker = threading.Thread(
+                target=lambda: transport.send_request({"method": "ping"}, 5.0))
+            worker.start()
+            worker.join()
+
+        live = [sock for sock in ctx.sockets if not sock.closed]
+        self.assertLessEqual(len(live), 1,
+                             "%d sockets still open after 5 threads exited"
+                             % len(live))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
修 #186 和 #189。

## #186：zmq 客户端把并发请求排成一队

`send_request` 在**整个** send/poll/recv 周期内持 `_client_lock` —— 客户端只有一个 DEALER socket，而 zmq socket 不是线程安全的，所以这把锁是必需的，但它让多线程调用只能轮流来。

实盘 4 并发实测：

| | 串行 | 4 并发 |
|---|---|---|
| zmq + 后台线程 | ping 2.4 次每秒 | 2.7 |
| zmq + drain | ping 10.2 次每秒 | 10.2 |
| redis（没有这把锁）| ping 20.7 次每秒 | **143.3** |

线程数在 zmq 上买不到任何东西。

**改法**是 zmq 自己的答案 —— **每个调用线程一个 socket**，各自随机 IDENTITY，服务端 ROUTER 把回复路由回发起的那个线程 —— 而不是给共享 socket 加锁。`_client_lock` 现在只保护注册表。

一个线程一个 socket 的风险是泄漏：按请求开线程的调用方会给每个线程留一条到 ROUTER 的 TCP 连接。所以建新 socket 时顺带回收已退出线程的 —— 它们的 owner 已经消失、不可能有人正在其中收发，这正是可以从别的线程关掉它们的理由（和 router socket 不同，见 `stop()` 里那条注释）。`stop()` 关掉全部。

## #189：redis transport 停止时甩完整 traceback

`stop()` 在监听线程正停在 `get_message(timeout=1.0)` 时把 pubsub 关掉，socket 在它脚下失效 —— Windows 上是 `WinError 10038` 包在 `redis.exceptions.ConnectionError` 里，而循环的裸 `except Exception` 把整个栈打出来，实盘一次重启三条。

纯噪声，但代价是真的：**正常关闭和真故障长得一模一样**，读的人学会忽略这个 traceback 之后，真出问题那次也会被忽略。`except` 里先看 `self._running`，已经在停就安静退出；队列循环同样处理。

## 验证

**离线**：新增两个测试文件共 9 例，全量 **1567 通过**，收集数 **119/119**。

- `test_zmq_client_concurrency.py`（5 例，修复前 4 例红）—— 核心那条是行为性的：4 个并发调用在一次 0.3 秒往返里必须重叠而不是排队；另有每线程独立 socket、IDENTITY 不重复、单线程复用、`stop()` 关掉全部、以及**死线程的 socket 被回收而不是泄漏**。
- `test_redis_shutdown_quiet.py`（4 例，修复前 2 例红）—— 两个循环的安静退出，加上**运行中仍然大声报错**的负面对照：让关闭安静下来不能顺带让故障也安静。

**#189 实盘前后对照**：同一台桥、同一个 reload 操作，只换代码 ——

| | traceback 数 |
|---|---|
| reload 拆**旧**代码 | **3**（正是报告里的数量）|
| reload 拆**新**代码 | **0** |

两次 reload 都 `ok purged=31 0.3.21 -> 0.3.21`，只读冒烟 13 项通过。

**#186 实盘未验证**：这是纯客户端改动，而当前部署跑的是 redis transport，根本不经过这段代码；要验它得把终端换成 zmq 再重启策略。行为性的离线测试（4 并发必须重叠）是这条的主要证据。
