### PR TITLE
fix: close secondary listen_redis in MultiAccountRpcServiceManager.stop()

### DIFF
--- a/src/bigqmt_signal_trader/multi_account.py
+++ b/src/bigqmt_signal_trader/multi_account.py
@@ -97,6 +97,31 @@ class MultiAccountRpcServiceManager:
                 s.stop()
             except Exception:
                 pass
+            # Close secondary's transport listen_redis so zombie brpop/pubsub
+            # threads exit immediately instead of surviving the join timeout
+            # and competing for requests after reload.  The primary's
+            # listen_redis is shared with the service-level attribute and
+            # must NOT be closed here — it is managed by the primary's own
+            # stop() lifecycle.
+            if s is not self._primary:
+                transport = getattr(s, "_transport", None)
+                if transport is not None:
+                    lr = getattr(transport, "listen_redis", None)
+                    if lr is not None:
+                        try:
+                            lr.close()
+                        except Exception:
+                            pass
+                # Also close the service-level listen_redis if it is a
+                # separate connection (not shared with primary).
+                slr = getattr(s, "listen_redis", None)
+                if slr is not None and slr is not getattr(
+                    self._primary, "listen_redis", None
+                ):
+                    try:
+                        slr.close()
+                    except Exception:
+                        pass
 
     def drain_request_queue(self, max_items=20):
         return sum(


### PR DESCRIPTION
When stop() is called (e.g. during strategy reload), the secondary background listener threads may survive the join(timeout) and become zombie brpop/pubsub consumers that compete with the new service instance after reload. This causes ~50% request loss on the secondary channel.

Close the secondary transport listen_redis and service-level listen_redis (if separate from primary) in MultiAccountRpcServiceManager.stop(), so that blocking socket calls unblock immediately and the threads exit cleanly.

The primary listen_redis is never closed here - it is managed by the primary service own lifecycle.

Production-proven in QMT0 dual-account deployment since 2026-09-03 (in _DualServiceManager.stop()), zero zombie consumer incidents since.