### PR TITLE
fix: 批量超时后不再回退重提（双倍下单），批量超时随 N 缩放 (#195)

### DIFF
--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -1858,6 +1858,7 @@ class BigQmtRpcHandlers:
             raise ValueError("orders must be a non-empty list")
         if len(orders) > 500:
             raise ValueError("orders exceeds batch limit 500")
+        batch_started = time.time()
         batch_id = str(params.get("batch_id") or uuid.uuid4().hex)
         account_id = self._request_account_id(params)
         strategy_name = str(
@@ -2006,6 +2007,19 @@ class BigQmtRpcHandlers:
                     "error": "%s: %s" % (exc.__class__.__name__, exc),
                     "user_order_id": order_tag,
                 })
+        # One line per batch, always: a batch that outlives the client's
+        # timeout keeps running to completion here, and without this line the
+        # doubled orders that follow have no server-side trace.
+        try:
+            from .logging_setup import get_logger
+            get_logger("rpc").info(
+                "batch submit account=%s items=%d placed=%d failed=%d %.0fms",
+                account_id, len(orders),
+                sum(1 for r in results if r.get("success") and not r.get("idempotent")),
+                sum(1 for r in results if not r.get("success")),
+                (time.time() - batch_started) * 1000.0)
+        except Exception:
+            pass
         return results
 
     def _handle_cancel_order(self, params):

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -947,13 +947,15 @@ class BigQmtRpcClient:
                 timeout_seconds=wait_seconds,
             )
         if not response.get("ok"):
-            raise RuntimeError(response.get("error") or "Big QMT RPC failed: %s" % method)
+            raise RpcServerRepliedError(
+                response.get("error") or "Big QMT RPC failed: %s" % method)
         # server_error 携带 QMT 端诊断（如 passorder 提交但委托没进系统）。
         # 只在交易类方法上设置（读取类恒为空），转成异常让调用方看到真实原因，
         # 而不是把「无委托号」误判为 -1 失败（issue #38）。
         server_error = str(response.get("server_error") or "")
         if server_error:
-            raise RuntimeError("Big QMT %s server_error: %s" % (method, server_error))
+            raise RpcServerRepliedError(
+                "Big QMT %s server_error: %s" % (method, server_error))
         # The transport already scanned the raw text for a typed envelope; when
         # it found none there is provably nothing to rebuild, and skipping the
         # walk turns 345.9ms into 3.7ms on a 51285-instrument snapshot. A None
@@ -1111,6 +1113,28 @@ MARKET_TOKENS = frozenset({"SH", "SZ", "BJ", "HK"})
 # 30s is also what the whole-market snapshot path already used, so there is
 # one number rather than two.
 DEFAULT_RPC_TIMEOUT_SECONDS = 30.0
+
+# Batch timeout scaling: the server runs batch items serially on the adjust
+# thread. Per-item cost is milliseconds in market hours but ~300ms with the
+# counter disconnected -- a 100-item batch then outlives even the 30s default
+# (live 2026-09-05: the client gave up, fell back to singles, and the still
+# running batch completed too, doubling 100 orders into 200). Scale the wait
+# with N so the client outlives the server.
+BATCH_TIMEOUT_FLOOR_SECONDS = 15.0
+BATCH_TIMEOUT_PER_ITEM_SECONDS = 0.5
+
+
+class RpcServerRepliedError(RuntimeError):
+    """The server answered with an error -- as opposed to a timeout/transport
+    failure, where the request's fate is unknown.
+
+    The distinction matters for writes: a batch submit handler raises only
+    before its per-item loop, so a replied error means no item ran and a retry
+    is safe. A timeout means the batch may still be running and retrying
+    doubles orders."""
+
+
+
 
 LARGE_CODE_LIST = 1000
 # What the fallback reads first. Stocks are 8.7% of an exchange listing, so
@@ -3931,8 +3955,14 @@ class BigQmtXtTrader:
         parks each item's settlement in the single _pending_settlement slot, so
         only the last item of a batch would ever get its order id backfilled.
 
-        A batch that fails as a whole falls back to submitting one at a time.
-        Losing a network round trip must not lose the orders in it (#156).
+        Fallbacks, and when they are allowed: a batch whose outcome is UNKNOWN
+        (timeout, connection drop) must NOT be resubmitted -- the server may
+        still be running it, and the resubmit doubles the orders (live: a
+        100-item batch outlived the 30s timeout, the fallback resubmitted, and
+        200 orders landed). Only two failure shapes may fall back to
+        one-at-a-time: the server REPLIED with an error (the handler raises
+        before its per-item loop, so nothing ran), and an empty result list
+        (the handler appends one entry per item, so empty means it never ran).
         """
         payload = []
         for (seq, args, kwargs), fields in group:
@@ -3956,10 +3986,25 @@ class BigQmtXtTrader:
         try:
             results = self.order_stock_batch(account_id, payload,
                                              idempotent=False) or []
-        except Exception:
-            log.exception("async batch of %d failed; submitting one at a time",
-                          len(group))
+        except RpcServerRepliedError as exc:
+            log.warning("async batch of %d refused by the server (%s); "
+                        "submitting one at a time", len(group), exc)
             results = None
+        except Exception as exc:
+            # Timeout / transport failure: the batch's fate is unknown. Do NOT
+            # resubmit -- report each item as unknown-outcome instead. The
+            # message must say the orders may be live, because they may be:
+            # a caller that retries on failure double-orders.
+            log.exception("async batch of %d outcome unknown; NOT resubmitting",
+                          len(group))
+            for (seq, args, kwargs), fields in group:
+                self._enqueue_batch_outcome(seq, fields, {
+                    "success": False, "code": -4,
+                    "error": ("batch outcome unknown (%s: %s); the orders MAY "
+                              "BE LIVE -- query orders before retrying"
+                              % (exc.__class__.__name__, exc)),
+                })
+            return
         if not results:
             if results is not None:
                 # The server appends one result per item, so nothing back means
@@ -4178,7 +4223,8 @@ class BigQmtXtTrader:
                 time.sleep(0.005)
         return True
 
-    def order_stock_batch(self, account, orders, batch_id="", idempotent=True):
+    def order_stock_batch(self, account, orders, batch_id="", idempotent=True,
+                          timeout_seconds=None):
         """Submit N orders in one RPC.
 
         ``idempotent`` (default True, unchanged) is the batch contract: every
@@ -4186,6 +4232,11 @@ class BigQmtXtTrader:
         placing again, so a retried batch cannot double-order. Pass False for
         callers that never agreed to that -- order_stock_async routes its
         backlog through here (#181) and lost orders to it (#190).
+
+        The wait scales with N when not given: the server runs items serially
+        and per-item cost swings from ~ms (market hours) to ~300ms (counter
+        disconnected), so a flat default turns a slow-but-alive batch into a
+        client-side timeout -- and a retried batch doubles orders.
         """
         account_id = _account_id(account, self.client.account_id)
         payload = []
@@ -4198,10 +4249,18 @@ class BigQmtXtTrader:
             params["idempotent"] = False
         if batch_id:
             params["batch_id"] = str(batch_id)
+        if timeout_seconds is None:
+            timeout_seconds = max(
+                float(getattr(self.client, "timeout_seconds",
+                              DEFAULT_RPC_TIMEOUT_SECONDS)),
+                BATCH_TIMEOUT_FLOOR_SECONDS
+                + BATCH_TIMEOUT_PER_ITEM_SECONDS * len(payload),
+            )
         return self.client.call(
             "order_stock_batch",
             params,
             account_id=account_id,
+            timeout_seconds=timeout_seconds,
         ) or []
 
     def cancel_order_stock_sysid(self, account, market, order_sysid):

--- a/tests/bigqmt_signal_trader/test_async_callback_order.py
+++ b/tests/bigqmt_signal_trader/test_async_callback_order.py
@@ -79,7 +79,7 @@ class AsyncCallbackOrderTest(unittest.TestCase):
 
         trader.order_stock_result = submit or default_submit
 
-        def default_batch(account, orders, batch_id=""):
+        def default_batch(account, orders, batch_id="", idempotent=True):
             # The worker batches a backlog of >=2 into one order_stock_batch
             # (issue #181); route each item through the same stub the single
             # path uses so both paths behave identically under test.

--- a/tests/bigqmt_signal_trader/test_async_exit_drain.py
+++ b/tests/bigqmt_signal_trader/test_async_exit_drain.py
@@ -37,7 +37,7 @@ def _queue_three(trader, slow_seconds=0.25, prefix="drain"):
 
     trader.order_stock_result = slow_order
 
-    def slow_batch(account, orders, batch_id=""):
+    def slow_batch(account, orders, batch_id="", idempotent=True):
         # The worker batches a backlog of >=2 into one order_stock_batch
         # (issue #181); route each item through the same slow stub so the
         # drain contract is exercised whichever path the worker took.

--- a/tests/bigqmt_signal_trader/test_async_order_batch.py
+++ b/tests/bigqmt_signal_trader/test_async_order_batch.py
@@ -17,7 +17,9 @@ import unittest
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, os.path.join(ROOT, "src"))
 
-from bigqmt_signal_trader.xtquant_compat import BigQmtXtTrader, XtQuantTraderCallback
+from bigqmt_signal_trader.xtquant_compat import (
+    BigQmtXtTrader, RpcServerRepliedError, XtQuantTraderCallback,
+)
 
 
 class Recorder(XtQuantTraderCallback):
@@ -90,13 +92,15 @@ class BatchSelectionTest(unittest.TestCase):
         self.assertEqual(calls["batch"], [])
         self.assertEqual(len(rec.responses), 1)
 
-    def test_a_failing_batch_falls_back_to_single_submits(self):
+    def test_a_server_refused_batch_falls_back_to_single_submits(self):
+        """The server answered with an error: the handler raises before its
+        per-item loop, so nothing ran and resubmitting is safe."""
         trader, rec, calls = self._trader()
         calls_log = []
-        def raising_batch(account, orders, batch_id="", idempotent=True):
+        def refused_batch(account, orders, batch_id="", idempotent=True):
             calls_log.append(len(orders))
-            raise RuntimeError("network gone")
-        trader.order_stock_batch = raising_batch
+            raise RpcServerRepliedError("order_gateway is not configured")
+        trader.order_stock_batch = refused_batch
         seqs = [trader.order_stock_async("acct", "60%04d.SH" % i, 23, 100, 11,
                                          10.0, "s", "r-%d" % i)
                 for i in range(3)]
@@ -106,6 +110,31 @@ class BatchSelectionTest(unittest.TestCase):
         self.assertEqual(calls_log, [3])
         self.assertEqual(len(calls["single"]), 3, "batch loss must not lose orders")
         self.assertEqual([r.seq for r in rec.responses], seqs)
+
+    def test_a_timed_out_batch_is_never_resubmitted(self):
+        """A timeout means the batch may STILL BE RUNNING on the server.
+        Resubmitting doubles the orders (live: a 100-item batch outlived the
+        timeout, the fallback resubmitted, 200 orders landed). Report each
+        item as unknown-outcome instead, and say the orders may be live."""
+        trader, rec, calls = self._trader()
+
+        def slow_batch(account, orders, batch_id="", idempotent=True):
+            raise TimeoutError("redis rpc timeout: order_stock_batch")
+
+        trader.order_stock_batch = slow_batch
+        seqs = [trader.order_stock_async("acct", "60%04d.SH" % i, 23, 100, 11,
+                                         10.0, "s", "r-%d" % i)
+                for i in range(3)]
+
+        self.assertTrue(trader.wait_async_orders(timeout=5.0))
+
+        self.assertEqual(calls["single"], [],
+                         "a timed-out batch must NOT be resubmitted")
+        self.assertEqual(len(rec.errors), 3)
+        self.assertEqual([e.seq for e in rec.errors], seqs)
+        for err in rec.errors:
+            self.assertIn("MAY BE LIVE", err.error_msg)
+            self.assertNotIn("not found", err.error_msg.lower())
 
     def test_an_empty_batch_result_falls_back_to_single_submits(self):
         trader, rec, calls = self._trader()
@@ -173,6 +202,58 @@ class BatchSelectionTest(unittest.TestCase):
                                 "an order landed in another account's batch")
         self.assertEqual(singles, [])
         self.assertEqual(len(rec.responses), 4)
+
+
+class BatchTimeoutScalingTest(unittest.TestCase):
+    """The batch RPC's wait must scale with N: the server runs items serially
+    and per-item cost swings from ~ms to ~300ms (counter disconnected), so a
+    flat 30s default turns a slow-but-alive 100-item batch into a client
+    timeout -- and a retried batch doubles orders."""
+
+    def _trader_with_capturing_client(self):
+        trader = BigQmtXtTrader(account_id="acct")
+        captured = []
+
+        class StubClient:
+            account_id = "acct"
+            timeout_seconds = 30.0
+
+            def call(self, method, params=None, account_id=None, timeout_seconds=None):
+                captured.append((method, params, timeout_seconds))
+                return []
+
+        trader.client = StubClient()
+        return trader, captured
+
+    def test_timeout_scales_with_item_count(self):
+        trader, captured = self._trader_with_capturing_client()
+        orders = [{"stock_code": "60%04d.SH" % i, "order_type": 23,
+                   "order_volume": 100, "price_type": 11, "price": 10.0,
+                   "order_remark": "t-%d" % i} for i in range(100)]
+        trader.order_stock_batch("acct", orders)
+
+        _method, _params, timeout = captured[-1]
+        self.assertGreaterEqual(timeout, 15.0 + 0.5 * 100)
+
+    def test_small_batches_keep_the_plain_default(self):
+        trader, captured = self._trader_with_capturing_client()
+        orders = [{"stock_code": "600000.SH", "order_type": 23,
+                   "order_volume": 100, "price_type": 11, "price": 10.0,
+                   "order_remark": "t"}]
+        trader.order_stock_batch("acct", orders)
+
+        _method, _params, timeout = captured[-1]
+        self.assertEqual(timeout, 30.0)
+
+    def test_an_explicit_timeout_wins_over_the_scaling(self):
+        trader, captured = self._trader_with_capturing_client()
+        orders = [{"stock_code": "600000.SH", "order_type": 23,
+                   "order_volume": 100, "price_type": 11, "price": 10.0,
+                   "order_remark": "t"}]
+        trader.order_stock_batch("acct", orders, timeout_seconds=7.0)
+
+        _method, _params, timeout = captured[-1]
+        self.assertEqual(timeout, 7.0)
 
 
 class CallbackOffTheSubmitPathTest(unittest.TestCase):

--- a/tests/bigqmt_signal_trader/test_exec_events.py
+++ b/tests/bigqmt_signal_trader/test_exec_events.py
@@ -794,7 +794,7 @@ class ExecEventsClientDispatchTest(unittest.TestCase):
         def fake(*args, **kwargs):
             return {"order_sys_id": "sys-%s" % args[1]}
 
-        def fake_batch(account, orders, batch_id=""):
+        def fake_batch(account, orders, batch_id="", idempotent=True):
             # Same per-item answer as fake, via the batch seam the worker
             # picks for a backlog of >=2.
             return [{

--- a/tests/bigqmt_signal_trader/test_order_sysid_race.py
+++ b/tests/bigqmt_signal_trader/test_order_sysid_race.py
@@ -193,13 +193,18 @@ class DeadlineTest(_Service):
 
     def test_the_client_turns_that_into_an_exception_not_a_minus_one(self):
         """xtquant_compat raises on server_error, which is the whole reason
-        the deadline path sets one."""
+        the deadline path sets one. RpcServerRepliedError is a RuntimeError
+        subclass, so callers catching RuntimeError see no change; the distinct
+        type is what lets the batch path tell a refused batch (nothing ran)
+        from a timed-out one (may be running)."""
         import inspect
 
         from bigqmt_signal_trader import xtquant_compat
 
         source = inspect.getsource(xtquant_compat)
-        self.assertIn('raise RuntimeError("Big QMT %s server_error: %s"', source)
+        self.assertIn('raise RpcServerRepliedError(', source)
+        self.assertIn('"Big QMT %s server_error: %s"', source)
+        self.assertTrue(issubclass(xtquant_compat.RpcServerRepliedError, RuntimeError))
 
 
 class MissingOrderIsStillMissingTest(_Service):


### PR DESCRIPTION
修复 #195。

# 事故

0.3.21 实盘（周六 08:24，柜台未连接）：循环 100 单逆回购走一个批量 RPC，服务端 adjust 线程串行执行（该时段 ~300ms/项，整体 >30s），客户端 30s 默认超时放弃 → 既有兜底「逐笔重提」启动 → **服务端的批量仍在跑并最终跑完** → 100 + 100 = **200 单**。同环境 50 单股票 ~10s 完成，未超时就只是慢。

# 修复内容

1. **超时不重提**：`call()` 对服务端已应答的错误改抛 `RpcServerRepliedError`（RuntimeError 子类，向后兼容）。批量 handler 只在逐项循环之前抛错 → 「服务端拒绝」= 一笔没跑 = 回退安全保留；超时/断连 = 生死未知 → 逐项 `on_order_error`，信息明说「orders MAY BE LIVE -- query orders before retrying」，**不再自动重提**。
2. **批量超时随 N 缩放**：`order_stock_batch(..., timeout_seconds=None)` 缺省为 `max(客户端默认, 15s + 0.5s×N)`——让客户端比服务端最慢的合法批量活得久，而不是中途放弃它。
3. **服务端一行批量日志**：items/placed/failed/耗时。超时后仍跑完的批量此前在服务端没有任何痕迹。

# 测试

- 新增：超时绝不重提（且逐笔错误带 MAY BE LIVE 字样）、超时随 N 缩放、显式 timeout 优先、小批量保持默认。
- 更新：原「失败回退」用例改走「服务端拒绝」方向（它原来的 RuntimeError 语义被新异常类型重新分类了）。
- 顺带修掉三个 #185 时期的批量 fake 缺 `idempotent` 形参的隐患——自 a8af642 给批量调用加上该参数后，它们每逢队列竞争走批量路径就 TypeError（间歇性红）。
- server_error 源码字钉跟随新异常类。
- 红绿验证：改动前的树上复现了 bug 本体（TimeoutError 后回退逐笔跑了 3/3、零错误上报）。
- 全量 **1562 通过，117/117 模块收集**。

# 部署提醒

双单修复在**客户端**——你的客户端是 pip 安装的 0.3.21，合并后需要发 0.3.22 并在客户端机器 `pip install -U` 才生效。服务端那行日志需要 sync + reload（不改行为，可缓）。
