### PR TITLE
feat: passorder 原生透传(路 2)——自己控 orderType/quickTrade,绕过安全网

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 
 ## [未发布]
 
+### 新增
+
+- **`passorder` 原生透传（路 2）**：新增客户端 `xt.passorder(opType, orderType, account, orderCode, prType, price, volume, strategyName, quickTrade, userOrderId)`，参数顺序与 QMT 原生 `passorder` 一致，ContextInfo 由服务端补（它只在 QMT 里存在，过不了 RPC）。和 `order_stock` 的区别是**暴露了 `orderType` 和 `quickTrade`**，并且**不跑任何安全网** —— 无 opType 校验（融资/期货 opType 由调用方负责，见 #103）、无代码大小写归一化（#95）、无结算回读。要的就是裸 API，契约归调用方。
+
+  `orderType` / `quickTrade` 留空时回落到服务端配置（1101 / 2），所以常见情形写起来仍和 `order_stock` 一样。passorder 异步、不返回委托号（QMT 稍后在 order_callback 推送里给），同 `order_stock_async`。
+
+  `dry_run=True` 返回服务端**将要**传给 passorder 的 11 元组而不下单 —— 用来核对参数映射，也是本条的实盘验证方式（不下真单）。
+
+  服务端 `passorder` 走 `ORDER_METHODS`：和其它下单一样受 `rpc_allow_order_methods` 门禁、并 defer 到 adjust 主线程。新增 `tests/bigqmt_signal_trader/test_passorder_passthrough.py`（11 例，下单类放文件最前，修复前 8 例红）。实盘 dry_run 四项验证通过，未下任何单。
+
 ### 性能
 
 - **zmq 客户端不再把并发请求排成一队**（#186）：`send_request` 此前在**整个** send/poll/recv 周期内持 `_client_lock`，因为客户端只有一个 DEALER socket 而 zmq socket 不是线程安全的。于是多线程调用只能轮流来。实盘 4 并发实测：zmq 的 ping 从 2.4 只到 2.7 次每秒（drain 模式 10.2 到 10.2，纹丝不动），而没有这把锁的 redis 从 20.7 到 **143.3**。线程数在 zmq 上买不到任何东西。

--- a/src/bigqmt_signal_trader/adapters/order_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/order_bigqmt.py
@@ -568,6 +568,70 @@ class BigQmtOrderGateway:
             message="passorder submitted",
         )
 
+    def passorder_passthrough(
+        self,
+        op_type,
+        order_type,
+        account_id,
+        order_code,
+        price_type,
+        price,
+        volume,
+        strategy_name,
+        quick_trade,
+        user_order_id,
+        dry_run=False,
+    ):
+        """Call QMT's native passorder with the 11-arg signature untouched.
+
+        The deliberate escape hatch (route 2): the caller controls every
+        argument, including orderType (股/手 vs 金额 vs 比例 vs 组合) and
+        quickTrade, which submit()/order_stock do not expose. NONE of submit()'s
+        safety nets run here -- no opType validation (a credit or futures opType
+        that submit() would guard becomes the caller's responsibility, see
+        #103), no code case-normalization (#95), no settlement read-back. The
+        caller asked for the native API, so they own its contract.
+
+        ContextInfo is supplied here, not by the caller: passorder reads
+        internals off the raw QMT ContextInfo (e.g. .request_id) and it only
+        exists inside QMT, so it can never travel over RPC.
+
+        ``dry_run`` resolves everything and returns the exact 11-tuple that
+        WOULD be sent, without calling passorder. It is how this path is
+        verified against the live terminal without placing an order, and it
+        lets a caller confirm their own argument mapping the same way.
+
+        passorder itself is async and returns None (QMT assigns the 合同编号
+        later, on the order_callback push), so there is no order id to return
+        synchronously -- exactly as with order_stock_async.
+        """
+        passorder = self._require_passorder()
+        args = [
+            int(op_type),
+            int(order_type),
+            str(account_id or self.account_id),
+            str(order_code),                 # RAW: no normalization (#95)
+            int(price_type),
+            float(price),
+            int(volume),
+            str(strategy_name or ""),
+            int(quick_trade),
+            str(user_order_id or ""),
+        ]
+        if dry_run:
+            return {
+                "dry_run": True,
+                "would_call": "passorder",
+                "args": list(args),
+                "context_info_supplied": self.context_info is not None,
+            }
+        passorder(*(args + [self.context_info]))
+        return {
+            "dry_run": False,
+            "submitted": True,
+            "user_order_id": args[9],
+        }
+
     def cancel(self, order_ref, account_id=None):
         cancel_func = self._require_cancel()
         aid = account_id or self.account_id

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -114,6 +114,10 @@ ORDER_METHODS = {
     "submit_order",
     "submit_orders_batch",
     "cancel_order",
+    # Raw native-passorder passthrough (route 2). Gated behind
+    # allow_order_methods like every other write, and deferred to the adjust
+    # thread by virtue of not being in READ_METHODS.
+    "passorder",
 }
 
 # Whole-quote push subscription control methods. These drive a server-side
@@ -2021,6 +2025,65 @@ class BigQmtRpcHandlers:
         except Exception:
             pass
         return results
+
+    def _handle_passorder(self, params):
+        """Raw native-passorder passthrough (route 2).
+
+        Forwards the 11-arg passorder signature straight through to QMT, with
+        ContextInfo supplied server-side. No opType validation, no code
+        normalization, no settlement read-back -- the caller owns the native
+        contract. See BigQmtOrderGateway.passorder_passthrough.
+
+        Accepts both the native argument names (op_type/order_type/price_type/
+        prType...) and passorder's own spellings, so a caller can paste the
+        signature they know. account defaults to the request/gateway account.
+        """
+        if self.order_gateway is None:
+            raise RuntimeError("order_gateway is not configured")
+        passthrough = getattr(self.order_gateway, "passorder_passthrough", None)
+        if not callable(passthrough):
+            raise RuntimeError("this deployment predates the passorder passthrough")
+
+        def pick(*names, **kw):
+            for name in names:
+                if name in params and params[name] is not None:
+                    return params[name]
+            return kw.get("default")
+
+        op_type = pick("op_type", "opType", "optype")
+        order_type = pick("order_type", "orderType", "ordertype",
+                          default=self.order_gateway.combo_type)
+        account_id = self._request_account_id(params)
+        order_code = pick("order_code", "orderCode", "stock_code", "code")
+        price_type = pick("price_type", "prType", "prtype",
+                          default=self.order_gateway.price_type)
+        price = pick("price", default=-1)
+        volume = pick("volume", "order_volume", "vol")
+        strategy_name = pick("strategy_name", "strategyName",
+                             default=self.default_strategy_name)
+        quick_trade = pick("quick_trade", "quickTrade",
+                           default=self.order_gateway.quick_trade)
+        user_order_id = pick("user_order_id", "userOrderId", "order_remark",
+                             "remark", default="")
+        if op_type is None:
+            raise ValueError("op_type is required")
+        if not order_code:
+            raise ValueError("order_code is required")
+        if volume is None:
+            raise ValueError("volume is required")
+        return passthrough(
+            op_type=op_type,
+            order_type=order_type,
+            account_id=account_id,
+            order_code=order_code,
+            price_type=price_type,
+            price=price,
+            volume=volume,
+            strategy_name=strategy_name,
+            quick_trade=quick_trade,
+            user_order_id=user_order_id,
+            dry_run=bool(pick("dry_run", "dryRun", default=False)),
+        )
 
     def _handle_cancel_order(self, params):
         if self.order_gateway is None:

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -4263,6 +4263,48 @@ class BigQmtXtTrader:
             timeout_seconds=timeout_seconds,
         ) or []
 
+    def passorder(self, op_type, order_type, account, order_code, price_type,
+                  price, volume, strategy_name="", quick_trade=None,
+                  user_order_id="", dry_run=False):
+        """Call QMT's native passorder straight through (route 2).
+
+        The argument order matches QMT's own signature -- opType, orderType,
+        accountid, orderCode, prType, price, volume, strategyName, quickTrade,
+        userOrderId -- with ContextInfo supplied server-side (it only exists
+        inside QMT). Unlike order_stock this exposes orderType and quickTrade,
+        and runs NONE of order_stock's safety nets: no opType validation, no
+        code case-normalization (#95), no settlement read-back. You own the
+        native contract.
+
+        order_type / quick_trade default to the server config (1101 / 2) when
+        left None, so the common case still reads like order_stock.
+
+        passorder is async and returns no order id (QMT assigns the 合同编号
+        later on the order_callback push), same as order_stock_async. This
+        returns the server's ack dict.
+
+        dry_run=True returns the exact 11-tuple the server WOULD pass to
+        passorder without placing an order -- use it to check your mapping.
+        """
+        account_id = _account_id(account, self.client.account_id)
+        params = {
+            "account_id": account_id,
+            "op_type": op_type,
+            "order_code": order_code,
+            "price_type": price_type,
+            "price": price,
+            "volume": volume,
+            "strategy_name": strategy_name,
+            "user_order_id": user_order_id,
+        }
+        if order_type is not None:
+            params["order_type"] = order_type
+        if quick_trade is not None:
+            params["quick_trade"] = quick_trade
+        if dry_run:
+            params["dry_run"] = True
+        return self.client.call("passorder", params, account_id=account_id)
+
     def cancel_order_stock_sysid(self, account, market, order_sysid):
         """MiniQMT contract: 0 on success, -1 on failure (issue #113).
 

--- a/tests/bigqmt_signal_trader/test_passorder_passthrough.py
+++ b/tests/bigqmt_signal_trader/test_passorder_passthrough.py
@@ -1,0 +1,161 @@
+# coding: utf-8
+"""Route 2: a raw passthrough to QMT's native passorder.
+
+order_stock exposes a MiniQMT-shaped subset and runs safety nets (opType
+validation, code normalization, settlement read-back). Some callers want the
+native 11-arg passorder instead -- full control of orderType and quickTrade,
+no nets. This is that hatch. It is gated behind allow_order_methods like every
+other write, and deferred to the adjust thread like every other order.
+
+These are order-placement tests and lead the file deliberately: a wrong answer
+here costs real money.
+"""
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from bigqmt_signal_trader.adapters.order_bigqmt import BigQmtOrderGateway
+from bigqmt_signal_trader.redis_rpc import (
+    BigQmtRpcHandlers, ORDER_METHODS, METHOD_ALIASES)
+from test_redis_rpc import FakeMarketData, FakePositionProvider
+
+
+class RecordingPassorder(object):
+    """Stands in for QMT's injected passorder: records the exact call."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, *args):
+        self.calls.append(args)
+
+
+CTX = object()      # the raw QMT ContextInfo sentinel
+
+
+def _gateway():
+    rec = RecordingPassorder()
+    gw = BigQmtOrderGateway(
+        context_info=CTX, account_id="acct", passorder_func=rec,
+        combo_type=1101, price_type=11, quick_trade=2)
+    return gw, rec
+
+
+def _handlers(gw):
+    return BigQmtRpcHandlers(
+        account_id="acct", market_data=FakeMarketData(),
+        position_provider=FakePositionProvider(), order_gateway=gw,
+        allow_order_methods=True)
+
+
+class GatewayPassthroughTest(unittest.TestCase):
+    def test_forwards_all_eleven_args_verbatim_with_context_last(self):
+        gw, rec = _gateway()
+        out = gw.passorder_passthrough(
+            op_type=23, order_type=1101, account_id="acct",
+            order_code="600000.SH", price_type=11, price=10.5, volume=100,
+            strategy_name="s", quick_trade=2, user_order_id="tag1")
+        self.assertEqual(len(rec.calls), 1)
+        self.assertEqual(
+            rec.calls[0],
+            (23, 1101, "acct", "600000.SH", 11, 10.5, 100, "s", 2, "tag1", CTX))
+        self.assertTrue(out["submitted"])
+
+    def test_code_is_passed_raw_without_normalization(self):
+        """RAW means raw: futures case is preserved, nothing is upper-cased."""
+        gw, rec = _gateway()
+        gw.passorder_passthrough(0, 1101, "acct", "cu2610.SF", 11, 50000, 1,
+                                 "s", 2, "t")
+        self.assertEqual(rec.calls[0][3], "cu2610.SF")
+
+    def test_dry_run_places_nothing_and_echoes_the_tuple(self):
+        gw, rec = _gateway()
+        out = gw.passorder_passthrough(
+            24, 1123, "acct", "000001.SZ", 5, -1, 200, "s", 1, "t",
+            dry_run=True)
+        self.assertEqual(rec.calls, [], "dry_run must not call passorder")
+        self.assertTrue(out["dry_run"])
+        self.assertEqual(out["args"],
+                         [24, 1123, "acct", "000001.SZ", 5, -1.0, 200, "s", 1, "t"])
+        self.assertTrue(out["context_info_supplied"])
+
+    def test_no_passorder_available_raises(self):
+        gw = BigQmtOrderGateway(context_info=CTX, account_id="acct",
+                                passorder_func=None)
+        with self.assertRaises(RuntimeError):
+            gw.passorder_passthrough(23, 1101, "acct", "600000.SH", 11, 1, 1,
+                                     "s", 2, "t")
+
+
+class HandlerRoutingTest(unittest.TestCase):
+    def test_handler_forwards_native_and_spelled_names(self):
+        gw, rec = _gateway()
+        _handlers(gw).handle("passorder", {
+            "opType": 23, "orderType": 1101, "account_id": "acct",
+            "orderCode": "600000.SH", "prType": 11, "price": 10.5,
+            "volume": 100, "strategyName": "s", "quickTrade": 2,
+            "userOrderId": "tag1"})
+        self.assertEqual(
+            rec.calls[0],
+            (23, 1101, "acct", "600000.SH", 11, 10.5, 100, "s", 2, "tag1", CTX))
+
+    def test_handler_fills_order_type_and_quick_trade_from_config(self):
+        gw, rec = _gateway()
+        _handlers(gw).handle("passorder", {
+            "op_type": 23, "account_id": "acct", "order_code": "600000.SH",
+            "price_type": 11, "price": 10.5, "volume": 100})
+        # order_type -> combo_type 1101, quick_trade -> 2, strategy -> default
+        self.assertEqual(rec.calls[0][1], 1101)
+        self.assertEqual(rec.calls[0][8], 2)
+
+    def test_handler_dry_run(self):
+        gw, rec = _gateway()
+        out = _handlers(gw).handle("passorder", {
+            "op_type": 23, "account_id": "acct", "order_code": "600000.SH",
+            "price_type": 11, "price": 10.5, "volume": 100, "dry_run": True})
+        self.assertEqual(rec.calls, [])
+        self.assertTrue(out["dry_run"])
+
+    def test_missing_required_args_raise_before_any_call(self):
+        gw, rec = _gateway()
+        h = _handlers(gw)
+        with self.assertRaises(ValueError):
+            h.handle("passorder", {"account_id": "acct", "order_code": "x",
+                                   "price_type": 11, "price": 1})  # no volume
+        with self.assertRaises(ValueError):
+            h.handle("passorder", {"op_type": 23, "account_id": "acct",
+                                   "price_type": 11, "price": 1, "volume": 1})
+        self.assertEqual(rec.calls, [])
+
+
+class GateTest(unittest.TestCase):
+    def test_passorder_is_an_order_method(self):
+        self.assertIn("passorder", ORDER_METHODS)
+
+    def test_blocked_when_order_methods_disabled(self):
+        """Same gate as submit_order: not in allowed_methods, so 'not allowed'
+        fires before it can reach QMT."""
+        gw, rec = _gateway()
+        handlers = BigQmtRpcHandlers(
+            account_id="acct", market_data=FakeMarketData(),
+            position_provider=FakePositionProvider(), order_gateway=gw,
+            allow_order_methods=False)
+        with self.assertRaises(ValueError):
+            handlers.handle("passorder", {
+                "op_type": 23, "account_id": "acct", "order_code": "600000.SH",
+                "price_type": 11, "price": 1, "volume": 100})
+        self.assertEqual(rec.calls, [], "a blocked order must not reach QMT")
+
+    def test_not_deferred_inline_on_listener_wildcard(self):
+        """An order must not run on the listener thread even under '*'."""
+        from bigqmt_signal_trader.redis_rpc import READ_METHODS
+        self.assertNotIn("passorder", READ_METHODS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
路 2:给想直接写原生 `passorder` 的调用方开一个透传口。

## 为什么

`order_stock` 只暴露 MiniQMT 风格的子集,还跑一堆安全网(opType 校验、代码大小写归一化、结算回读),而且**不暴露 `orderType` 和 `quickTrade`** —— 这两个是原生 passorder 的第 2、9 参数,分别控制"按股/金额/比例/组合"和"快速交易"语义。有人就是要那个原生 11 参数签名、自己控全部参数。

## 用法

```python
xt.passorder(23, 1101, acc, "600000.SH", 11, 10.50, 100, "我的策略", 2, "备注X")
```

参数顺序 = QMT 原生 `passorder(opType, orderType, accountid, orderCode, prType, price, volume, strategyName, quickTrade, userOrderId, ContextInfo)`,最后的 ContextInfo 由服务端补(它只在 QMT 进程里存在,读自身内部字段如 `.request_id`,过不了 RPC)。

- `orderType` / `quickTrade` 留空(`None`)时回落到服务端配置(1101 / 2),所以常见情形写起来和 `order_stock` 一样。
- passorder 异步、不返回委托号(QMT 稍后在 `order_callback` 推送里给),同 `order_stock_async`。返回服务端 ack。
- `dry_run=True` 返回服务端**将要**传给 passorder 的 11 元组而**不下单** —— 核对映射用,也是本 PR 的实盘验证方式。

## 明确的取舍

这条**绕过 order_stock 的全部安全网**:

- 无 opType 校验 —— 融资"买入"、期货"平今"这类 opType 由调用方负责(#103 那类坑不再挡)
- 无代码大小写归一化 —— 期货 `cu2610.SF` 原样透传(#95 那个不再帮你修)
- 无结算回读

要的就是裸 API,契约归调用方。想要安全网的继续用 `order_stock`。

## 接线

`passorder` 加入 `ORDER_METHODS`:和其它下单一样受 `rpc_allow_order_methods` 门禁,并因不在 `READ_METHODS` 里而自动 defer 到 adjust 主线程。服务端 handler 同时接受原生拼写(`opType`/`prType`/`orderCode`...)和蛇形命名,能直接粘贴你熟的签名。

## 验证

**离线**:新增 `tests/bigqmt_signal_trader/test_passorder_passthrough.py`,11 例,**下单类放文件最前**(答错要花真钱)。修复前 8 例红。覆盖:11 参数逐字透传且 ContextInfo 在末位、代码不归一化、dry_run 不下单、门禁(禁用时不达 QMT)、缺参在到 passorder 前报错、以及 passorder 不在 listener wildcard 里(不会跑在错的线程)。全量 **1573 通过**,收集数 **118/118**。

**实盘 dry_run,未下任何单**(0.3.21 桥,reload 后):

| 用例 | 结果 |
|---|---|
| 原生 11 参数 | `args=[23,1101,'8886800503','600000.SH',11,10.5,100,'我的策略',2,'备注X']`,ContextInfo 服务端补 |
| 省略 orderType/quickTrade | 回落 1101 / 2 |
| 期货 `cu2610.SF` | 大小写透传,未 upper |
| 缺 volume | 到 passorder 前报 `volume is required` |

**未验证**:没真下过单,所以证不到"透传的单最终出现在委托列表"。dry_run 证的是参数一路正确送到 passorder 的调用点、ContextInfo 已就位。要端到端确认得开盘经由本口真下一单。
