### PR TITLE
修复两融账户明细：query_credit_detail 映射错误 (#201) + 备用的查柜台通道 (#202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/) 和 [语义化版本](https://semver.org/)。
 
 
+## [未发布]
+
+### 修复
+
+- **两融账户调 `query_credit_detail` 恒为空列表**（#201）：handler 把它路由到了 `get_debt_contract`。两处都不对 —— 那是「负债合约明细」（一张张合约），不是信用账户对象；而且官方参考 6.17 已把它标记【已弃用】。于是没有未了结负债的两融账户必然拿到 `[]`，有负债的也只拿到合约行，永远拿不到维持担保比例 / 授信额度那一组字段。
+
+  改走 `get_trade_detail_data(accId, 'CREDIT', 'ACCOUNT')` → `CCreditAccountDetail`（官方参考 3.14），也就是本仓 `docs/MiniQMT_2_BigQMT-Skill/api_mapping.md:83` 一直记着、而代码一直没对上的那条映射。账户类型强制 `CREDIT`，不跟部署配置走：账户类型是「问哪本账」，不是「这台部署下单用哪本账」，否则按 `STOCK` 配置的部署永远查不到自己的信用账户。
+
+  顺带修了 `probe_capabilities` 自己的一个坑：它统一用单参数调那四个信用全局函数，而 `get_unclosed_compacts` / `get_closed_compacts` 是两参数签名 `(accountID, accountType)`，实盘上撞 boost::python 的 `ArgumentError` —— **把一个好用的接口报成坏的**，排查时反而在误导人。另外新增 `get_trade_detail_data(CREDIT,ACCOUNT)` 探测项，报 `m_nBrokerType`（3=信用）和信用专有字段是否到位：空列表有「这本账户不是信用账户」和「这台终端读不到」两种成因，原来的裸 `[]` 分不开。
+
+### 新增
+
+- **信用账户「查柜台」通道**（#202）：大 QMT 里信用账户明细有两条路，此前只接了一条。同步那条读终端缓存（`CCreditAccountDetail`，官方参考 3.14 标注「非查柜台」，券商没推就是空的）；异步那条 `query_credit_account(accId, seq, ContextInfo)` 查柜台，结果只从 `credit_account_callback` 出来，本桥**完全没接过这个回调**，所以这条路一直不可达。两份对象字段名还不一样：柜台那份是 `m_dTotalDebt`，缓存那份是 `m_dTotalDebit`。
+
+  现在补齐：`credit_account_callback` 在策略模块定义、每个入口文件再导出一次（QMT 只往被挂载的那个文件回调，同 `order_callback`），新 RPC `query_credit_account` 负责发查询、有界等回调、缓存结果。官方参考 6.13 的限流（「只能有一个查询」「建议 30s 一次」）由桥自己挡，客户端怎么轮询都打不爆柜台；等不到回调就返回上一次的值并标 `stale=true`，不把陈数据冒充新的。响应里 `query_issued` / `fresh` / `callback_bound` / `not_issued_reason` 把「空」的几种成因分开报。
+
+  **入口文件 `reload_deployment()` 刷不了，这条需要真的重启策略**；没重启时 `callback_bound=false`。
+
+- **两融 API 只读体检报告 `tools/credit_api_report.py`**：把每个两融接口真调一遍，记下大 QMT 实际返回了什么（行数、字段名、字段有没有值），导出 `.txt` + `.json` 报告。**不下单、不撤单**（用例钉住了清单里不含任何写方法）。默认脱敏，报告可以直接贴到公开 issue：账号打码、金额只记「有值 / 全 0」、`get_positions` 的键是股票代码所以整组打掉；`m_nBrokerType` 例外，保留原值 —— 打了码就没法判断是不是信用账户了。报告带对照组（非两融接口），先回答「是桥不通还是两融接口的问题」，再下结论。
+
+  维护者没有两融账户，两融那一整片只能靠有两融账户的用户跑一次回报 —— 这个工具就是为了把「盲猜」换成「照着报告看」。
+
+### 已知限制
+
+- 上面两条**都没有在真实两融账户上验证过正向结果**。维护者的账户是普通股票账户（`m_nBrokerType=2`），信用账本根本不存在，所有两融接口返回空是正确行为，证明不了修复有效。已验证的部分：单元测试（#201 修复前 4 red / 修复后 green）、实盘上 `probe_capabilities` 的 `ArgumentError` 已消失、新增探测项能答、体检工具端到端跑通并正确判定「这不是信用账户」。**欢迎有两融账户的用户跑 `tools/credit_api_report.py` 并把报告贴到 #201 / #202。**
+
 ## [0.3.23] - 2026-09-06
 
 ### 修复

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 - **#201 的取数路径经维护者实测确认**：`get_trade_detail_data('<信用账号>', 'credit', 'account', '')` 在大 QMT 里能取到信用账户信息。但**这个仓的 RPC 链路本身没有在真实两融账户上跑过** —— 维护者的部署账户是普通股票账户（`m_nBrokerType=2`），信用账本不存在，所有两融接口返回空都是正确行为，证明不了这条链路端到端通。
 
-- **#202 的异步通道完全未验证**，且默认不需要它。`callback_bound` 在维护者的部署上仍是 `false`（入口文件改动要真的重启策略）。
+- **#202 的异步通道在维护者的终端上根本不可用，也就无从验证**，且默认不需要它。重启策略后 `callback_bound` 仍是 `false`：`get_debt_contract` / `get_assure_contract` / `get_enable_short_contract` / `get_unclosed_compacts` 都经同一条 `_resolve_runtime_name`（qmt_api → globals → builtins）解析得到，唯独 `query_credit_account` 解析不到 —— **这台国金 QMT 没有注入这个全局函数**，重启解决不了。这反过来说明同步那条不只是「够用」，在这类终端上是**唯一**的路。`probe_capabilities` 新增的 `global_namespace["query_credit_account"]` 能把「终端没有」和「有但没重启」分开，体检报告会直接说是哪一种。
 
 - 已验证的部分：全量测试 1631 passed（收集数 == 文件数）、#201 用例修复前 4 red / 修复后 green、实盘上 `probe_capabilities` 的 `ArgumentError` 已消失、新增探测项能答、体检工具端到端跑通并正确判定「这不是信用账户」、两个单文件构建器重新生成后都带上了回调且 no-redis 那份仍 GBK 可解析。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,15 @@
 
 ### 新增
 
-- **信用账户「查柜台」通道**（#202）：大 QMT 里信用账户明细有两条路，此前只接了一条。同步那条读终端缓存（`CCreditAccountDetail`，官方参考 3.14 标注「非查柜台」，券商没推就是空的）；异步那条 `query_credit_account(accId, seq, ContextInfo)` 查柜台，结果只从 `credit_account_callback` 出来，本桥**完全没接过这个回调**，所以这条路一直不可达。两份对象字段名还不一样：柜台那份是 `m_dTotalDebt`，缓存那份是 `m_dTotalDebit`。
+- **信用账户「查柜台」通道 `query_credit_account`（备用，一般用不上）**（#202）：大 QMT 里信用账户明细有两个来源。上面 #201 修好的同步那条读终端缓存（`CCreditAccountDetail`，官方参考 3.14），**这是默认路径，维护者实测可用**：`get_trade_detail_data('<信用账号>', 'credit', 'account', '')` 直接取得到，返回 list 取 `[0]`，大小写不敏感。
 
-  现在补齐：`credit_account_callback` 在策略模块定义、每个入口文件再导出一次（QMT 只往被挂载的那个文件回调，同 `order_callback`），新 RPC `query_credit_account` 负责发查询、有界等回调、缓存结果。官方参考 6.13 的限流（「只能有一个查询」「建议 30s 一次」）由桥自己挡，客户端怎么轮询都打不爆柜台；等不到回调就返回上一次的值并标 `stale=true`，不把陈数据冒充新的。响应里 `query_issued` / `fresh` / `callback_bound` / `not_issued_reason` 把「空」的几种成因分开报。
+  异步那条 `query_credit_account(accId, seq, ContextInfo)` 查柜台，结果只从 `credit_account_callback` 出来，本桥此前完全没接过这个回调。现在接上，但**定位是备用**：3.14 那份官方标注「非查柜台」，是终端本地缓存，万一换一家券商的终端不填它，那就只剩查柜台这一条路 —— 而这正是维护者这边验证不了的一类问题。不需要的话完全不用理会，不调它就什么都不会发生。
 
-  **入口文件 `reload_deployment()` 刷不了，这条需要真的重启策略**；没重启时 `callback_bound=false`。
+  两条路互不依赖：`query_credit_detail` 不会在空的时候偷偷退到 `query_credit_account`，也不共享状态。返回对象也不同，**总负债在缓存那份叫 `m_dTotalDebit`、柜台那份叫 `m_dTotalDebt`**，融资/融券负债细分只有柜台那份有，不能混着读。名字容易误导：`query_credit_account` 不是 `query_credit_detail` 的异步版本，两个名字来自两套命名体系（前者是大 QMT 原生全局函数名，后者是 MiniQMT 客户端 API 名）。
+
+  实现要点：`credit_account_callback` 在策略模块定义、每个入口文件再导出一次（QMT 只往被挂载的那个文件回调，同 `order_callback`；两个单文件构建器各自硬编码的清单也补上了，并有用例钉住不许漏）。官方参考 6.13 的限流（「只能有一个查询」「建议 30s 一次」）由桥自己挡，客户端怎么轮询都打不爆柜台；等不到回调就返回上一次的值并标 `stale=true`，不把陈数据冒充新的。响应里 `query_issued` / `fresh` / `callback_bound` / `not_issued_reason` 把「空」的几种成因分开报。
+
+  **入口文件 `reload_deployment()` 刷不了，这条需要真的重启策略**；没重启时 `callback_bound=false`，不影响同步那条。
 
 - **两融 API 只读体检报告 `tools/credit_api_report.py`**：把每个两融接口真调一遍，记下大 QMT 实际返回了什么（行数、字段名、字段有没有值），导出 `.txt` + `.json` 报告。**不下单、不撤单**（用例钉住了清单里不含任何写方法）。默认脱敏，报告可以直接贴到公开 issue：账号打码、金额只记「有值 / 全 0」、`get_positions` 的键是股票代码所以整组打掉；`m_nBrokerType` 例外，保留原值 —— 打了码就没法判断是不是信用账户了。报告带对照组（非两融接口），先回答「是桥不通还是两融接口的问题」，再下结论。
 
@@ -27,7 +31,13 @@
 
 ### 已知限制
 
-- 上面两条**都没有在真实两融账户上验证过正向结果**。维护者的账户是普通股票账户（`m_nBrokerType=2`），信用账本根本不存在，所有两融接口返回空是正确行为，证明不了修复有效。已验证的部分：单元测试（#201 修复前 4 red / 修复后 green）、实盘上 `probe_capabilities` 的 `ArgumentError` 已消失、新增探测项能答、体检工具端到端跑通并正确判定「这不是信用账户」。**欢迎有两融账户的用户跑 `tools/credit_api_report.py` 并把报告贴到 #201 / #202。**
+- **#201 的取数路径经维护者实测确认**：`get_trade_detail_data('<信用账号>', 'credit', 'account', '')` 在大 QMT 里能取到信用账户信息。但**这个仓的 RPC 链路本身没有在真实两融账户上跑过** —— 维护者的部署账户是普通股票账户（`m_nBrokerType=2`），信用账本不存在，所有两融接口返回空都是正确行为，证明不了这条链路端到端通。
+
+- **#202 的异步通道完全未验证**，且默认不需要它。`callback_bound` 在维护者的部署上仍是 `false`（入口文件改动要真的重启策略）。
+
+- 已验证的部分：全量测试 1631 passed（收集数 == 文件数）、#201 用例修复前 4 red / 修复后 green、实盘上 `probe_capabilities` 的 `ArgumentError` 已消失、新增探测项能答、体检工具端到端跑通并正确判定「这不是信用账户」、两个单文件构建器重新生成后都带上了回调且 no-redis 那份仍 GBK 可解析。
+
+- **欢迎有两融账户的用户跑 `tools/credit_api_report.py` 并把报告贴到 #201 / #202。**
 
 ## [0.3.23] - 2026-09-06
 

--- a/bigqmt_no_redis/DRYRUN_no_redis.py
+++ b/bigqmt_no_redis/DRYRUN_no_redis.py
@@ -244,6 +244,7 @@ try:
         "get_enable_short_contract", "get_unclosed_compacts", "get_closed_compacts",
         "get_debt_contract", "get_option_subject_position", "get_comb_option",
         "get_hkt_exchange_rate", "down_history_data",
+        "query_credit_account",   # credit account, counter query, async (#202)
     ):
         if function_name in globals():
             qmt_extra[function_name] = globals()[function_name]
@@ -263,3 +264,7 @@ handlebar = _runtime.handlebar
 adjust = _runtime.adjust
 order_callback = _runtime.order_callback
 deal_callback = _runtime.deal_callback
+# Credit-account counter query callback. QMT only calls back into the
+# namespace of the file it mounted, so this has to be re-exported here
+# the same way order_callback / deal_callback are (#202).
+credit_account_callback = _runtime.credit_account_callback

--- a/docs/RPC_API_REFERENCE.md
+++ b/docs/RPC_API_REFERENCE.md
@@ -329,7 +329,29 @@
 | `get_comb_option` | `account_id`(可选) | 组合期权 |
 | `get_hkt_exchange_rate` | 无 | 港股通汇率 |
 
-> **融资融券查询的正确方式**：官方文档明确 `get_trade_detail_data` 的合法 `strDatatype` 只有 6 个（`ACCOUNT`/`POSITION`/`POSITION_STATISTICS`/`ORDER`/`DEAL`/`TASK`）。两融查询必须用上述独立函数，不要传 `"CREDIT"` 等字符串。
+> **融资融券查询的正确方式**：`get_trade_detail_data(accountID, strAccountType, strDatatype, strategyName)` 有**两个轴**，别混在一起：
+>
+> - **`strDatatype`（查什么数据）** 只有 6 个合法值：`ACCOUNT` / `POSITION` / `POSITION_STATISTICS` / `ORDER` / `DEAL` / `TASK`。**别往这里传 `"CREDIT"`** —— 负债合约、担保标的、可融券这些要用上表的独立函数。
+> - **`strAccountType`（查哪本账）** 才是填 `'CREDIT'` 的地方。官方 `strDatatype` 说明里写着 `ACCOUNT：账号对象**或信用账号对象**` —— 所以信用账户明细就是 `get_trade_detail_data(accId, 'CREDIT', 'ACCOUNT')`，返回 `CCreditAccountDetail`。`query_credit_detail` 走的正是这条（#201 之前它错调了已弃用的 `get_debt_contract`，两融账户因此恒为空）。
+>
+> **信用账户明细有两份，字段名还不一样**：
+>
+> | | RPC | 大 QMT | 对象 | 特点 |
+> |---|---|---|---|---|
+> | 终端缓存 | `query_credit_detail` | `get_trade_detail_data(accId,'CREDIT','ACCOUNT')` | `CCreditAccountDetail`（3.14，**非查柜台**）| 同步、无限流；券商没推就是空的 |
+> | 查柜台 | `query_credit_account` | `query_credit_account` + `credit_account_callback` | `CCreditDetail`（3.15）| 异步、权威；官方建议 30s 一次 |
+>
+> 总负债在缓存那份叫 `m_dTotalDebit`，在柜台那份叫 `m_dTotalDebt` —— 只差一个字母，别看错。
+
+### `query_credit_account`
+- **参数**：`account_id`(可选) `wait_seconds`(可选，默认 1.5，上限 10)
+- **返回**：`{"rows": [...], "count": n, "query_issued": bool, "not_issued_reason": str, "fresh": bool, "stale": bool, "age_seconds": float|null, "seq": int, "error": str, "callback_bound": bool}`
+- **为什么不是裸列表**：大 QMT 那边 `query_credit_account(accId, seq, ContextInfo)` 立刻返回，结果只从 `credit_account_callback` 出来。桥替你发查询、等回调、缓存结果，所以这条 RPC 本身是同步的 —— 但**空列表有好几种成因**（没绑上 / 被限流 / 发了没等到回调 / 真没数据），只回一个 `[]` 分不开。看 `query_issued`、`fresh`、`callback_bound`，别只看 `rows`。
+- **限流**：官方参考 6.13 写明「只能有一个查询」「建议 30s 一次，不可频繁调用」。桥按 30 秒最小间隔挡住过密的查询，直接返回上一次的结果并标 `stale=true`，不会替你去打柜台。
+- **需要重启策略**：`credit_account_callback` 定义在入口文件命名空间里（QMT 只往被挂载的那个文件回调），而入口文件 `reload_deployment()` 刷不了。`callback_bound=false` 通常就是「部署了但没重启」。
+- **客户端**：`xt_trader.query_credit_account(account, wait_seconds=None)`
+
+> **体检工具**：`python tools/credit_api_report.py` 把上面每个两融接口都只读调一遍，导出一份可以直接贴到 issue 的报告（账号打码、金额不带原值、持仓代码不进报告）。维护者没有两融账户，两融那一片只能靠有两融账户的用户跑一次回报。
 
 ---
 

--- a/docs/RPC_API_REFERENCE.md
+++ b/docs/RPC_API_REFERENCE.md
@@ -351,7 +351,11 @@
 - **返回**：`{"rows": [...], "count": n, "query_issued": bool, "not_issued_reason": str, "fresh": bool, "stale": bool, "age_seconds": float|null, "seq": int, "error": str, "callback_bound": bool}`
 - **为什么不是裸列表**：大 QMT 那边 `query_credit_account(accId, seq, ContextInfo)` 立刻返回，结果只从 `credit_account_callback` 出来。桥替你发查询、等回调、缓存结果，所以这条 RPC 本身是同步的 —— 但**空列表有好几种成因**（没绑上 / 被限流 / 发了没等到回调 / 真没数据），只回一个 `[]` 分不开。看 `query_issued`、`fresh`、`callback_bound`，别只看 `rows`。
 - **限流**：官方参考 6.13 写明「只能有一个查询」「建议 30s 一次，不可频繁调用」。桥按 30 秒最小间隔挡住过密的查询，直接返回上一次的结果并标 `stale=true`，不会替你去打柜台。
-- **需要重启策略**：`credit_account_callback` 定义在入口文件命名空间里（QMT 只往被挂载的那个文件回调），而入口文件 `reload_deployment()` 刷不了。`callback_bound=false` 通常就是「部署了但没重启」。
+- **`callback_bound=false` 有两种成因，别白重启一次**：
+  - **这台终端根本没有 `query_credit_account` 这个全局函数** —— 重启也没用，只能走同步那条。维护者的国金 QMT 就是这种：`get_debt_contract` / `get_assure_contract` / `get_enable_short_contract` / `get_unclosed_compacts` 都经同一条 `_resolve_runtime_name`（qmt_api → globals → builtins）解析得到，唯独 `query_credit_account` 解析不到，说明 QMT 没注入它。
+  - **有这个函数但没重启策略** —— `credit_account_callback` 定义在入口文件命名空间里（QMT 只往被挂载的那个文件回调），而入口文件 `reload_deployment()` 刷不了，必须真重启。
+
+  `probe_capabilities` 的 `global_namespace["query_credit_account"]` 分得开这两种，体检报告也会直接告诉你是哪一种。
 - **客户端**：`xt_trader.query_credit_account(account, wait_seconds=None)`
 
 > **体检工具**：`python tools/credit_api_report.py` 把上面每个两融接口都只读调一遍，导出一份可以直接贴到 issue 的报告（账号打码、金额不带原值、持仓代码不进报告）。维护者没有两融账户，两融那一片只能靠有两融账户的用户跑一次回报。

--- a/docs/RPC_API_REFERENCE.md
+++ b/docs/RPC_API_REFERENCE.md
@@ -338,12 +338,15 @@
 >
 > | | RPC | 大 QMT | 对象 | 特点 |
 > |---|---|---|---|---|
-> | 终端缓存 | `query_credit_detail` | `get_trade_detail_data(accId,'CREDIT','ACCOUNT')` | `CCreditAccountDetail`（3.14，**非查柜台**）| 同步、无限流；券商没推就是空的 |
-> | 查柜台 | `query_credit_account` | `query_credit_account` + `credit_account_callback` | `CCreditDetail`（3.15）| 异步、权威；官方建议 30s 一次 |
+> | **终端缓存（默认用这条）** | `query_credit_detail` | `get_trade_detail_data(accId,'CREDIT','ACCOUNT')` | `CCreditAccountDetail`（3.14，标注「非查柜台」）| 同步、无限流、不用重启 |
+> | 查柜台（备用） | `query_credit_account` | `query_credit_account` + `credit_account_callback` | `CCreditDetail`（3.15）| 异步、权威；官方建议 30s 一次；要重启策略 |
+>
+> **先用同步那条。** 维护者实测确认 `get_trade_detail_data('<信用账号>', 'credit', 'account', '')` 在大 QMT 里直接取得到信用账户信息，返回 list，取 `[0]`；账号类型和数据类型大小写都不敏感（`'credit'` / `'CREDIT'` 均可）。异步那条只是备用：3.14 那份官方标注「非查柜台」，是终端本地缓存，万一换一家券商的终端不填它，那就只剩查柜台这一条路。不需要的话完全不用理会 `query_credit_account`，不调它就什么都不会发生。
 >
 > 总负债在缓存那份叫 `m_dTotalDebit`，在柜台那份叫 `m_dTotalDebt` —— 只差一个字母，别看错。
 
-### `query_credit_account`
+### `query_credit_account`（备用，一般用不上）
+- **什么时候才需要它**：`query_credit_detail` 在你的终端上取不到时。同步那条是主路径，实测可用；这条是为「终端不填 3.14 那份缓存」的券商准备的后路。
 - **参数**：`account_id`(可选) `wait_seconds`(可选，默认 1.5，上限 10)
 - **返回**：`{"rows": [...], "count": n, "query_issued": bool, "not_issued_reason": str, "fresh": bool, "stale": bool, "age_seconds": float|null, "seq": int, "error": str, "callback_bound": bool}`
 - **为什么不是裸列表**：大 QMT 那边 `query_credit_account(accId, seq, ContextInfo)` 立刻返回，结果只从 `credit_account_callback` 出来。桥替你发查询、等回调、缓存结果，所以这条 RPC 本身是同步的 —— 但**空列表有好几种成因**（没绑上 / 被限流 / 发了没等到回调 / 真没数据），只回一个 `[]` 分不开。看 `query_issued`、`fresh`、`callback_bound`，别只看 `rows`。

--- a/src/BIGQMT_REDIS_DRYRUN.py
+++ b/src/BIGQMT_REDIS_DRYRUN.py
@@ -377,3 +377,7 @@ handlebar = _runtime.handlebar
 adjust = _runtime.adjust
 order_callback = _runtime.order_callback
 deal_callback = _runtime.deal_callback
+# Credit-account counter query callback. QMT only calls back into the
+# namespace of the file it mounted, so this has to be re-exported here
+# the same way order_callback / deal_callback are (#202).
+credit_account_callback = _runtime.credit_account_callback

--- a/src/BIGQMT_ZMQ_BACKTEST.py
+++ b/src/BIGQMT_ZMQ_BACKTEST.py
@@ -204,5 +204,9 @@ init = _runtime.init
 handlebar = _runtime.handlebar
 order_callback = _runtime.order_callback
 deal_callback = _runtime.deal_callback
+# Credit-account counter query callback. QMT only calls back into the
+# namespace of the file it mounted, so this has to be re-exported here
+# the same way order_callback / deal_callback are (#202).
+credit_account_callback = _runtime.credit_account_callback
 stop = _runtime.stop
 after_backtest = _runtime.after_backtest

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -748,7 +748,12 @@ class BigQmtRpcHandlers:
         # True 说明确实拿得到，False 只说明「这条路径上没有」，不等于终端没有。
         info["global_namespace"] = {}
         for name in ("create_sector", "create_sector_folder", "add_sector",
-                     "remove_sector", "remove_stock_from_sector", "reset_sector"):
+                     "remove_sector", "remove_stock_from_sector", "reset_sector",
+                     # query_credit_account 也走这条查：它在 qmt_api 里没有时，
+                     # 要能分清「这台终端根本没有这个函数」和「有但没绑上」。
+                     # 策略侧 _resolve_runtime_name 的兜底正是 builtins，所以
+                     # builtins 里没有就等于这台终端不提供（#202）。
+                     "query_credit_account"):
             found = self.qmt_api.get(name)
             if not callable(found):
                 try:

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -86,6 +86,7 @@ READ_METHODS = {
     "query_account_infos",
     "query_account_status",
     "query_credit_detail",
+    "query_credit_account",
     "query_stk_compacts",
     "query_credit_subjects",
     "query_credit_slo_code",
@@ -148,6 +149,7 @@ LISTENER_DEFERRED_METHODS = {
     "query_account_infos",
     "query_account_status",
     "query_credit_detail",
+    "query_credit_account",
     "query_stk_compacts",
     "query_credit_subjects",
     "query_credit_slo_code",
@@ -203,6 +205,16 @@ CANCELED_ORDER_STATUSES = {"53", "54"}
 # strategy_name=, or once with rpc_default_strategy_name in the config;
 # "" leaves the column blank the way a hand-placed order does.
 DEFAULT_ORDER_STRATEGY_NAME = "bigqmt_rpc"
+# query_credit_account 是查柜台的，官方参考 6.13 原话：「本函数只能有一个查询，
+# 如果前面的查询正在进行中，后面的查询将会提前返回。本函数从服务器查询数据，
+# 建议平均查询时间间隔 30s 一次，不可频繁调用。」所以桥这边自己限流，客户端
+# 想怎么轮询都不会把柜台打爆（#202）。
+CREDIT_ACCOUNT_MIN_INTERVAL_SECONDS = 30.0
+# 一次 RPC 里最多等回调多久。回调走 QMT 的 C++ 线程，handler 在 adjust 主线程
+# 上；这里的等待用 sleep 轮询让出 GIL，回调才落得下来。默认给得短，因为拿不到
+# 新的就退回上一次的缓存值，不必把主线程按住。
+CREDIT_ACCOUNT_DEFAULT_WAIT_SECONDS = 1.5
+CREDIT_ACCOUNT_MAX_WAIT_SECONDS = 10.0
 TERMINAL_NON_CANCEL_ORDER_STATUSES = {"56", "57"}
 # 51 已报待撤 / 52 部成待撤: the exchange has ACCEPTED the cancel and it is
 # on its way. Neither cancelled nor failed -- keep waiting, and at the
@@ -545,6 +557,19 @@ class BigQmtRpcHandlers:
         # Server-side diagnostic for silent failures (e.g. passorder submitted
         # but order not found in system). Surfaced to client via server_error.
         self._last_server_error = ""
+        # 信用账户的「查柜台」通道（#202）。query_credit_account 是异步的：结果
+        # 只从 credit_account_callback 出来，所以这里存最后一次回调的结果，由
+        # note_credit_account 填。官方 6.13 明说「只能有一个查询」「建议 30s 一
+        # 次，不可频繁调用」，所以单飞 + 最小间隔，不能每个请求都透传下去。
+        self._credit_account_lock = threading.Lock()
+        self._credit_account_rows = []
+        self._credit_account_seq = 0
+        self._credit_account_stamp = 0.0      # 回调落地的时间
+        self._credit_account_asked = 0.0      # 上一次真的发出查询的时间
+        self._credit_account_inflight = False
+        self._credit_account_error = ""
+        self.credit_account_min_interval_seconds = CREDIT_ACCOUNT_MIN_INTERVAL_SECONDS
+        self.credit_account_max_wait_seconds = CREDIT_ACCOUNT_MAX_WAIT_SECONDS
         if allowed_methods is None:
             allowed = set(READ_METHODS)
             if self.allow_order_methods:
@@ -734,6 +759,10 @@ class BigQmtRpcHandlers:
             info["global_namespace"][name] = callable(found)
         # 信用接口只读探测：不存在的全局直接标 unavailable；存在的真调一次，
         # 记录是否报错和返回行数（担保品/融券标的可能很多行，只计数）。
+        # get_unclosed_compacts / get_closed_compacts 是两参数签名（accountID,
+        # accountType），单参数调用会撞 boost::python 的 ArgumentError —— 探测
+        # 自己少传一个参数，把一个好用的接口报成 ok:False（#201）。
+        _two_arg = ("get_unclosed_compacts", "get_closed_compacts")
         for name in ("get_assure_contract", "get_enable_short_contract",
                      "get_unclosed_compacts", "get_debt_contract"):
             func = self.qmt_api.get(name)
@@ -741,7 +770,11 @@ class BigQmtRpcHandlers:
                 info["credit_probe"][name] = {"available": False}
                 continue
             try:
-                rows = func(self.account_id) or []
+                if name in _two_arg:
+                    rows = func(self.account_id,
+                                self._configured_account_type(self.account_id)) or []
+                else:
+                    rows = func(self.account_id) or []
                 info["credit_probe"][name] = {
                     "available": True, "ok": True, "rows": len(rows),
                 }
@@ -750,10 +783,147 @@ class BigQmtRpcHandlers:
                     "available": True, "ok": False,
                     "error": "%s: %s" % (exc.__class__.__name__, exc),
                 }
+        # 信用账户对象本身（query_credit_detail 的数据源）。空列表有两种成因 ——
+        # 这本账户不是信用账户，还是这台终端读不到 —— m_nBrokerType 能分开：
+        # 3 = 信用。#201 的报告只看到「空列表」，无从判断是哪一种。
+        info["credit_probe"]["get_trade_detail_data(CREDIT,ACCOUNT)"] = \
+            self._probe_credit_account_object()
         info["sector_probe"] = self._probe_sector_channels()
         info["order_watch"] = self._probe_order_watch()
         info["reply_residency"] = self._probe_reply_residency()
         return info
+
+    # ------------------------------------------------------------------
+    # 信用账户「查柜台」通道（#202）
+    # ------------------------------------------------------------------
+
+    def note_credit_account(self, seq, result):
+        """credit_account_callback 的落点。
+
+        QMT 从 C++ 回调线程调进来，所以这里只做「归一化 + 存下来」，绝不碰
+        get_trade_detail_data 之类需要主线程上下文的东西，也绝不抛出去 ——
+        回调里抛异常在 QMT 那边表现为无堆栈的 SystemError。
+        """
+        try:
+            rows = _normalize_detail_rows([result] if result is not None else [])
+        except Exception as exc:
+            with self._credit_account_lock:
+                self._credit_account_inflight = False
+                self._credit_account_error = "%s: %s" % (exc.__class__.__name__, exc)
+            return False
+        with self._credit_account_lock:
+            self._credit_account_rows = rows
+            self._credit_account_stamp = time.time()
+            self._credit_account_inflight = False
+            self._credit_account_error = ""
+            try:
+                self._credit_account_seq = int(seq)
+            except Exception:
+                pass
+        return True
+
+    def _issue_credit_account_query(self, account_id):
+        """Fire query_credit_account once, honouring the counter's rate limit.
+
+        Returns (issued, reason). Not issuing is a normal outcome, not a
+        failure: the cached answer is still served.
+        """
+        func = self.qmt_api.get("query_credit_account")
+        if not callable(func):
+            return False, "query_credit_account is not bound in this deployment"
+        context_info = getattr(self.market_data, "context_info", None)
+        if context_info is None:
+            return False, "no ContextInfo available"
+        now = time.time()
+        with self._credit_account_lock:
+            if self._credit_account_inflight:
+                return False, "a query is already in flight"
+            since = now - self._credit_account_asked
+            if self._credit_account_asked and since < self.credit_account_min_interval_seconds:
+                return False, ("rate limited: %.1fs since the last query, minimum %.1fs"
+                               % (since, self.credit_account_min_interval_seconds))
+            self._credit_account_inflight = True
+            self._credit_account_asked = now
+            seq = int(now)
+        try:
+            func(account_id, seq, context_info)
+        except Exception as exc:
+            with self._credit_account_lock:
+                self._credit_account_inflight = False
+                self._credit_account_error = "%s: %s" % (exc.__class__.__name__, exc)
+            return False, self._credit_account_error
+        return True, ""
+
+    def _handle_query_credit_account(self, params):
+        """信用账户明细，查柜台的那条路（官方参考 6.13）。
+
+        query_credit_account(accId, seq, ContextInfo) 是异步的，结果只从
+        credit_account_callback 出来，所以这个 handler 做的是：发一次查询（受
+        30s 最小间隔约束），有界地等回调落地，然后连同「数据是什么时候的、这次
+        有没有真发出去」一起返回。等不到就返回上一次的缓存 —— 但响应里会说清楚
+        stale=true，不会把陈数据冒充新的。
+        """
+        account_id = self._request_account_id(params)
+        wait_seconds = params.get("wait_seconds")
+        if wait_seconds is None:
+            wait_seconds = CREDIT_ACCOUNT_DEFAULT_WAIT_SECONDS
+        wait_seconds = max(0.0, min(self.credit_account_max_wait_seconds,
+                                    float(wait_seconds)))
+        with self._credit_account_lock:
+            stamp_before = self._credit_account_stamp
+        issued, reason = self._issue_credit_account_query(account_id)
+        deadline = time.time() + wait_seconds
+        while issued and time.time() < deadline:
+            with self._credit_account_lock:
+                if self._credit_account_stamp > stamp_before:
+                    break
+                if not self._credit_account_inflight:
+                    break
+            # sleep 让出 GIL，回调线程才拿得到 —— busy-wait 会把它锁死在门外。
+            time.sleep(0.02)
+        with self._credit_account_lock:
+            rows = list(self._credit_account_rows)
+            stamp = self._credit_account_stamp
+            error = self._credit_account_error
+            seq = self._credit_account_seq
+        return {
+            "rows": rows,
+            "count": len(rows),
+            "query_issued": issued,
+            "not_issued_reason": "" if issued else reason,
+            "fresh": bool(stamp and stamp > stamp_before),
+            "stale": bool(rows and not (stamp and stamp > stamp_before)),
+            "age_seconds": round(time.time() - stamp, 3) if stamp else None,
+            "seq": seq,
+            "error": error,
+            "callback_bound": callable(self.qmt_api.get("query_credit_account")),
+        }
+
+    def _probe_credit_account_object(self):
+        """Read-only probe of the credit account object behind query_credit_detail.
+
+        Reports the row count and, when there is a row, m_nBrokerType (3 =
+        信用) plus whether the credit-only fields came through -- so an empty
+        answer can be told apart from a non-credit account, which the bare
+        [] the reporter saw could not (#201).
+        """
+        gateway = self.order_gateway
+        if gateway is None or gateway.get_trade_detail_data is None:
+            return {"available": False}
+        try:
+            rows = _normalize_detail_rows(
+                gateway.get_trade_detail_data(
+                    self.account_id, "CREDIT", "ACCOUNT", "")) or []
+        except Exception as exc:
+            return {"available": True, "ok": False,
+                    "error": "%s: %s" % (exc.__class__.__name__, exc)}
+        report = {"available": True, "ok": True, "rows": len(rows)}
+        if rows and isinstance(rows[0], dict):
+            report["broker_type"] = rows[0].get("m_nBrokerType")
+            report["has_credit_fields"] = any(
+                key in rows[0] for key in
+                ("m_dPerAssurescaleValue", "m_dFinMaxQuota", "m_dSloMaxQuota"))
+        return report
 
     def _probe_reply_residency(self):
         """How long finished replies wait for the transport to send them.
@@ -1321,20 +1491,28 @@ class BigQmtRpcHandlers:
             getattr(gateway, "account_type", "CREDIT") or "CREDIT"
         ).strip().upper()
 
-    def _query_trade_detail(self, params, detail_type, strategy_name=""):
+    def _query_trade_detail(self, params, detail_type, strategy_name="",
+                            account_type=None):
         """get_trade_detail_data with one of the 6 official detail types.
 
         Official strDatatype values: ACCOUNT / POSITION / POSITION_STATISTICS /
-        ORDER / DEAL / TASK. Other strings (CREDIT etc.) are NOT supported by
-        this API — use the dedicated functions below for margin queries.
+        ORDER / DEAL / TASK. Other strings are NOT supported as *detail types* —
+        use the dedicated functions below for the margin contract queries.
+
+        *account_type* overrides the deployment's configured type for this one
+        call. That is the ACCOUNT-TYPE axis, not the detail-type axis: the
+        credit account object is `(accId, 'CREDIT', 'ACCOUNT')`, which the
+        caller asks for explicitly regardless of what this deployment trades
+        as (#201).
         """
         account_id = self._request_account_id(params)
         gateway = self.order_gateway
         if gateway is None or gateway.get_trade_detail_data is None:
             return []
-        account_type = (gateway._resolve_account_type(account_id)
-                        if hasattr(gateway, "_resolve_account_type")
-                        else getattr(gateway, "account_type", "STOCK"))
+        if account_type is None:
+            account_type = (gateway._resolve_account_type(account_id)
+                            if hasattr(gateway, "_resolve_account_type")
+                            else getattr(gateway, "account_type", "STOCK"))
         try:
             rows = gateway.get_trade_detail_data(account_id, account_type, detail_type, strategy_name)
             return _normalize_detail_rows(rows)
@@ -1350,8 +1528,17 @@ class BigQmtRpcHandlers:
         return self._query_trade_detail(params, "TASK")
 
     def _handle_query_credit_detail(self, params):
-        # 融资融券账户明细 — 官方独立函数 get_debt_contract
-        return self._call_qmt_global("get_debt_contract", self._request_account_id(params))
+        # 信用（两融）账户明细 — get_trade_detail_data(accId, 'CREDIT', 'ACCOUNT')
+        # 返回 CCreditAccountDetail（维持担保比例 / 融资融券授信额度 / 合约金额…），
+        # 与 MiniQMT query_credit_detail -> XtCreditDetail 对应，也是本仓
+        # docs/MiniQMT_2_BigQMT-Skill/api_mapping.md 一直记着的映射。
+        #
+        # 0.3.23 之前这里调的是 get_debt_contract(accId)：那是「负债合约明细」——
+        # 一张张融资融券合约，不是账户对象，而且官方参考 6.17 已标记【已弃用】
+        # （改用 get_unclosed_compacts / get_closed_compacts）。两融账户查它必然
+        # 拿不到账户信息，没有未了结负债时更是直接空列表（#201）。负债合约本身
+        # 走 query_stk_compacts（get_unclosed_compacts）。
+        return self._query_trade_detail(params, "ACCOUNT", account_type="CREDIT")
 
     def _handle_query_stk_compacts(self, params):
         # 未平仓合约（负债）— 官方 get_unclosed_compacts

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -4355,7 +4355,34 @@ class BigQmtXtTrader:
         return self._query_account_list(account, "query_account_status")
 
     def query_credit_detail(self, account):
+        """信用账户明细，读终端缓存的信用账号对象（同步）。
+
+        大 QMT 走 get_trade_detail_data(accId, 'CREDIT', 'ACCOUNT')。这份是
+        「非查柜台」的本地缓存（官方参考 3.14），券商没推就是空的 —— 空列表
+        时用 query_credit_account() 问柜台那一份（#201 / #202）。
+        """
         return self._query_account_list(account, "query_credit_detail")
+
+    def query_credit_account(self, account=None, wait_seconds=None):
+        """信用账户明细，查柜台的那一份（官方参考 6.13）。
+
+        大 QMT 那边是异步的：query_credit_account 立刻返回，结果从
+        credit_account_callback 出来。桥这边替你发查询、等回调、缓存结果，
+        所以这个调用本身是同步的。
+
+        柜台有官方限流（建议 30s 一次），桥会挡住过密的查询并直接返回上一次
+        的结果 —— 响应里的 fresh / stale / age_seconds / query_issued 说清楚
+        这一次拿到的是新数据还是缓存，不要只看 rows（#202）。
+
+        Returns:
+            dict: rows / count / fresh / stale / age_seconds / query_issued /
+                not_issued_reason / seq / error / callback_bound
+        """
+        account_id = _account_id(account, self.client.account_id)
+        params = {"account_id": account_id}
+        if wait_seconds is not None:
+            params["wait_seconds"] = float(wait_seconds)
+        return self.client.call("query_credit_account", params, account_id=account_id)
 
     def query_stk_compacts(self, account):
         return self._query_account_list(account, "query_stk_compacts")

--- a/src/bigqmt_signal_trader_dryrun.py
+++ b/src/bigqmt_signal_trader_dryrun.py
@@ -9,6 +9,7 @@ submit real orders.
 from bigqmt_signal_trader_strategy import (  # noqa: E402
     adjust,
     configure,
+    credit_account_callback,
     deal_callback,
     handlebar,
     init,

--- a/src/bigqmt_signal_trader_redis_dryrun.py
+++ b/src/bigqmt_signal_trader_redis_dryrun.py
@@ -8,6 +8,7 @@ DryRunOrderGateway orders only. It does not submit real QMT orders.
 from bigqmt_signal_trader_strategy import (  # noqa: E402
     adjust,
     configure,
+    credit_account_callback,
     deal_callback,
     handlebar,
     init,

--- a/src/bigqmt_signal_trader_redis_rpc_runtime.py
+++ b/src/bigqmt_signal_trader_redis_rpc_runtime.py
@@ -40,6 +40,9 @@ if _load_bridge_module is not None:
     bind_qmt_api = _strategy_module.bind_qmt_api
     capture_qmt_injected_funcs = _strategy_module.capture_qmt_injected_funcs
     configure = _strategy_module.configure
+    # 信用账户查柜台的回调；QMT 只往被挂载的文件回调，所以这里必须再导出一次，
+    # 和 order_callback / deal_callback 同理 (#202)。
+    credit_account_callback = _strategy_module.credit_account_callback
     deal_callback = _strategy_module.deal_callback
     handlebar = _strategy_module.handlebar
     init = _strategy_module.init
@@ -53,6 +56,7 @@ else:
         bind_qmt_api,
         capture_qmt_injected_funcs,
         configure,
+        credit_account_callback,
         deal_callback,
         handlebar,
         init,

--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -486,6 +486,9 @@ _EXTRA_QMT_GLOBAL_FUNCS = (
     "get_unclosed_compacts",          # 未平仓合约（负债）
     "get_closed_compacts",            # 已平仓合约
     "get_debt_contract",              # 负债合约
+    # 信用账户明细，查柜台的那条路。异步：结果只从 credit_account_callback
+    # 出来，见下面的 credit_account_callback 和 #202。
+    "query_credit_account",
     "get_option_subject_position",    # 期权标的持仓
     "get_comb_option",                # 组合期权
     "get_hkt_exchange_rate",          # 港股通汇率
@@ -1855,6 +1858,29 @@ def deal_callback(ContextInfo, dealInfo):
     """Standard Big QMT deal callback."""
     _publish_exec_event("trade", dealInfo, ContextInfo)
     return forward_trade_event(BigQmtRuntimeAdapter.to_trade_event(dealInfo))
+
+
+def credit_account_callback(ContextInfo, seq, result):
+    """Standard Big QMT credit-account callback (官方参考 6.13).
+
+    信用账户明细只有这一条查柜台的路：query_credit_account 立刻返回，结果从这里
+    出来。QMT 只往被挂载的那个文件的命名空间里回调，所以每个入口文件都要像
+    order_callback / deal_callback 那样再导出一次这个名字（#202）。
+
+    回调跑在 QMT 的 C++ 线程上，所以这里只把结果交给 handlers 存着，绝不做需要
+    主线程上下文的事，也绝不让异常逃出去 —— 回调里抛异常在 QMT 那边表现为没有
+    堆栈的 SystemError（issue #76）。
+    """
+    try:
+        handlers = getattr(_rpc_service, "handlers", None) if _rpc_service else None
+        if handlers is None or not hasattr(handlers, "note_credit_account"):
+            return False
+        return handlers.note_credit_account(seq, result)
+    except Exception as exc:
+        _log_err("credit_account_callback",
+                 "recording the credit account detail failed: %s (%s)"
+                 % (exc, exc.__class__.__name__))
+        return False
 
 
 def sync_positions(ContextInfo):

--- a/tests/bigqmt_signal_trader/test_query_credit_account.py
+++ b/tests/bigqmt_signal_trader/test_query_credit_account.py
@@ -1,0 +1,240 @@
+# coding: utf-8
+"""#202: 信用账户「查柜台」通道 query_credit_account + credit_account_callback。
+
+大 QMT 里信用账户的账户明细有两条路：
+
+  同步 get_trade_detail_data(accId, 'CREDIT', 'ACCOUNT')  -> 终端缓存那份
+  异步 query_credit_account(accId, seq, ContextInfo)      -> 柜台那份
+
+第二条只从 credit_account_callback 出来，原来完全没接。这组用例钉住接进来之后
+的三件事：真发得出去、回调落得下来、以及官方 6.13 的限流（「只能有一个查询」
+「建议 30s 一次」）确实挡得住。
+"""
+import os
+import sys
+import threading
+import time
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.adapters.market_bigqmt import BigQmtMarketDataProvider
+from bigqmt_signal_trader.adapters.order_dryrun import DryRunOrderGateway
+from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+
+
+class _CreditResult(object):
+    """回调交回来的对象是属性袋，不是 dict —— 和 QMT 一样。"""
+
+    def __init__(self):
+        self.m_strAccountID = "acct"
+        self.m_nBrokerType = 3
+        self.m_dPerAssurescaleValue = 2.87
+        self.m_dTotalDebt = 12345.67       # 注意：回调这份是 Debt，不是 Debit
+        self.m_dFinEnableQuota = 500000.0
+
+
+class _Ctx(object):
+    accid = "acct"
+
+    def get_full_tick(self, codes):
+        return {}
+
+
+def _handlers(query_func=None, **kw):
+    qmt_api = {}
+    if query_func is not None:
+        qmt_api["query_credit_account"] = query_func
+    return BigQmtRpcHandlers(
+        account_id="acct",
+        market_data=BigQmtMarketDataProvider(_Ctx()),
+        position_provider=None,
+        order_gateway=DryRunOrderGateway(),
+        qmt_api=qmt_api,
+        **kw
+    )
+
+
+class QueryCreditAccountTest(unittest.TestCase):
+
+    def test_issues_the_query_and_returns_the_callback_result(self):
+        """回调在另一个线程落地，handler 的有界等待要等得到。"""
+        seen = []
+        handlers_box = {}
+
+        def query_credit_account(account_id, seq, context_info):
+            seen.append((account_id, seq, context_info))
+            # QMT 从 C++ 回调线程调进来，这里用一个真线程模拟
+            def fire():
+                time.sleep(0.05)
+                handlers_box["h"].note_credit_account(seq, _CreditResult())
+            threading.Thread(target=fire).start()
+
+        handlers = _handlers(query_credit_account)
+        handlers_box["h"] = handlers
+        out = handlers.handle("query_credit_account", {})
+
+        self.assertEqual(len(seen), 1)
+        self.assertEqual(seen[0][0], "acct")
+        self.assertIsInstance(seen[0][1], int)
+        self.assertIsNotNone(seen[0][2])            # ContextInfo 必须传下去
+
+        self.assertTrue(out["query_issued"])
+        self.assertTrue(out["fresh"])
+        self.assertFalse(out["stale"])
+        self.assertEqual(out["count"], 1)
+        row = out["rows"][0]
+        self.assertEqual(row["m_dPerAssurescaleValue"], 2.87)
+        self.assertEqual(row["m_dTotalDebt"], 12345.67)
+        self.assertEqual(row["m_nBrokerType"], 3)
+
+    def test_rate_limited_second_call_serves_the_cache_and_says_so(self):
+        """官方建议 30s 一次。第二次不该再打柜台，但也不该假装没数据。"""
+        calls = []
+        handlers_box = {}
+
+        def query_credit_account(account_id, seq, context_info):
+            calls.append(seq)
+            handlers_box["h"].note_credit_account(seq, _CreditResult())
+
+        handlers = _handlers(query_credit_account)
+        handlers_box["h"] = handlers
+
+        first = handlers.handle("query_credit_account", {})
+        second = handlers.handle("query_credit_account", {})
+
+        self.assertEqual(len(calls), 1)             # 只发了一次
+        self.assertTrue(first["fresh"])
+        self.assertFalse(second["query_issued"])
+        self.assertIn("rate limited", second["not_issued_reason"])
+        # 缓存照给，但明说是陈的
+        self.assertEqual(second["count"], 1)
+        self.assertTrue(second["stale"])
+        self.assertFalse(second["fresh"])
+        self.assertIsNotNone(second["age_seconds"])
+
+    def test_min_interval_is_configurable_for_a_deliberate_refresh(self):
+        calls = []
+        handlers_box = {}
+
+        def query_credit_account(account_id, seq, context_info):
+            calls.append(seq)
+            handlers_box["h"].note_credit_account(seq, _CreditResult())
+
+        handlers = _handlers(query_credit_account)
+        handlers_box["h"] = handlers
+        handlers.credit_account_min_interval_seconds = 0.0
+
+        handlers.handle("query_credit_account", {})
+        handlers.handle("query_credit_account", {})
+        self.assertEqual(len(calls), 2)
+
+    def test_unbound_global_is_reported_not_silently_empty(self):
+        """这台部署没注入 query_credit_account —— 要说出来，不能只回空。"""
+        out = _handlers(None).handle("query_credit_account", {})
+
+        self.assertFalse(out["query_issued"])
+        self.assertFalse(out["callback_bound"])
+        self.assertIn("not bound", out["not_issued_reason"])
+        self.assertEqual(out["count"], 0)
+
+    def test_a_throwing_global_is_reported_not_swallowed(self):
+        def query_credit_account(account_id, seq, context_info):
+            raise RuntimeError("counter refused")
+
+        out = _handlers(query_credit_account).handle("query_credit_account", {})
+
+        self.assertFalse(out["query_issued"])
+        self.assertIn("counter refused", out["not_issued_reason"])
+
+    def test_no_callback_within_the_wait_is_not_reported_as_fresh(self):
+        """回调没来就是没来，不能把空/陈的当新数据报上去。"""
+        def query_credit_account(account_id, seq, context_info):
+            pass                                    # 永不回调
+
+        out = _handlers(query_credit_account).handle(
+            "query_credit_account", {"wait_seconds": 0.1})
+
+        self.assertTrue(out["query_issued"])
+        self.assertFalse(out["fresh"])
+        self.assertEqual(out["count"], 0)
+
+    def test_wait_seconds_is_clamped(self):
+        """客户端不能靠一个大 wait_seconds 把 adjust 主线程按住。"""
+        def query_credit_account(account_id, seq, context_info):
+            pass                                    # 永不回调，只能靠上限收场
+
+        handlers = _handlers(query_credit_account)
+        handlers.credit_account_max_wait_seconds = 0.2
+
+        t0 = time.time()
+        handlers.handle("query_credit_account", {"wait_seconds": 3600})
+        self.assertLess(time.time() - t0, 2.0)
+
+    def test_default_ceiling_bounds_the_main_thread_hold(self):
+        from bigqmt_signal_trader.redis_rpc import (
+            CREDIT_ACCOUNT_DEFAULT_WAIT_SECONDS, CREDIT_ACCOUNT_MAX_WAIT_SECONDS,
+        )
+        self.assertLessEqual(CREDIT_ACCOUNT_DEFAULT_WAIT_SECONDS, 2.0)
+        self.assertLessEqual(CREDIT_ACCOUNT_MAX_WAIT_SECONDS, 10.0)
+        self.assertEqual(_handlers(None).credit_account_max_wait_seconds,
+                         CREDIT_ACCOUNT_MAX_WAIT_SECONDS)
+
+    def test_callback_never_raises_out_of_the_c_thread(self):
+        """回调里抛异常在 QMT 那边是无堆栈的 SystemError，绝不能漏出去。"""
+        class _Exploding(object):
+            @property
+            def m_dTotalDebt(self):
+                raise RuntimeError("boom")
+
+        handlers = _handlers(lambda *a: None)
+        # 不抛，返回真假即可
+        result = handlers.note_credit_account(1, _Exploding())
+        self.assertIn(result, (True, False))
+
+    def test_method_is_whitelisted_and_deferred_to_the_main_thread(self):
+        from bigqmt_signal_trader.redis_rpc import (
+            LISTENER_DEFERRED_METHODS, READ_METHODS,
+        )
+        # query_credit_account 需要 ContextInfo 和主线程上下文，必须走 drain
+        self.assertIn("query_credit_account", READ_METHODS)
+        self.assertIn("query_credit_account", LISTENER_DEFERRED_METHODS)
+        self.assertIn("query_credit_account", _handlers(None).allowed_methods)
+
+
+class CreditCallbackWiringTest(unittest.TestCase):
+    """QMT 只往被挂载的那个文件回调，所以每个入口文件都要再导出一次。"""
+
+    ENTRY_FILES = (
+        "src/BIGQMT_REDIS_DRYRUN.py",
+        "src/BIGQMT_ZMQ_BACKTEST.py",
+        "src/BIGQMT_REDIS_DRYRUN_ALL_IN_ONE.py",
+        "src/bigqmt_signal_trader_redis_rpc_runtime.py",
+        "src/bigqmt_signal_trader_redis_dryrun.py",
+        "src/bigqmt_signal_trader_dryrun.py",
+        "bigqmt_no_redis/DRYRUN_no_redis.py",
+    )
+
+    def test_every_entry_that_exports_deal_callback_exports_the_credit_one(self):
+        import io
+        missing = []
+        for rel in self.ENTRY_FILES:
+            path = os.path.join(ROOT, rel.replace("/", os.sep))
+            text = io.open(path, encoding="utf-8", errors="replace").read()
+            if "deal_callback" in text and "credit_account_callback" not in text:
+                missing.append(rel)
+        self.assertEqual(missing, [])
+
+    def test_strategy_defines_the_callback_and_binds_the_global(self):
+        import io
+        path = os.path.join(ROOT, "src", "bigqmt_signal_trader_strategy.py")
+        text = io.open(path, encoding="utf-8", errors="replace").read()
+        self.assertIn("def credit_account_callback(ContextInfo, seq, result):", text)
+        # 全局函数要在捕获名单里，否则 handler 永远拿不到它
+        self.assertIn('"query_credit_account",', text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_query_credit_detail.py
+++ b/tests/bigqmt_signal_trader/test_query_credit_detail.py
@@ -1,0 +1,193 @@
+# coding: utf-8
+"""#201: query_credit_detail 返回空列表。
+
+两融账户调 query_credit_detail 拿到 []。原实现把它路由到 get_debt_contract：
+
+  - 语义就不对。get_debt_contract 是「负债合约明细」——一张张融资融券合约，
+    不是信用账户对象。用户要的是维持担保比例 / 授信额度 / 合约金额那一组，
+    即 CCreditAccountDetail（官方参考 3.14）。
+  - 而且官方参考 6.17 把 get_debt_contract 标了【已弃用】，替代接口是
+    get_unclosed_compacts / get_closed_compacts。
+  - 于是没有未了结负债的两融账户必然拿到 []，有负债的也拿不到账户信息。
+
+本仓自己的 docs/MiniQMT_2_BigQMT-Skill/api_mapping.md 一直写的是正确映射：
+query_credit_detail(acc) -> get_trade_detail_data(account, 'CREDIT', 'account')。
+代码和这份表对不上。
+
+顺带：probe_capabilities 探测 get_unclosed_compacts 时只传了 account_id，
+而它是两参数签名，实盘上撞 boost::python ArgumentError —— 把一个好用的接口
+报成 ok:False。
+"""
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.adapters.market_bigqmt import BigQmtMarketDataProvider
+from bigqmt_signal_trader.adapters.order_dryrun import DryRunOrderGateway
+from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+
+
+CREDIT_ACCOUNT_ROW = {
+    "m_strAccountID": "acct",
+    "m_nBrokerType": 3,                    # 3 = 信用
+    "m_dPerAssurescaleValue": 3.14,        # 个人维持担保比例
+    "m_dFinMaxQuota": 1000000.0,           # 融资授信额度
+    "m_dSloMaxQuota": 500000.0,            # 融券授信额度
+    "m_dEnableBailBalance": 88888.0,       # 可用保证金
+}
+
+STOCK_ACCOUNT_ROW = {
+    "m_strAccountID": "acct",
+    "m_nBrokerType": 2,                    # 2 = 普通股票
+    "m_dAssetBalance": 120230.88,
+}
+
+
+class _Ctx(object):
+    def get_full_tick(self, codes):
+        return {}
+
+
+class RecordingGateway(DryRunOrderGateway):
+    """记录 get_trade_detail_data 的每次调用，按 accountType 回不同的账户对象。"""
+
+    account_type = "STOCK"        # 部署配置成普通账户，credit 查询仍须问 CREDIT
+
+    def __init__(self):
+        super(RecordingGateway, self).__init__()
+        self.detail_calls = []
+        self.get_trade_detail_data = self._get_trade_detail_data
+
+    def _get_trade_detail_data(self, account_id, account_type, detail_type,
+                               strategy_name=""):
+        self.detail_calls.append((account_id, account_type, detail_type))
+        if str(account_type).upper() == "CREDIT" and detail_type == "ACCOUNT":
+            return [CREDIT_ACCOUNT_ROW]
+        if detail_type == "ACCOUNT":
+            return [STOCK_ACCOUNT_ROW]
+        return []
+
+
+def _handlers(gateway=None, qmt_api=None):
+    return BigQmtRpcHandlers(
+        account_id="acct",
+        market_data=BigQmtMarketDataProvider(_Ctx()),
+        position_provider=None,
+        order_gateway=gateway if gateway is not None else RecordingGateway(),
+        qmt_api=qmt_api or {},
+    )
+
+
+class QueryCreditDetailTest(unittest.TestCase):
+
+    def test_asks_for_the_credit_account_object_not_debt_contracts(self):
+        gateway = RecordingGateway()
+        rows = _handlers(gateway).handle("query_credit_detail", {})
+
+        self.assertEqual(gateway.detail_calls, [("acct", "CREDIT", "ACCOUNT")])
+        self.assertEqual(len(rows), 1)
+        # 信用账户特有字段必须在，这才是「两融账户信息」
+        self.assertEqual(rows[0]["m_dPerAssurescaleValue"], 3.14)
+        self.assertEqual(rows[0]["m_dFinMaxQuota"], 1000000.0)
+        self.assertEqual(rows[0]["m_nBrokerType"], 3)
+
+    def test_credit_type_is_forced_even_when_deployment_trades_as_stock(self):
+        """部署配置成 STOCK，query_credit_detail 仍然问 CREDIT。
+
+        账户类型是问哪本账，不是这台部署下单用哪本账；跟着配置走的话，一台
+        按 STOCK 配置的部署永远查不到自己的信用账户。
+        """
+        gateway = RecordingGateway()
+        gateway.account_type = "STOCK"
+        rows = _handlers(gateway).handle("query_credit_detail", {})
+
+        self.assertEqual(gateway.detail_calls[0][1], "CREDIT")
+        self.assertEqual(rows[0]["m_nBrokerType"], 3)
+
+    def test_deprecated_get_debt_contract_is_no_longer_the_source(self):
+        """即使 get_debt_contract 绑着且有数据，也不该从它取账户信息。"""
+        calls = []
+
+        def get_debt_contract(account_id):
+            calls.append(account_id)
+            return [{"m_strCompactId": "C1"}]
+
+        gateway = RecordingGateway()
+        rows = _handlers(gateway, {"get_debt_contract": get_debt_contract}).handle(
+            "query_credit_detail", {})
+
+        self.assertEqual(calls, [])
+        self.assertNotIn("m_strCompactId", rows[0])
+
+    def test_account_infos_still_follows_the_configured_type(self):
+        """query_account_infos 不受影响，仍按部署配置的账户类型查。"""
+        gateway = RecordingGateway()
+        rows = _handlers(gateway).handle("query_account_infos", {})
+
+        self.assertEqual(gateway.detail_calls, [("acct", "STOCK", "ACCOUNT")])
+        self.assertEqual(rows[0]["m_nBrokerType"], 2)
+
+    def test_missing_get_trade_detail_data_degrades_to_empty(self):
+        gateway = RecordingGateway()
+        gateway.get_trade_detail_data = None
+        self.assertEqual(_handlers(gateway).handle("query_credit_detail", {}), [])
+
+
+class ProbeUnclosedCompactsArityTest(unittest.TestCase):
+    """get_unclosed_compacts(accountID, accountType) — 探测必须传两个参数。"""
+
+    def test_probe_passes_account_type_to_unclosed_compacts(self):
+        calls = []
+
+        def get_unclosed_compacts(account_id, account_type):
+            calls.append((account_id, account_type))
+            return [{"m_strCompactId": "C1"}]
+
+        info = _handlers(None, {"get_unclosed_compacts": get_unclosed_compacts}).handle(
+            "probe_capabilities", {})
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0], "acct")
+        self.assertTrue(calls[0][1])
+        probe = info["credit_probe"]["get_unclosed_compacts"]
+        self.assertTrue(probe["ok"], probe.get("error"))
+        self.assertEqual(probe["rows"], 1)
+
+    def test_probe_reports_the_credit_account_object(self):
+        """空列表要能分辨「不是信用账户」和「读不到」。"""
+        gateway = RecordingGateway()
+        info = _handlers(gateway).handle("probe_capabilities", {})
+
+        probe = info["credit_probe"]["get_trade_detail_data(CREDIT,ACCOUNT)"]
+        self.assertTrue(probe["ok"], probe.get("error"))
+        self.assertEqual(probe["rows"], 1)
+        self.assertEqual(probe["broker_type"], 3)
+        self.assertTrue(probe["has_credit_fields"])
+
+    def test_probe_credit_object_survives_a_missing_gateway_function(self):
+        gateway = RecordingGateway()
+        gateway.get_trade_detail_data = None
+        info = _handlers(gateway).handle("probe_capabilities", {})
+        self.assertFalse(
+            info["credit_probe"]["get_trade_detail_data(CREDIT,ACCOUNT)"]["available"])
+
+    def test_single_arg_globals_are_still_called_with_one_arg(self):
+        calls = []
+
+        def get_assure_contract(account_id):
+            calls.append(account_id)
+            return [{"a": 1}]
+
+        info = _handlers(None, {"get_assure_contract": get_assure_contract}).handle(
+            "probe_capabilities", {})
+
+        self.assertEqual(calls, ["acct"])
+        self.assertTrue(info["credit_probe"]["get_assure_contract"]["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_credit_api_report.py
+++ b/tests/test_credit_api_report.py
@@ -1,0 +1,273 @@
+# coding: utf-8
+"""tools/credit_api_report.py —— 两融只读体检报告工具。
+
+这个工具存在的理由是维护者没有两融账户：两融那一整片只能靠别人跑一次回报。
+所以它自己必须是对的，否则收回来的报告会把人带偏。这组用例钉住三件事：
+
+  1. **不能下单。** 清单里只能有查询方法。
+  2. **默认不能泄露。** 报告是要贴到公开 issue 上的 —— 账号打码、金额不带原值、
+     get_positions 的键（就是股票代码，等于持仓）不能进报告。
+  3. **结论要能分辨「空」的几种成因。** 不是信用账户 / 桥不通 / 接口没绑 /
+     被限流 / 真的没数据 —— 分不开的话，报告只是把「空列表」换个地方再说一遍。
+"""
+import io
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, "tools"))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+import credit_api_report as rep  # noqa: E402
+
+
+ALL_CHECKS = (rep.CREDIT_ACCOUNT_CHECKS + rep.CREDIT_CONTRACT_CHECKS
+              + rep.CONTROL_CHECKS)
+
+
+class ReadOnlyTest(unittest.TestCase):
+    """工具号称只读，这条要能被证伪才算数。"""
+
+    WRITE_METHODS = (
+        "submit_order", "submit_orders_batch", "cancel_order", "passorder",
+        "order_stock", "order_stock_async", "smt_appointment",
+        "create_sector", "add_sector", "remove_sector", "reset_sector",
+    )
+
+    def test_no_write_method_in_any_checklist(self):
+        methods = [check[0] for check in ALL_CHECKS]
+        for bad in self.WRITE_METHODS:
+            self.assertNotIn(bad, methods)
+
+    def test_every_check_is_a_query(self):
+        for check in ALL_CHECKS:
+            method = check[0]
+            self.assertTrue(
+                method.startswith(("query_", "get_")) or method == "ping",
+                "非查询方法进了清单: %s" % method)
+
+    def test_source_never_calls_an_order_entry_point(self):
+        text = io.open(os.path.join(ROOT, "tools", "credit_api_report.py"),
+                       encoding="utf-8").read()
+        for bad in ("passorder", "order_stock", "submit_order", "cancel_order"):
+            self.assertNotIn('"%s"' % bad, text)
+
+
+class RedactionTest(unittest.TestCase):
+
+    def test_account_id_is_masked(self):
+        self.assertEqual(rep.mask_account("8886800503"), "88******03")
+        self.assertNotIn("88680050", rep.mask_account("8886800503"))
+
+    def test_amounts_are_bucketed_not_reported(self):
+        self.assertEqual(rep.describe_value(120230.88, full=False), "non-zero")
+        self.assertEqual(rep.describe_value(0.0, full=False), "zero")
+        self.assertEqual(rep.describe_value(120230.88, full=True), 120230.88)
+
+    def test_account_kind_fields_keep_their_real_value(self):
+        """m_nBrokerType 打了码报告就没用了 —— 它是判断信用账户的唯一依据。"""
+        out = rep.summarize_rows([{"m_nBrokerType": 3, "m_dBalance": 120230.88}],
+                                 full=False)
+        self.assertEqual(out["values"]["m_nBrokerType"], 3)
+        self.assertEqual(out["values"]["m_dBalance"], "non-zero")
+
+    def test_data_keyed_fields_are_redacted(self):
+        """get_positions 的键是股票代码 —— 那就是持仓，不能进公开报告。"""
+        row = {"600000.SH": {"volume": 100}, "000001.SZ": {"volume": 200}}
+        out = rep.summarize_rows([row], full=False, keys_are_data=True)
+
+        self.assertTrue(out["fields_redacted"])
+        self.assertEqual(out["fields"], [])
+        self.assertEqual(out["field_count"], 2)
+        rendered = repr(out)
+        self.assertNotIn("600000.SH", rendered)
+        self.assertNotIn("000001.SZ", rendered)
+
+    def test_full_mode_does_include_them(self):
+        row = {"600000.SH": {"volume": 100}}
+        out = rep.summarize_rows([row], full=True, keys_are_data=True)
+        self.assertEqual(out["fields"], ["600000.SH"])
+
+    def test_positions_check_is_marked_as_data_keyed(self):
+        """清单本身要标出来，否则上面那条防护根本不会生效。"""
+        by_method = dict((c[0], c) for c in rep.CONTROL_CHECKS)
+        positions = by_method["get_positions"]
+        self.assertGreater(len(positions), 4)
+        self.assertTrue(positions[4])
+
+
+class SummaryTest(unittest.TestCase):
+
+    def test_key_credit_fields_are_singled_out(self):
+        out = rep.summarize_rows([{
+            "m_dPerAssurescaleValue": 2.87,
+            "m_dTotalDebt": 12345.0,
+            "m_dSloMaxQuota": 0.0,
+            "m_strAccountID": "acct",
+        }], full=False)
+        self.assertIn("m_dPerAssurescaleValue", out["key_credit_fields_present"])
+        self.assertIn("m_dPerAssurescaleValue", out["key_credit_fields_non_zero"])
+        self.assertNotIn("m_dSloMaxQuota", out["key_credit_fields_non_zero"])
+
+    def test_both_spellings_of_total_debt_are_known(self):
+        """柜台那份是 m_dTotalDebt，缓存那份是 m_dTotalDebit，只差一个字母。"""
+        self.assertIn("m_dTotalDebt", rep.KEY_CREDIT_FIELDS)
+        self.assertIn("m_dTotalDebit", rep.KEY_CREDIT_FIELDS)
+
+    def test_all_zero_rows_are_flagged(self):
+        """字段都在、值全是 0 —— 和「没数据」不是一回事，要分开报。"""
+        out = rep.summarize_rows([{"m_dBalance": 0.0, "m_dTotalDebt": 0.0}],
+                                 full=False)
+        self.assertTrue(out["all_numeric_zero"])
+        state, _detail = rep.verdict_for(dict(out, ok=True, method="x"))
+        self.assertEqual(state, "有行但数值全为 0")
+
+    def test_envelope_is_preserved_verbatim(self):
+        """query_credit_account 的信封就是判断柜台通没通的依据，不能被归纳掉。"""
+        rows, extra = rep.normalize_result({
+            "rows": [], "query_issued": False, "callback_bound": False,
+            "not_issued_reason": "query_credit_account is not bound",
+        })
+        self.assertEqual(rows, [])
+        self.assertFalse(extra["callback_bound"])
+        self.assertIn("not bound", extra["not_issued_reason"])
+
+
+class VerdictTest(unittest.TestCase):
+    """「空」有好几种成因，报告要说出是哪一种。"""
+
+    def test_unbound_global(self):
+        state, detail = rep.verdict_for({
+            "ok": True, "row_count": 0,
+            "envelope": {"callback_bound": False,
+                         "not_issued_reason": "not bound in this deployment"},
+        })
+        self.assertEqual(state, "接口没绑上")
+        self.assertIn("not bound", detail)
+
+    def test_rate_limited(self):
+        state, detail = rep.verdict_for({
+            "ok": True, "row_count": 0,
+            "envelope": {"callback_bound": True, "query_issued": False,
+                         "not_issued_reason": "rate limited: 3.0s since..."},
+        })
+        self.assertEqual(state, "没发出查询")
+        self.assertIn("rate limited", detail)
+
+    def test_issued_but_no_callback(self):
+        state, _ = rep.verdict_for({
+            "ok": True, "row_count": 0,
+            "envelope": {"callback_bound": True, "query_issued": True,
+                         "fresh": False},
+        })
+        self.assertEqual(state, "发了但没等到回调")
+
+    def test_plain_error(self):
+        state, detail = rep.verdict_for({"ok": False, "error": "boom"})
+        self.assertEqual(state, "报错")
+        self.assertEqual(detail, "boom")
+
+    def test_has_data(self):
+        state, _ = rep.verdict_for({
+            "ok": True, "row_count": 1, "field_count": 40,
+            "key_credit_fields_non_zero": ["m_dPerAssurescaleValue"],
+        })
+        self.assertEqual(state, "有数据")
+
+
+class ConclusionTest(unittest.TestCase):
+
+    def _report(self, credit_account, contracts=None, control=None,
+                broker_type=3):
+        return {
+            "account_shape": {"broker_type": broker_type},
+            "checks": {
+                "credit_account": credit_account,
+                "credit_contracts": contracts or [],
+                "control": control or [
+                    {"method": "query_account_infos", "ok": True, "row_count": 1}],
+            },
+        }
+
+    def test_non_credit_account_is_called_out_loudly(self):
+        """普通账户跑出来的空报告说明不了任何事 —— 必须写清楚，不能当证据用。"""
+        out = rep.build_conclusions(self._report(
+            [{"method": "query_credit_detail", "ok": True, "row_count": 0},
+             {"method": "query_credit_account", "ok": True, "row_count": 0}],
+            broker_type=2))
+        joined = "\n".join(out)
+        self.assertIn("不是", joined)
+        self.assertIn("说明不了", joined)
+
+    def test_cached_empty_counter_ok_points_at_the_fallback(self):
+        out = rep.build_conclusions(self._report([
+            {"method": "query_credit_detail", "ok": True, "row_count": 0},
+            {"method": "query_credit_account", "ok": True, "row_count": 1},
+        ]))
+        joined = "\n".join(out)
+        self.assertIn("柜台那条通", joined)
+
+    def test_both_paths_working_is_reported(self):
+        out = rep.build_conclusions(self._report([
+            {"method": "query_credit_detail", "ok": True, "row_count": 1},
+            {"method": "query_credit_account", "ok": True, "row_count": 1},
+        ]))
+        self.assertIn("两条路都有数据", "\n".join(out))
+
+    def test_dead_bridge_is_diagnosed_before_blaming_credit(self):
+        """对照组也空的话，问题不在两融接口 —— 别让人去查错的地方。"""
+        out = rep.build_conclusions(self._report(
+            [{"method": "query_credit_detail", "ok": True, "row_count": 0}],
+            control=[{"method": "query_account_infos", "ok": True, "row_count": 0}]))
+        self.assertIn("问题多半不在两融接口", "\n".join(out))
+
+
+class CoverageTest(unittest.TestCase):
+    """清单要盖全 —— 漏一个接口，别人跑一趟也照样查不出来。"""
+
+    def test_every_credit_rpc_method_is_covered(self):
+        from bigqmt_signal_trader.redis_rpc import READ_METHODS
+
+        credit_methods = set(m for m in READ_METHODS
+                             if "credit" in m or "compact" in m
+                             or "assure" in m or "short_contract" in m
+                             or m == "get_debt_contract")
+        covered = set(check[0] for check in ALL_CHECKS)
+        self.assertEqual(sorted(credit_methods - covered), [])
+
+    def test_both_account_detail_paths_are_checked(self):
+        methods = set(c[0] for c in rep.CREDIT_ACCOUNT_CHECKS)
+        self.assertEqual(methods, {"query_credit_detail", "query_credit_account"})
+
+    def test_credit_order_type_constants_match_xtconstant(self):
+        """PR #88 把 33/34 当成了信用融资类型，其实那是股票期权。这条钉住。"""
+        from xtquant import xtconstant
+
+        for name, expected, _meaning in rep.CREDIT_ORDER_TYPES:
+            self.assertEqual(getattr(xtconstant, name), expected, name)
+
+    def test_report_renders_without_a_live_bridge(self):
+        report = {
+            "meta": {"generated_at": "2026-09-06 00:00:00",
+                     "account_masked": "88******03", "client_version": "0.0.0",
+                     "bridge_version": "0.0.0", "full_values": False},
+            "account_shape": {"broker_type": 3, "configured_account_type": "CREDIT",
+                              "verdict": "信用账户"},
+            "checks": {"credit_account": [
+                {"method": "query_credit_detail", "label": "x", "qmt_backend": "y",
+                 "ok": True, "row_count": 0, "elapsed_ms": 1.0}],
+                "credit_contracts": [], "control": []},
+            "probe": {"credit_probe": {}},
+            "order_types": [],
+            "conclusions": ["ok"],
+        }
+        text = rep.render_text(report)
+        self.assertIn("两融", text)
+        self.assertIn("88******03", text)
+        self.assertIn("没有下过任何单", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_credit_api_report.py
+++ b/tests/test_credit_api_report.py
@@ -216,6 +216,29 @@ class ConclusionTest(unittest.TestCase):
         ]))
         self.assertIn("两条路都有数据", "\n".join(out))
 
+    def test_terminal_without_the_global_is_told_restarting_wont_help(self):
+        """「没绑上」有两种成因，差别很大，别让人白重启一次策略。"""
+        report = self._report([
+            {"method": "query_credit_detail", "ok": True, "row_count": 0},
+            {"method": "query_credit_account", "ok": True, "row_count": 0,
+             "envelope": {"callback_bound": False}},
+        ])
+        report["probe"] = {"global_namespace": {"query_credit_account": False}}
+        joined = "\n".join(rep.build_conclusions(report))
+        self.assertIn("没有 query_credit_account", joined)
+        self.assertIn("重启策略也解决不了", joined)
+
+    def test_bound_in_namespace_but_unbound_points_at_the_restart(self):
+        report = self._report([
+            {"method": "query_credit_detail", "ok": True, "row_count": 0},
+            {"method": "query_credit_account", "ok": True, "row_count": 0,
+             "envelope": {"callback_bound": False}},
+        ])
+        report["probe"] = {"global_namespace": {"query_credit_account": True}}
+        joined = "\n".join(rep.build_conclusions(report))
+        self.assertIn("重启策略", joined)
+        self.assertNotIn("重启策略也解决不了", joined)
+
     def test_dead_bridge_is_diagnosed_before_blaming_credit(self):
         """对照组也空的话，问题不在两融接口 —— 别让人去查错的地方。"""
         out = rep.build_conclusions(self._report(

--- a/tools/build_no_redis_single_file_flat.py
+++ b/tools/build_no_redis_single_file_flat.py
@@ -592,6 +592,10 @@ handlebar = _runtime.handlebar
 adjust = _runtime.adjust
 order_callback = _runtime.order_callback
 deal_callback = _runtime.deal_callback
+# Credit-account counter query callback. QMT only calls back into the
+# namespace of the file it mounted, so the single-file entry has to
+# re-export it too or query_credit_account can never answer (#202).
+credit_account_callback = _runtime.credit_account_callback
 '''
 
 

--- a/tools/build_single_file.py
+++ b/tools/build_single_file.py
@@ -382,6 +382,10 @@ handlebar = _runtime.handlebar
 adjust = _runtime.adjust
 order_callback = _runtime.order_callback
 deal_callback = _runtime.deal_callback
+# Credit-account counter query callback. QMT only calls back into the
+# namespace of the file it mounted, so the single-file entry has to
+# re-export it too or query_credit_account can never answer (#202).
+credit_account_callback = _runtime.credit_account_callback
 '''
 
 

--- a/tools/credit_api_report.py
+++ b/tools/credit_api_report.py
@@ -391,6 +391,22 @@ def build_conclusions(report):
     if not control_alive:
         out.append("对照组也没数据 —— 问题多半不在两融接口，先查桥/账户/终端本身。")
 
+    # query_credit_account 报「没绑上」有两种成因，差别很大：这台终端根本没有
+    # 这个全局函数（那就无解，只能走同步那条），还是有但没重启策略（重启就好）。
+    # probe 的 global_namespace 走的是策略侧 _resolve_runtime_name 同一条解析
+    # 路径（qmt_api -> globals -> builtins），所以它能分开这两种。
+    counter_entry = by_method.get("query_credit_account", {})
+    if (counter_entry.get("envelope") or {}).get("callback_bound") is False:
+        in_namespace = ((report.get("probe") or {}).get("global_namespace")
+                        or {}).get("query_credit_account")
+        if in_namespace is False:
+            out.append("这台终端没有 query_credit_account 这个全局函数（QMT 没注入），"
+                       "查柜台那条路在这台机器上不可用 —— 用同步的 "
+                       "query_credit_detail。重启策略也解决不了。")
+        else:
+            out.append("query_credit_account 没绑上，多半是部署了但没**重启策略**"
+                       "（入口文件 reload_deployment() 刷不了）。不影响同步那条。")
+
     cached = by_method.get("query_credit_detail", {})
     counter = by_method.get("query_credit_account", {})
     cached_ok = bool(cached.get("row_count"))

--- a/tools/credit_api_report.py
+++ b/tools/credit_api_report.py
@@ -1,0 +1,581 @@
+# coding: utf-8
+"""两融（信用账户）API 只读体检报告。
+
+**这个工具不下单、不撤单、不改任何东西。** 只调查询接口。
+
+维护者本人没有两融账户，两融那一整片只能靠有两融账户的用户跑一次回报。所以
+这个脚本把每个两融接口都真调一遍，记下大 QMT 实际返回了什么 —— 行数、字段名、
+字段是不是真有值 —— 然后导出一份报告文件。把报告贴到 issue 里，就能直接看出
+是哪个接口出问题，不用来回猜。
+
+用法::
+
+    python tools/credit_api_report.py
+
+配置和 test_all_apis.py 一样，从 bigqmt_signal_trader_local_config 或环境变量
+读，不用改脚本。可选参数::
+
+    --account 8886800503     指定账号（默认用配置里的）
+    --out DIR                报告写到哪个目录（默认当前目录）
+    --full                   报告里带上原始数值。**默认不带** —— 报告是要贴到
+                             公开 issue 上的，默认只记「这个字段有没有值」，
+                             账号号码也打码。确认过内容再用 --full。
+    --wait 3                 查柜台那条路等回调的秒数（默认 3）
+
+产出两个文件：``credit_api_report_<时间戳>.json``（结构化，给维护者看）和
+``.txt``（人能读的摘要，贴 issue 用这个）。
+"""
+from __future__ import print_function
+
+import argparse
+import datetime as _dt
+import json
+import os
+import sys
+import time
+import traceback
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+if os.path.join(ROOT, "src") not in sys.path:
+    sys.path.insert(0, os.path.join(ROOT, "src"))
+# 运行一个脚本时 sys.path[0] 是**脚本所在目录**，不是当前目录 —— 所以
+# 「在放着配置的目录下运行」这句话，不把 cwd 加进来是不成立的。放在最前面，
+# 别让 QMT 目录里那份真配置抢在用户自己那份前面（CLAUDE.md 记过这个坑）。
+_CWD = os.getcwd()
+if _CWD not in sys.path:
+    sys.path.insert(0, _CWD)
+
+# 本进程自己一个日志文件，别去抢部署那份的句柄（Windows 上两个句柄会让日志轮转
+# 永远失败，见 CLAUDE.md / #144）。
+os.environ.setdefault("BIGQMT_LOG_NAME", "bigqmt-credit-report")
+
+
+# ---------------------------------------------------------------------------
+# 要体检的接口清单
+# ---------------------------------------------------------------------------
+# (RPC 方法名, 中文名, 这条 RPC 在大 QMT 那边最终调的东西, 额外参数)
+CREDIT_ACCOUNT_CHECKS = [
+    ("query_credit_detail", "信用账户明细（终端缓存）",
+     "get_trade_detail_data(accId, 'CREDIT', 'ACCOUNT') -> CCreditAccountDetail 3.14", {}),
+    ("query_credit_account", "信用账户明细（查柜台，异步回调）",
+     "query_credit_account(accId, seq, ContextInfo) + credit_account_callback -> CCreditDetail 3.15", {}),
+]
+
+CREDIT_CONTRACT_CHECKS = [
+    ("query_stk_compacts", "未了结负债合约",
+     "get_unclosed_compacts(accId, accType) -> StkCompacts 3.17", {}),
+    ("get_unclosed_compacts", "未了结负债合约（直连全局函数）",
+     "get_unclosed_compacts(accId, accType)", {}),
+    ("get_closed_compacts", "已了结负债合约（直连全局函数）",
+     "get_closed_compacts(accId, accType)", {}),
+    ("query_credit_subjects", "担保标的明细",
+     "get_assure_contract(accId) -> StkSubjects 3.18", {}),
+    ("query_credit_assure", "担保品合约（同 query_credit_subjects）",
+     "get_assure_contract(accId)", {}),
+    ("get_assure_contract", "担保标的明细（直连全局函数）",
+     "get_assure_contract(accId)", {}),
+    ("query_credit_slo_code", "可融券明细",
+     "get_enable_short_contract(accId) -> CreditSloEnableAmount 3.16", {}),
+    ("get_enable_short_contract", "可融券明细（直连全局函数）",
+     "get_enable_short_contract(accId)", {}),
+    ("get_debt_contract", "负债合约【官方已弃用 6.17】",
+     "get_debt_contract(accId)", {}),
+]
+
+# 对照组：不是两融接口，用来确认桥本身是活的。如果这几个也空，那问题不在两融。
+CONTROL_CHECKS = [
+    ("ping", "存活/版本", "-", {}),
+    ("query_account_infos", "账户信息（按部署配置的账户类型）",
+     "get_trade_detail_data(accId, <配置类型>, 'ACCOUNT')", {}),
+    ("get_asset", "资产", "get_trade_detail_data(...ACCOUNT)", {}),
+    # get_positions 的键就是股票代码 —— 键名本身是持仓数据，报告里要打掉。
+    ("get_positions", "持仓", "get_trade_detail_data(...POSITION)", {}, True),
+    ("query_orders", "当日委托", "get_trade_detail_data(...ORDER)", {}),
+]
+
+# 信用委托类型（xtconstant）。**只做静态核对，不下单。**
+CREDIT_ORDER_TYPES = [
+    ("CREDIT_BUY", 23, "担保品买入"),
+    ("CREDIT_SELL", 24, "担保品卖出"),
+    ("CREDIT_FIN_BUY", 27, "融资买入"),
+    ("CREDIT_SLO_SELL", 28, "融券卖出"),
+    ("CREDIT_BUY_SECU_REPAY", 29, "买券还券"),
+    ("CREDIT_DIRECT_SECU_REPAY", 30, "直接还券"),
+    ("CREDIT_SELL_SECU_REPAY", 31, "卖券还款"),
+    ("CREDIT_DIRECT_CASH_REPAY", 32, "直接还款"),
+    ("CREDIT_FIN_BUY_SPECIAL", 40, "专项融资买入"),
+    ("CREDIT_SLO_SELL_SPECIAL", 41, "专项融券卖出"),
+    ("CREDIT_BUY_SECU_REPAY_SPECIAL", 42, "专项买券还券"),
+    ("CREDIT_DIRECT_SECU_REPAY_SPECIAL", 43, "专项直接还券"),
+    ("CREDIT_SELL_SECU_REPAY_SPECIAL", 44, "专项卖券还款"),
+    ("CREDIT_DIRECT_CASH_REPAY_SPECIAL", 45, "专项直接还款"),
+]
+
+# 信用账户明细里，判断「这份数据到底有没有内容」要看的关键字段。
+# 缓存那份是 CCreditAccountDetail(3.14)，柜台那份是 CCreditDetail(3.15)，
+# 字段名不完全一样 —— 尤其 m_dTotalDebit / m_dTotalDebt 只差一个字母。
+KEY_CREDIT_FIELDS = (
+    "m_dPerAssurescaleValue",   # 维持担保比例，两份都有
+    "m_dTotalDebt",             # 总负债（柜台那份）
+    "m_dTotalDebit",            # 总负债（缓存那份）
+    "m_dFinMaxQuota", "m_dFinEnableQuota", "m_dFinUsedQuota",
+    "m_dSloMaxQuota", "m_dSloEnableQuota", "m_dSloUsedQuota",
+    "m_dEnableBailBalance",
+    "m_dFinDebt", "m_dSloDebt",
+    "m_dAssureAsset", "m_dBalance", "m_dAvailable",
+)
+
+
+# ---------------------------------------------------------------------------
+# 脱敏
+# ---------------------------------------------------------------------------
+
+def mask_account(account_id):
+    text = str(account_id or "")
+    if len(text) <= 4:
+        return "*" * len(text)
+    return text[:2] + "*" * (len(text) - 4) + text[-2:]
+
+
+# 这几个字段永远记原值。它们不是余额也不是持仓，是「这本账户是什么账户」的
+# 判据 —— 打了码报告就没法用了。m_nBrokerType: 2=普通股票 3=信用。
+ALWAYS_RAW_FIELDS = ("m_nBrokerType", "m_nDirection", "account_type")
+
+
+def describe_value(value, full):
+    """报告里怎么记一个字段值。
+
+    默认不记原值 —— 这份报告是要贴到公开 issue 上的，账户余额不该跟着走。
+    诊断真正需要的只是「这个字段回没回、是不是全是 0」。
+    """
+    if full:
+        return value
+    if value is None:
+        return "<null>"
+    if isinstance(value, bool):
+        return "bool:%s" % value
+    if isinstance(value, (int, float)):
+        return "zero" if value == 0 else "non-zero"
+    if isinstance(value, str):
+        if not value:
+            return "empty-str"
+        return "str(len=%d)" % len(value)
+    if isinstance(value, (list, tuple)):
+        return "list(len=%d)" % len(value)
+    if isinstance(value, dict):
+        return "dict(keys=%d)" % len(value)
+    return type(value).__name__
+
+
+# ---------------------------------------------------------------------------
+# 结果归纳
+# ---------------------------------------------------------------------------
+
+def summarize_rows(rows, full, keys_are_data=False):
+    """把一批返回行归纳成「字段名 + 每个字段有没有值」。
+
+    *keys_are_data* 用于 get_positions 这类「键就是数据」的返回（键是股票代码）。
+    这种字段名不能进报告 —— 报告是要贴到公开 issue 上的，那等于把持仓贴出去。
+    """
+    out = {"row_count": len(rows)}
+    if not rows:
+        return out
+    first = rows[0]
+    if not isinstance(first, dict):
+        out["row_type"] = type(first).__name__
+        out["sample"] = describe_value(first, full)
+        return out
+    fields = sorted(first.keys())
+    out["field_count"] = len(fields)
+    if keys_are_data and not full:
+        out["fields_redacted"] = True
+        out["fields"] = []
+        return out
+    out["fields"] = fields
+    out["values"] = dict(
+        (k, first.get(k) if k in ALWAYS_RAW_FIELDS else describe_value(first.get(k), full))
+        for k in fields)
+    populated = [k for k in fields
+                 if isinstance(first.get(k), (int, float))
+                 and not isinstance(first.get(k), bool)
+                 and first.get(k) != 0]
+    out["non_zero_numeric_fields"] = populated
+    out["all_numeric_zero"] = (not populated) and any(
+        isinstance(first.get(k), (int, float)) and not isinstance(first.get(k), bool)
+        for k in fields)
+    present_key = [k for k in KEY_CREDIT_FIELDS if k in first]
+    if present_key:
+        out["key_credit_fields_present"] = present_key
+        out["key_credit_fields_non_zero"] = [
+            k for k in present_key
+            if isinstance(first.get(k), (int, float)) and first.get(k) != 0]
+    return out
+
+
+def normalize_result(result):
+    """各个接口返回形状不一：list / dict / {rows: [...]}。统一成 (rows, extra)。"""
+    if result is None:
+        return [], {}
+    if isinstance(result, dict):
+        if "rows" in result and isinstance(result["rows"], list):
+            extra = dict((k, v) for k, v in result.items() if k != "rows")
+            return result["rows"], extra
+        return [result], {}
+    if isinstance(result, (list, tuple)):
+        return list(result), {}
+    return [result], {}
+
+
+# ---------------------------------------------------------------------------
+# 跑一个接口
+# ---------------------------------------------------------------------------
+
+def run_check(call, method, label, backend, params, full, keys_are_data=False):
+    entry = {
+        "method": method,
+        "label": label,
+        "qmt_backend": backend,
+        "params": dict(params or {}),
+    }
+    started = time.time()
+    try:
+        result = call(method, dict(params or {}))
+    except Exception as exc:
+        entry["ok"] = False
+        entry["error"] = "%s: %s" % (exc.__class__.__name__, exc)
+        entry["elapsed_ms"] = round((time.time() - started) * 1000, 1)
+        return entry
+    entry["ok"] = True
+    entry["elapsed_ms"] = round((time.time() - started) * 1000, 1)
+    rows, extra = normalize_result(result)
+    entry.update(summarize_rows(rows, full, keys_are_data))
+    if extra:
+        # query_credit_account 的 fresh / stale / query_issued / error 等都在这里,
+        # 这些正是判断「柜台那条路到底通没通」的依据，一定要原样记下来。
+        entry["envelope"] = extra
+    return entry
+
+
+def verdict_for(entry):
+    """一句话结论，给人看的那份报告用。"""
+    if not entry.get("ok"):
+        return "报错", entry.get("error", "")
+    envelope = entry.get("envelope") or {}
+    if entry.get("row_count"):
+        if entry.get("all_numeric_zero"):
+            return "有行但数值全为 0", "字段回来了，值都是 0 —— 可能是没数据，也可能是没读到"
+        key_nz = entry.get("key_credit_fields_non_zero")
+        if key_nz:
+            return "有数据", "关键字段有值：%s" % ", ".join(key_nz[:4])
+        return "有数据", "%d 行 / %d 字段" % (entry.get("row_count", 0),
+                                               entry.get("field_count", 0))
+    if envelope.get("callback_bound") is False:
+        return "接口没绑上", envelope.get("not_issued_reason", "")
+    if envelope.get("query_issued") is False and envelope.get("not_issued_reason"):
+        return "没发出查询", envelope["not_issued_reason"]
+    if envelope.get("query_issued") and not envelope.get("fresh"):
+        return "发了但没等到回调", "柜台没回，或回调没接上"
+    return "空", ""
+
+
+# ---------------------------------------------------------------------------
+# 报告
+# ---------------------------------------------------------------------------
+
+def render_text(report):
+    lines = []
+    add = lines.append
+    add("=" * 72)
+    add("两融（信用账户）API 只读体检报告")
+    add("=" * 72)
+    meta = report["meta"]
+    add("生成时间   : %s" % meta["generated_at"])
+    add("账号       : %s (已打码)" % meta["account_masked"])
+    add("客户端版本 : %s" % meta["client_version"])
+    add("桥端版本   : %s" % meta["bridge_version"])
+    add("原始数值   : %s" % ("已包含 (--full)" if meta["full_values"]
+                             else "已省略（默认，可安全贴到 issue）"))
+    add("")
+    add("这份报告只调查询接口，没有下过任何单。")
+    add("")
+
+    account = report.get("account_shape") or {}
+    add("-" * 72)
+    add("这个账户是不是信用账户")
+    add("-" * 72)
+    add("  部署配置的账户类型 : %s" % account.get("configured_account_type", "?"))
+    add("  m_nBrokerType      : %s   (2=普通股票  3=信用)" % account.get("broker_type"))
+    add("  判定               : %s" % account.get("verdict", "?"))
+    add("")
+
+    for title, key in (("信用账户明细（这次报告的重点）", "credit_account"),
+                       ("负债合约 / 标的", "credit_contracts"),
+                       ("对照组（非两融，用来确认桥本身是活的）", "control")):
+        add("-" * 72)
+        add(title)
+        add("-" * 72)
+        for entry in report["checks"].get(key, []):
+            state, detail = verdict_for(entry)
+            add("  %-28s %-22s %7.1fms" % (entry["method"], state,
+                                           entry.get("elapsed_ms", 0)))
+            add("      %s" % entry["label"])
+            add("      QMT: %s" % entry["qmt_backend"])
+            if detail:
+                add("      -> %s" % detail)
+            if entry.get("fields"):
+                shown = entry["fields"][:14]
+                add("      字段(%d): %s%s" % (entry.get("field_count", 0),
+                                              ", ".join(shown),
+                                              " ..." if len(entry["fields"]) > 14 else ""))
+            if entry.get("envelope"):
+                add("      信封: %s" % json.dumps(entry["envelope"],
+                                                  ensure_ascii=False, default=str)[:300])
+            add("")
+        add("")
+
+    add("-" * 72)
+    add("桥端能力探测 (probe_capabilities)")
+    add("-" * 72)
+    probe = report.get("probe") or {}
+    if probe.get("error"):
+        add("  探测失败: %s" % probe["error"])
+    else:
+        for name, value in sorted((probe.get("credit_probe") or {}).items()):
+            add("  %-40s %s" % (name, json.dumps(value, ensure_ascii=False)[:200]))
+        globals_map = probe.get("qmt_globals") or {}
+        missing = sorted(k for k, v in globals_map.items() if not v)
+        if missing:
+            add("")
+            add("  这台终端没有绑上的全局函数: %s" % ", ".join(missing))
+    add("")
+
+    add("-" * 72)
+    add("信用委托类型常量（静态核对，没有下过单）")
+    add("-" * 72)
+    for item in report.get("order_types", []):
+        flag = "ok" if item["matches"] else ("缺失" if item["actual"] is None else "不一致")
+        add("  %-36s 期望 %-3s 实际 %-6s %-6s %s"
+            % (item["name"], item["expected"], item["actual"], flag, item["meaning"]))
+    add("")
+
+    add("=" * 72)
+    add("结论")
+    add("=" * 72)
+    for line in report.get("conclusions", []):
+        add("  - %s" % line)
+    add("")
+    add("请把这个文件（以及同名的 .json）贴到 issue 里。")
+    return "\n".join(lines)
+
+
+def build_conclusions(report):
+    out = []
+    account = report.get("account_shape") or {}
+    if account.get("broker_type") == 3:
+        out.append("这是信用账户（m_nBrokerType=3），两融接口的结果可以采信。")
+    elif account.get("broker_type") is not None:
+        out.append("这**不是**信用账户（m_nBrokerType=%s）。两融接口返回空是正常的，"
+                   "这份报告说明不了两融接口有没有问题。" % account.get("broker_type"))
+    else:
+        out.append("读不到 m_nBrokerType，无法判断账户类型 —— 先看对照组是不是也空。")
+
+    by_method = {}
+    for group in report["checks"].values():
+        for entry in group:
+            by_method[entry["method"]] = entry
+
+    control_alive = any(by_method.get(m, {}).get("row_count")
+                        for m in ("query_account_infos", "get_asset", "ping"))
+    if not control_alive:
+        out.append("对照组也没数据 —— 问题多半不在两融接口，先查桥/账户/终端本身。")
+
+    cached = by_method.get("query_credit_detail", {})
+    counter = by_method.get("query_credit_account", {})
+    cached_ok = bool(cached.get("row_count"))
+    counter_ok = bool(counter.get("row_count"))
+    if cached_ok and counter_ok:
+        out.append("信用账户明细两条路都有数据：缓存 (query_credit_detail) 和 "
+                   "柜台 (query_credit_account) 都通。")
+    elif cached_ok and not counter_ok:
+        out.append("缓存那条通、柜台那条没数据 —— 用 query_credit_detail；"
+                   "把 query_credit_account 的信封贴上来看是没绑、被限流还是没回调。")
+    elif counter_ok and not cached_ok:
+        out.append("柜台那条通、缓存那条空 —— 说明 CCreditAccountDetail 在这台终端"
+                   "没被填上，query_credit_detail 应该回退到查柜台那条。这正是 #202 要解决的。")
+    else:
+        out.append("信用账户明细两条路都空。请把 probe_capabilities 那一段一起贴上来。")
+
+    broken = [m for m, e in by_method.items() if not e.get("ok")]
+    if broken:
+        out.append("直接报错的接口: %s" % ", ".join(sorted(broken)))
+    empty = sorted(m for m, e in by_method.items()
+                   if e.get("ok") and not e.get("row_count"))
+    if empty:
+        out.append("返回空的接口: %s" % ", ".join(empty))
+    return out
+
+
+# ---------------------------------------------------------------------------
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="两融 API 只读体检报告（不下单）")
+    parser.add_argument("--account", default=None, help="账号，默认用配置里的")
+    parser.add_argument("--out", default=".", help="报告输出目录")
+    parser.add_argument("--full", action="store_true",
+                        help="报告里带上原始数值（默认省略，便于直接贴 issue）")
+    parser.add_argument("--wait", type=float, default=3.0,
+                        help="查柜台那条路等回调的秒数（默认 3）")
+    args = parser.parse_args(argv)
+
+    from bigqmt_signal_trader.xtquant_compat import XtQuantTrader
+    from bigqmt_signal_trader.version import __version__ as client_version
+
+    account_id = args.account or os.environ.get("BIGQMT_ACCOUNT_ID") or ""
+    trader = XtQuantTrader(None, int(time.time()) % 100000,
+                           account_id=account_id or None)
+    trader.start()
+    trader.connect()
+    if not account_id:
+        try:
+            account_id = trader.client.account_id
+        except Exception:
+            account_id = ""
+
+    def call(method, params):
+        params = dict(params or {})
+        params.setdefault("account_id", account_id)
+        return trader.client.call(method, params, account_id=account_id)
+
+    # 先确认桥是通的。不先探这一下的话，配置没读到会让下面 16 个接口每一个都
+    # 报同一条「account_id is required」，报告看着像「两融全挂了」——那种报告
+    # 贴上来是帮倒忙的。
+    try:
+        handshake = call("ping", {}) or {}
+    except Exception as exc:
+        print("连不上桥，体检没跑：%s: %s" % (exc.__class__.__name__, exc))
+        print("")
+        print("这个脚本要能找到账号和 redis/zmq 配置，方式任选其一：")
+        print("  1. 在有 bigqmt_signal_trader_client_config.py 的目录下运行；")
+        print("  2. 设环境变量 BIGQMT_ACCOUNT_ID（以及 redis 那几个）；")
+        print("  3. 加 --account <账号> 参数。")
+        print("确认 QMT 终端开着、策略在跑，再重试。")
+        try:
+            trader.stop()
+        except Exception:
+            pass
+        return 2
+
+    report = {
+        "meta": {
+            "generated_at": _dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+            "account_masked": mask_account(account_id),
+            "client_version": client_version,
+            "bridge_version": "?",
+            "full_values": bool(args.full),
+            "read_only": True,
+            "orders_placed": 0,
+        },
+        "checks": {"credit_account": [], "credit_contracts": [], "control": []},
+    }
+
+    report["meta"]["bridge_version"] = handshake.get("version", "?")
+    report["meta"]["account_masked"] = mask_account(account_id)
+
+    print("正在体检两融接口（只读，不下单）...")
+    for method, label, backend, params in CREDIT_ACCOUNT_CHECKS:
+        p = dict(params)
+        if method == "query_credit_account":
+            p["wait_seconds"] = args.wait
+        print("  ->", method)
+        report["checks"]["credit_account"].append(
+            run_check(call, method, label, backend, p, args.full))
+    for method, label, backend, params in CREDIT_CONTRACT_CHECKS:
+        print("  ->", method)
+        report["checks"]["credit_contracts"].append(
+            run_check(call, method, label, backend, params, args.full))
+    for check in CONTROL_CHECKS:
+        method, label, backend, params = check[:4]
+        keys_are_data = check[4] if len(check) > 4 else False
+        print("  ->", method)
+        report["checks"]["control"].append(
+            run_check(call, method, label, backend, params, args.full, keys_are_data))
+
+    # 账户形状：信用账户 m_nBrokerType=3。两条路哪条有行就从哪条读。
+    # m_nBrokerType 在 ALWAYS_RAW_FIELDS 里，所以脱敏模式下也是真值。信用
+    # 账户那两条优先 —— 对照组读的是部署配置的账户类型，可能根本不是信用那本。
+    broker_type = None
+    for entry in report["checks"]["credit_account"] + report["checks"]["control"]:
+        value = (entry.get("values") or {}).get("m_nBrokerType")
+        if isinstance(value, int):
+            broker_type = value
+            break
+    probe = {}
+    try:
+        probe = call("probe_capabilities", {}) or {}
+    except Exception as exc:
+        probe = {"error": "%s: %s" % (exc.__class__.__name__, exc)}
+    report["probe"] = probe
+    credit_object = (probe.get("credit_probe") or {}).get(
+        "get_trade_detail_data(CREDIT,ACCOUNT)") or {}
+    if broker_type is None:
+        broker_type = credit_object.get("broker_type")
+    report["account_shape"] = {
+        "broker_type": broker_type,
+        "configured_account_type": (handshake.get("account_type")
+                                    or probe.get("account_type") or "?"),
+        "verdict": ("信用账户" if broker_type == 3 else
+                    ("普通账户" if broker_type is not None else "判断不了")),
+        "credit_object_probe": credit_object,
+    }
+
+    # 信用委托类型：只核对常量，绝不下单。
+    order_types = []
+    try:
+        from xtquant import xtconstant
+    except Exception:
+        xtconstant = None
+    for name, expected, meaning in CREDIT_ORDER_TYPES:
+        actual = getattr(xtconstant, name, None) if xtconstant else None
+        order_types.append({"name": name, "expected": expected, "actual": actual,
+                            "matches": actual == expected, "meaning": meaning})
+    report["order_types"] = order_types
+
+    report["conclusions"] = build_conclusions(report)
+
+    stamp = _dt.datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_dir = os.path.abspath(args.out)
+    if not os.path.isdir(out_dir):
+        os.makedirs(out_dir)
+    json_path = os.path.join(out_dir, "credit_api_report_%s.json" % stamp)
+    text_path = os.path.join(out_dir, "credit_api_report_%s.txt" % stamp)
+    text = render_text(report)
+    with open(json_path, "w", encoding="utf-8") as handle:
+        json.dump(report, handle, ensure_ascii=False, indent=2, default=str)
+    with open(text_path, "w", encoding="utf-8") as handle:
+        handle.write(text)
+
+    print()
+    print(text)
+    print()
+    print("报告已写入:")
+    print("  ", text_path)
+    print("  ", json_path)
+
+    try:
+        trader.stop()
+    except Exception:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)
+    except Exception:
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
Closes #201, closes #202.

三个提交，一个一件事。

## 1. `query_credit_detail` 读信用账户对象（#201）

两融账户调 `query_credit_detail` 恒为空列表。handler 路由到了 `get_debt_contract`——那是「负债合约明细」（一张张合约），不是信用账户对象，而且官方参考 6.17 已标记【已弃用】。没有未了结负债的两融账户必然拿到 `[]`，有负债的也只拿到合约行，永远拿不到维持担保比例和授信额度。

改走 `get_trade_detail_data(accId, 'CREDIT', 'ACCOUNT')` → `CCreditAccountDetail`，也就是本仓 `api_mapping.md:83` 一直记着、代码一直没对上的那条映射。官方 `strDatatype` 说明写着 `ACCOUNT：账号对象或信用账号对象`——两个轴要分开：`strDatatype` 说查什么数据（6 个合法值，别传 CREDIT），`strAccountType` 才是填 `CREDIT` 的地方。

账户类型强制 `CREDIT` 而不跟部署配置走：账户类型是「问哪本账」，不是「这台部署下单用哪本账」。

顺带修 `probe_capabilities` 自己的坑：它统一单参数调那四个信用全局函数，而 `get_unclosed_compacts` / `get_closed_compacts` 是两参数签名，实盘撞 `ArgumentError`——**把一个好用的接口报成坏的**，排查时反而误导人。

## 2. 接入「查柜台」通道 `query_credit_account`（#202，**备用，一般用不上**）

**先说结论：默认只用上面那条同步的。** 维护者实测确认 `get_trade_detail_data('<信用账号>', 'credit', 'account', '')` 在大 QMT 里直接取得到信用账户信息（返回 list 取 `[0]`，大小写不敏感），所以同步那条就是主路径。

这条异步的接进来只是留条后路：3.14 那份官方标注「非查柜台」，是终端本地缓存 —— 万一换一家券商的终端不填它，就只剩查柜台这一条，而这正是维护者这边验证不了的一类问题。不需要的话完全不用理会，不调它就什么都不会发生。

**两条路互不依赖**：不互相调用、不共享状态，`query_credit_detail` 也不会在空的时候偷偷退到 `query_credit_account`。名字容易误导 —— 后者不是前者的异步版本，两个名字来自两套命名体系（大 QMT 原生全局函数名 vs MiniQMT 客户端 API 名）。返回对象也不同：总负债在缓存那份叫 `m_dTotalDebit`、柜台那份叫 `m_dTotalDebt`，融资/融券负债细分只有柜台那份有，不能混着读。

从客户端看这条也是同步的（桥替你发查询、有界等回调、把结果放进响应），但等待有上限（默认 1.5s / 最大 10s）：handler 跑在 QMT adjust 主线程上，在那儿死等会把所有其他 RPC 排在后面，就是 #44 里把下单卡到 ~2 笔/秒的那个坑。超时返回上次的值并标 `stale=true`。

- `credit_account_callback` 在策略模块定义、每个入口文件再导出一次（QMT 只往被挂载的那个文件回调）
- 限流按官方 6.13 自己挡（30s 最小间隔），客户端怎么轮询都打不爆柜台
- 等不到回调返回上一次的值并标 `stale=true`，不把陈数据冒充新的
- `query_issued` / `fresh` / `callback_bound` / `not_issued_reason` 把「空」的成因分开报——只回一个 `[]` 的话，没绑上、被限流、没等到回调、真没数据这四种看起来一模一样

两个单文件构建器各自硬编码了一份回调再导出清单，都补上了。入口文件注释写成纯 ASCII——这几个文件声明 `#coding:gbk`，UTF-8 中文注释会让 QMT 根本加载不了（被 `test_entry_encoding` 拦下）。

**这条需要真的重启策略**，入口文件 `reload_deployment()` 刷不了。

## 3. 两融 API 只读体检报告 `tools/credit_api_report.py`

维护者的账户是普通股票账户（`m_nBrokerType=2`），信用账本根本不存在——所有两融接口返回空都是正确行为，本机验证不了任何两融修复。这个工具把每个两融接口真调一遍、记下大 QMT 实际返回了什么，导出可以直接贴 issue 的报告。

- **不下单、不撤单**：用例钉住清单里不含任何写方法，源码里也不出现下单入口名
- **默认脱敏**：账号打码、金额只记「有值 / 全 0」、`get_positions` 的键是股票代码（等于持仓）所以整组打掉；`m_nBrokerType` 例外保留原值——打了码就没法判断是不是信用账户
- **带对照组**：先回答「是桥不通还是两融接口的问题」再下结论；普通账户跑出来的空报告会被明确标成「说明不了任何事」

## 验证

**已验证**

- 全量测试 1631 passed，收集数 124 == 文件数 124
- #201 的用例修复前 4 red / 修复后 green（`git stash` 对照）
- 用终端自己的 `xtquant` 预检导入通过（bundled xtconstant 99 names）
- 实盘部署 + reload：`probe_capabilities` 的 `ArgumentError` 已消失，`get_unclosed_compacts` 报 `ok: true`；新增的 `get_trade_detail_data(CREDIT,ACCOUNT)` 探测项能答、无报错
- 体检工具端到端跑通：正确读出 `m_nBrokerType=2`、判定「普通账户」、结论明确写出「这份报告说明不了两融接口有没有问题」；`get_positions` 的股票代码确认没进报告
- 两个单文件构建器重新生成后都带上了 `credit_account_callback`，no-redis 那份仍 GBK 可解析

- **#201 的取数路径经维护者实测确认**：`get_trade_detail_data('<信用账号>', 'credit', 'account', '')` 在大 QMT 里能取到信用账户信息。

**未验证**

- **这个仓的 RPC 链路本身没有在真实两融账户上跑过**。维护者的部署账户是普通股票账户（`m_nBrokerType=2`），信用账本不存在，两融接口返回空都是正确行为，证明不了链路端到端通。
- **#202 的异步通道完全未验证**，且默认不需要它。实盘上仍报 `callback_bound=false` —— 入口文件改动需要真的重启策略，`reload_deployment()` 刷不了。不影响同步那条。

**求助**：有两融账户的用户跑一次 `python tools/credit_api_report.py`，把生成的 `.txt` 贴到 #201 / #202。报告默认脱敏，可以直接贴。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
