### PR TITLE
QMT 全局函数参数/返回形状修复 + 机械校验闸 (#207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 
 ### 修复
 
+- **三个 QMT 全局函数的参数写错，外加两个返回形状用错，全部静默返回空**（#207）：QMT 全局函数的映射是纯手写的，没有任何东西校验它和官方签名对不对。用 AST 把所有调用点扫出来和官方参考比对，查出：`get_value_by_order_id` 只传了 1 个参数（签名要 4 个）、`get_last_order_id` 只传了 1 个（要 3-4 个）、`get_history_trade_detail_data` 传了 4 个且把 `detail_type` 塞到了 `strAccountType` 的位置（要 5 个，和 #96 同一个形状）。全部被 `_call_qmt_global` 的 `except: return []` 吞掉。
+
+  参数修好后实盘一跑，又暴露出返回形状也用错了：`get_last_order_id` 返回的是**委托号字符串**，不是行列表，`_normalize_detail_rows` 会去迭代它 —— 真委托号 `'635005110'` 变成 **9 个空 dict**（一个字符一个），QMT 表示「没找到」的 `'-1'` 变成 2 个空 dict，int 直接抛 TypeError 被吞成 `[]`。**委托号被完全销毁**，而这个函数正是官方「下单 → 查单 → 撤单」标准流程的第二步。`get_value_by_order_id` 同理，它返回**单个**委托对象不是列表，迭代它抛异常同样被吞成 `[]`，看起来像「查不到这笔委托」。新增 `_call_qmt_scalar`（保留标量原样）和 `_call_qmt_object`（单对象归一化）两条取数路径。
+
+  顺带：`_normalize_detail_rows` 丢掉非标识符的属性名。QMT 委托对象上除了 60 个 `m_*` 字段还挂着 60 个数字串名的枚举常量（`'0': 48` / `'-1': -1`），`dir()` 一并刮走让载荷翻倍。实盘实测 120 字段 → 65 字段，真字段一个不少。
+
+  **同时加了一道机械闸**：`tests/bigqmt_signal_trader/test_qmt_global_arity.py` 用 AST 扫出所有 `_call_qmt_*` 调用点，和一张按官方参考手抄的签名表比对，写错参数个数从此是「测试红」而不是「线上静默返回空」；新接一个全局函数不登记签名也会红，防止这道闸慢慢失效。这一个 session 里同形态的 bug 出现了六次（#96 / #201 / #205 / #207 三条），值得一道闸。
+
+  实盘验证（只读）：`get_last_order_id` 从 `[{}, {}]` 变成 `'-1'`；`get_value_by_order_id(635005110)` 从 `[]` 变成 65 个字段的委托对象，`m_strOrderSysID=635005110`、`m_nOrderStatus=56`。`get_history_trade_detail_data` 在本机终端未绑定，未验证。
+
 - **直连的两融 `get_*` 查询恒返回空，而调同一个 QMT 函数的 `query_*` 孪生方法有数据**：一位有两融账户的用户跑 `tools/credit_api_report.py` 回报，同一次运行里 `query_stk_compacts` 52 行 / `query_credit_subjects` 71002 行 / `query_credit_slo_code` 50 行，而 `get_unclosed_compacts` / `get_assure_contract` / `get_enable_short_contract` 全是 0 行。两边的 handler **逐字节相同**，账号相同，底层 QMT 函数也是同一个 —— 唯一的差别是 `query_*` 在 `LISTENER_DEFERRED_METHODS` 里（走 adjust 主线程），直连的不在（走后台 listener 线程）。
 
   这正是 `get_ipo_data` 早就踩过并修掉的坑，它的注释原文就是「交易类查询, 需主线程上下文（后台线程返回空）」—— 当时只修了它一个，孪生方法漏网。现在把所有要交易上下文的 QMT 全局函数补进 defer 名单：`get_assure_contract` / `get_enable_short_contract` / `get_unclosed_compacts` / `get_closed_compacts` / `get_debt_contract` / `get_option_subject_position` / `get_comb_option` / `get_new_purchase_limit` / `get_hkt_exchange_rate`。行情读（`get_ticks` / `get_market_data*` / `get_option_list` / `get_main_contract` …）保持 inline 不动，defer 会白搭上一个 adjust 间隔的延迟；用例同时钉住这两侧。

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -1552,6 +1552,50 @@ class BigQmtRpcHandlers:
         except Exception:
             return []
 
+    def _call_qmt_scalar(self, func_name, *args, **kwargs):
+        """Same as _call_qmt_global, for the QMT globals that answer with a
+        plain scalar rather than detail rows -- get_last_order_id returns the
+        委托号 as a str.
+
+        The row normaliser iterates whatever it is handed, so a string goes in
+        and a list of one empty dict PER CHARACTER comes out: the real order id
+        '635005110' became [{}, {}, {}, {}, {}, {}, {}, {}, {}] and '-1'
+        (QMT's "not found") became [{}, {}]. An int raises TypeError inside the
+        normaliser and is swallowed to []. Same shape as #96, where get_ipo_data
+        was destroyed the same way (#207).
+        """
+        func = self.qmt_api.get(func_name)
+        if func is None:
+            return None
+        try:
+            return _normalize_mapping_value(func(*args, **kwargs))
+        except Exception:
+            return None
+
+    def _call_qmt_object(self, func_name, *args, **kwargs):
+        """Same as _call_qmt_global, for the QMT globals that answer with ONE
+        object rather than a list of them -- get_value_by_order_id returns a
+        single 委托/成交 object.
+
+        Handing that straight to the row normaliser iterates the object itself,
+        which raises TypeError and gets swallowed to [] -- the call looks like
+        "no such order" when it actually worked (#207).
+        """
+        func = self.qmt_api.get(func_name)
+        if func is None:
+            return {}
+        try:
+            value = func(*args, **kwargs)
+        except Exception:
+            return {}
+        if value is None:
+            return {}
+        if isinstance(value, (list, tuple)):
+            rows = _normalize_detail_rows(value)
+            return rows[0] if rows else {}
+        rows = _normalize_detail_rows([value])
+        return rows[0] if rows else {}
+
     def _call_qmt_mapping(self, func_name, *args, **kwargs):
         """Same as _call_qmt_global, for the QMT globals that answer with a
         mapping rather than a row list -- get_ipo_data, get_new_purchase_limit.
@@ -1688,13 +1732,41 @@ class BigQmtRpcHandlers:
 
     # 官方交易查询函数（直接暴露）
     def _handle_get_value_by_order_id(self, params):
+        # 官方签名 get_value_by_order_id(orderId, accountID, strAccountType,
+        # strDatatype)，strDatatype 是 'ORDER' / 'DEAL'（6.11）。原来只传了
+        # orderId 一个参数 —— 少三个，_call_qmt_global 把 TypeError 吞掉返回
+        # 空，从客户端看就是「查不到这笔委托」（#207）。
         order_id = str(params.get("order_id") or params.get("order_sysid") or "")
         if not order_id:
             raise ValueError("order_id is required")
-        return self._call_qmt_global("get_value_by_order_id", order_id)
+        account_id = self._request_account_id(params)
+        detail_type = str(params.get("detail_type")
+                          or params.get("datatype") or "ORDER").strip().upper()
+        # 返回的是单个委托/成交对象，不是行列表 —— 走 _call_qmt_object，
+        # 否则 _normalize_detail_rows 会去迭代这个对象、抛 TypeError 被吞成
+        # []，看起来像「查不到这笔委托」（#207）。
+        return self._call_qmt_object(
+            "get_value_by_order_id", order_id, account_id,
+            self._configured_account_type(account_id), detail_type)
 
     def _handle_get_last_order_id(self, params):
-        return self._call_qmt_global("get_last_order_id", self._request_account_id(params))
+        # 官方签名 get_last_order_id(accountID, strAccountType, strDatatype
+        # [, strategyName])（6.11）。原来只传了 accountID。strategyName 只对
+        # 本地下单有效，用部署的默认策略名，空则不传。
+        account_id = self._request_account_id(params)
+        detail_type = str(params.get("detail_type")
+                          or params.get("datatype") or "ORDER").strip().upper()
+        strategy_name = params.get("strategy_name")
+        if strategy_name is None:
+            strategy_name = self.default_strategy_name
+        strategy_name = str(strategy_name or "")
+        args = [account_id, self._configured_account_type(account_id), detail_type]
+        if strategy_name:
+            args.append(strategy_name)
+        # 返回的是委托号字符串，不是行列表 —— 走 _call_qmt_scalar。实盘实测：
+        # 走 _call_qmt_global 时 '635005110' 被按字符迭代成 9 个空 dict，
+        # QMT 表示「没找到」的 '-1' 变成 2 个空 dict（#207）。
+        return self._call_qmt_scalar("get_last_order_id", *args)
 
     def _handle_get_ipo_data(self, params):
         # get_ipo_data answers with a dict KEYED BY SUBSCRIPTION CODE, not with
@@ -1717,8 +1789,14 @@ class BigQmtRpcHandlers:
         detail_type = str(params.get("detail_type") or params.get("datatype") or "DEAL")
         start_date = str(params.get("start_date") or params.get("start_time") or "")
         end_date = str(params.get("end_date") or params.get("end_time") or "")
+        # 官方签名 get_history_trade_detail_data(accountID, strAccountType,
+        # strDatatype, startDate, endDate)（6.9）。原来漏了 strAccountType，
+        # 于是 detail_type 被塞进了账户类型的位置 —— 少一个参数、还错位，
+        # 和 #96 里 get_ipo_data 把 account_id 当 type 传是同一个形状（#207）。
         result = self._call_qmt_global(
-            "get_history_trade_detail_data", account_id, detail_type, start_date, end_date
+            "get_history_trade_detail_data", account_id,
+            self._configured_account_type(account_id),
+            detail_type, start_date, end_date
         )
         return result
 
@@ -2599,6 +2677,12 @@ def _normalize_detail_rows(rows):
         item = {}
         for name in dir(row):
             if name.startswith("_"):
+                continue
+            # QMT 的委托对象上除了 60 个 m_* 字段，还挂着 60 个枚举常量，
+            # 名字是 '0' / '-1' / '101' 这种数字串（值就是常量本身）。dir()
+            # 一并刮进来会让载荷翻倍、还夹着看不懂的键。非标识符的名字一律
+            # 丢掉 —— 真字段（m_xxx / 普通属性名）都是合法标识符，不会误伤。
+            if not name.isidentifier():
                 continue
             try:
                 value = getattr(row, name)

--- a/tests/bigqmt_signal_trader/test_qmt_global_arity.py
+++ b/tests/bigqmt_signal_trader/test_qmt_global_arity.py
@@ -1,0 +1,313 @@
+# coding: utf-8
+"""#207：机械校验每个 QMT 全局函数调用点的参数个数。
+
+这一个 session 里，同一个形态的 bug 出现了六次：
+
+  #96   get_ipo_data                  account_id 传到了 type 的位置
+  #201  probe 探测                     单参数调两参数签名的 get_unclosed_compacts
+  #205  get_hkt_exchange_rate         一个参数都没传（签名要两个）
+  #207  get_value_by_order_id         只传 1 个（签名要 4 个）
+  #207  get_last_order_id             只传 1 个（签名要 3-4 个）
+  #207  get_history_trade_detail_data 传 4 个且错位（签名要 5 个）
+
+每一次的表现都一样：`_call_qmt_global` 把 TypeError / boost::python 的
+ArgumentError 吞掉返回空，从客户端看和「这台终端没这个功能」「这个账户没
+数据」完全一样。**一个失败的调用和一个从没跑过的调用长得一模一样。**
+
+映射是纯手写的，没有任何东西会发现它和官方签名对不上 —— 所以这里用 AST
+把所有调用点扫出来，和下面这张按官方参考手抄的签名表比对。写错参数个数
+从此是「测试红」，不是「线上静默返回空」。
+
+签名表的出处一律是 docs/BIGQMT_INNER_PYTHON_API_REFERENCE.md，条目号写在
+每一行后面，改之前先去核对文档。
+"""
+import ast
+import io
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+RPC_SOURCE = os.path.join(ROOT, "src", "bigqmt_signal_trader", "redis_rpc.py")
+
+# QMT 全局函数 -> (最少参数, 最多参数)。None 表示不限。
+# 出处：docs/BIGQMT_INNER_PYTHON_API_REFERENCE.md，条目号见注释。
+OFFICIAL_ARITY = {
+    "get_assure_contract": (1, 1),              # 6.12  (accId)
+    "get_enable_short_contract": (1, 1),        # 6.12  (accId)
+    "get_unclosed_compacts": (2, 2),            # 6.16  (accountID, accountType)
+    "get_closed_compacts": (2, 2),              # 6.16  (accountID, accountType)
+    "get_debt_contract": (1, 1),                # 6.17  (accId) 【已弃用】
+    "get_ipo_data": (0, 1),                     # 6.10  (type="")
+    "get_new_purchase_limit": (1, 1),           # 6.10  (accid)
+    "get_option_subject_position": (1, 1),      # (accountID)
+    "get_comb_option": (1, 1),                  # (accountID)
+    "get_hkt_exchange_rate": (2, 2),            # 6.18  (accountID, accountType)
+    "get_value_by_order_id": (4, 4),            # 6.11  (orderId, accountID,
+                                                #        strAccountType, strDatatype)
+    "get_last_order_id": (3, 4),                # 6.11  (accountID, strAccountType,
+                                                #        strDatatype[, strategyName])
+    "get_history_trade_detail_data": (5, 5),    # 6.9   (accountID, strAccountType,
+                                                #        strDatatype, startDate, endDate)
+}
+
+
+def _call_sites():
+    """(函数名, 实参个数, 行号) —— 所有 _call_qmt_global / _call_qmt_mapping 调用点。"""
+    tree = ast.parse(io.open(RPC_SOURCE, encoding="utf-8").read())
+    sites = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            continue
+        if func.attr not in ("_call_qmt_global", "_call_qmt_mapping",
+                             "_call_qmt_scalar", "_call_qmt_object"):
+            continue
+        if not node.args or not isinstance(node.args[0], ast.Constant):
+            continue
+        if any(isinstance(a, ast.Starred) for a in node.args):
+            continue          # *args 展开的（get_last_order_id）单独用例覆盖
+        sites.append((node.args[0].value, len(node.args) - 1, node.lineno))
+    return sites
+
+
+class QmtGlobalArityTest(unittest.TestCase):
+
+    def test_every_call_site_matches_the_official_signature(self):
+        wrong = []
+        for name, count, line in _call_sites():
+            bounds = OFFICIAL_ARITY.get(name)
+            if bounds is None:
+                continue
+            low, high = bounds
+            if not (low <= count <= high):
+                wrong.append("redis_rpc.py:%d %s 传了 %d 个参数，官方签名要 %s"
+                             % (line, name, count,
+                                "%d" % low if low == high else "%d-%d" % (low, high)))
+        self.assertEqual(wrong, [], "\n".join([""] + wrong))
+
+    def test_the_signature_table_covers_every_global_we_call(self):
+        """新接一个 QMT 全局函数就得往表里加一行，否则这道闸形同虚设。"""
+        called = set(name for name, _count, _line in _call_sites())
+        missing = sorted(called - set(OFFICIAL_ARITY))
+        self.assertEqual(
+            missing, [],
+            "这些 QMT 全局函数被调用但没登记官方签名，去 "
+            "docs/BIGQMT_INNER_PYTHON_API_REFERENCE.md 查了以后补进 "
+            "OFFICIAL_ARITY: %s" % missing)
+
+    def test_the_probe_calls_them_with_the_right_arity_too(self):
+        """探测自己也踩过这个坑（#201）—— 它调的是同一批函数。"""
+        from bigqmt_signal_trader.adapters.market_bigqmt import BigQmtMarketDataProvider
+        from bigqmt_signal_trader.adapters.order_dryrun import DryRunOrderGateway
+        from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+
+        class _Ctx(object):
+            def get_full_tick(self, codes):
+                return {}
+
+        seen = {}
+
+        def _recorder(name):
+            def _fn(*args):
+                seen[name] = len(args)
+                return []
+            return _fn
+
+        probed = ("get_assure_contract", "get_enable_short_contract",
+                  "get_unclosed_compacts", "get_debt_contract")
+        BigQmtRpcHandlers(
+            account_id="acct",
+            market_data=BigQmtMarketDataProvider(_Ctx()),
+            position_provider=None,
+            order_gateway=DryRunOrderGateway(),
+            qmt_api=dict((n, _recorder(n)) for n in probed),
+        ).handle("probe_capabilities", {})
+
+        for name in probed:
+            low, high = OFFICIAL_ARITY[name]
+            self.assertIn(name, seen, name)
+            self.assertTrue(low <= seen[name] <= high,
+                            "probe 用 %d 个参数调 %s，官方签名要 %d-%d"
+                            % (seen[name], name, low, high))
+
+
+class OrderIdQueryArgumentsTest(unittest.TestCase):
+    """三个新修的：参数个数对不上只是表象，位置也得对。"""
+
+    def _handlers(self, qmt_api):
+        from bigqmt_signal_trader.adapters.market_bigqmt import BigQmtMarketDataProvider
+        from bigqmt_signal_trader.adapters.order_dryrun import DryRunOrderGateway
+        from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+
+        class _Ctx(object):
+            def get_full_tick(self, codes):
+                return {}
+
+        return BigQmtRpcHandlers(
+            account_id="acct",
+            market_data=BigQmtMarketDataProvider(_Ctx()),
+            position_provider=None,
+            order_gateway=DryRunOrderGateway(),
+            qmt_api=qmt_api,
+        )
+
+    def test_get_value_by_order_id_passes_all_four(self):
+        seen = []
+
+        def get_value_by_order_id(order_id, account_id, account_type, datatype):
+            seen.append((order_id, account_id, account_type, datatype))
+            return [{"m_strOrderSysID": "X1"}]
+
+        order = self._handlers({"get_value_by_order_id": get_value_by_order_id}).handle(
+            "get_value_by_order_id", {"order_id": "X1"})
+
+        self.assertEqual(len(seen), 1)
+        self.assertEqual(seen[0][0], "X1")
+        self.assertEqual(seen[0][1], "acct")
+        self.assertTrue(seen[0][2])          # strAccountType
+        self.assertEqual(seen[0][3], "ORDER")
+        # 回的是一个委托对象，不是行列表 —— 官方 6.11 就是这么定义的
+        self.assertEqual(order["m_strOrderSysID"], "X1")
+
+    def test_get_value_by_order_id_can_ask_for_deals(self):
+        seen = []
+        self._handlers({"get_value_by_order_id":
+                        lambda *a: (seen.append(a), [])[1]}).handle(
+            "get_value_by_order_id", {"order_id": "X1", "detail_type": "deal"})
+        self.assertEqual(seen[0][3], "DEAL")
+
+    def test_get_last_order_id_passes_account_type_and_datatype(self):
+        seen = []
+
+        def get_last_order_id(*args):
+            seen.append(args)
+            return "12345"
+
+        self._handlers({"get_last_order_id": get_last_order_id}).handle(
+            "get_last_order_id", {})
+
+        self.assertEqual(len(seen), 1)
+        self.assertGreaterEqual(len(seen[0]), 3)
+        self.assertLessEqual(len(seen[0]), 4)
+        self.assertEqual(seen[0][0], "acct")
+        self.assertEqual(seen[0][2], "ORDER")
+
+    def test_get_history_trade_detail_data_puts_account_type_second(self):
+        """漏掉 strAccountType 会让 detail_type 落到账户类型的位置（#96 同款）。"""
+        seen = []
+
+        def get_history_trade_detail_data(*args):
+            seen.append(args)
+            return []
+
+        self._handlers({
+            "get_history_trade_detail_data": get_history_trade_detail_data
+        }).handle("get_history_trade_detail_data", {
+            "detail_type": "DEAL", "start_date": "20260101", "end_date": "20260201"})
+
+        self.assertEqual(len(seen[0]), 5)
+        self.assertEqual(seen[0][0], "acct")
+        self.assertNotEqual(seen[0][1], "DEAL")     # 这里必须是账户类型，不是数据类型
+        self.assertEqual(seen[0][2], "DEAL")
+        self.assertEqual(seen[0][3], "20260101")
+        self.assertEqual(seen[0][4], "20260201")
+
+
+class ReturnShapeTest(unittest.TestCase):
+    """参数对了还不够 —— 返回形状用错，数据照样被毁掉（#96 / #207 同款）。"""
+
+    def _handlers(self, qmt_api):
+        from bigqmt_signal_trader.adapters.market_bigqmt import BigQmtMarketDataProvider
+        from bigqmt_signal_trader.adapters.order_dryrun import DryRunOrderGateway
+        from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+
+        class _Ctx(object):
+            def get_full_tick(self, codes):
+                return {}
+
+        return BigQmtRpcHandlers(
+            account_id="acct",
+            market_data=BigQmtMarketDataProvider(_Ctx()),
+            position_provider=None,
+            order_gateway=DryRunOrderGateway(),
+            qmt_api=qmt_api,
+        )
+
+    def test_order_id_survives_instead_of_becoming_one_dict_per_character(self):
+        """实盘实测：'635005110' 曾变成 9 个空 dict，一个字符一个。"""
+        out = self._handlers(
+            {"get_last_order_id": lambda *a: "635005110"}).handle(
+            "get_last_order_id", {})
+        self.assertEqual(out, "635005110")
+
+    def test_qmt_not_found_marker_survives_too(self):
+        """QMT 用 '-1' 表示没找到，原来变成 [{}, {}] —— 调用方无从分辨。"""
+        out = self._handlers({"get_last_order_id": lambda *a: "-1"}).handle(
+            "get_last_order_id", {})
+        self.assertEqual(out, "-1")
+
+    def test_an_int_order_id_is_not_swallowed(self):
+        """int 在行归一化里直接抛 TypeError，被吞成 []。"""
+        out = self._handlers({"get_last_order_id": lambda *a: 12345}).handle(
+            "get_last_order_id", {})
+        self.assertEqual(out, 12345)
+
+    def test_unbound_scalar_global_answers_none_not_a_fake_row(self):
+        out = self._handlers({}).handle("get_last_order_id", {})
+        self.assertIsNone(out)
+
+    def test_single_order_object_is_not_iterated_into_nothing(self):
+        """get_value_by_order_id 回的是一个对象，不是列表。"""
+        class _Order(object):
+            m_strOrderSysID = "635005110"
+            m_nOrderStatus = 56
+
+        out = self._handlers(
+            {"get_value_by_order_id": lambda *a: _Order()}).handle(
+            "get_value_by_order_id", {"order_id": "635005110"})
+
+        self.assertEqual(out["m_strOrderSysID"], "635005110")
+        self.assertEqual(out["m_nOrderStatus"], 56)
+
+    def test_a_list_of_one_object_also_works(self):
+        """有的券商实现回一个单元素列表，两种都得吃得下。"""
+        out = self._handlers(
+            {"get_value_by_order_id": lambda *a: [{"m_strOrderSysID": "X1"}]}).handle(
+            "get_value_by_order_id", {"order_id": "X1"})
+        self.assertEqual(out["m_strOrderSysID"], "X1")
+
+    def test_enum_constants_are_not_scraped_into_the_row(self):
+        """QMT 委托对象上挂着 60 个数字串名的枚举常量，实盘实测把载荷翻了一倍。"""
+        class _Order(object):
+            m_strOrderSysID = "635005110"
+            m_nOrderStatus = 56
+
+        order = _Order()
+        # 模拟 QMT 那些 '0' / '-1' / '101' 的常量属性
+        for name, value in (("0", 48), ("-1", -1), ("101", 101)):
+            setattr(order, name, value)
+
+        out = self._handlers(
+            {"get_value_by_order_id": lambda *a: order}).handle(
+            "get_value_by_order_id", {"order_id": "635005110"})
+
+        self.assertEqual(out["m_strOrderSysID"], "635005110")
+        self.assertEqual(out["m_nOrderStatus"], 56)
+        for junk in ("0", "-1", "101"):
+            self.assertNotIn(junk, out)
+
+    def test_missing_order_answers_empty_mapping(self):
+        out = self._handlers(
+            {"get_value_by_order_id": lambda *a: None}).handle(
+            "get_value_by_order_id", {"order_id": "X1"})
+        self.assertEqual(out, {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #207.

起因：被问到「现在是可以自动映射对的 API 了吗」。**答案是不能** —— 映射全是手写在 `_handle_*` 里的，没有任何东西校验它和官方签名对不对。于是用 AST 把所有调用点扫出来机械比对了一遍，又查出三条同样的 bug。

## 1. 参数个数写错（三处）

| QMT 函数 | 官方签名 | 代码实际传 |
|---|---|---|
| `get_value_by_order_id` | `(orderId, accountID, strAccountType, strDatatype)` 4 个（6.11）| **1 个** |
| `get_last_order_id` | `(accountID, strAccountType, strDatatype[, strategyName])` 3-4 个（6.11）| **1 个** |
| `get_history_trade_detail_data` | `(accountID, strAccountType, strDatatype, startDate, endDate)` 5 个（6.9）| **4 个，且错位** |

第三条把 `detail_type` 塞到了 `strAccountType` 的位置 —— 和 #96 里 `get_ipo_data` 把 `account_id` 当 `type` 传是同一个形状。全部被 `_call_qmt_global` 的 `except: return []` 吞掉。

## 2. 返回形状也用错了（参数修完实盘一跑才暴露）

`get_last_order_id` 返回的是**委托号字符串**，不是行列表，而 `_normalize_detail_rows` 会去迭代它：

```
'-1'         -> [{}, {}]                                  # QMT 的「没找到」
'635005110'  -> [{}, {}, {}, {}, {}, {}, {}, {}, {}]       # 真委托号，一个字符一个
12345        -> TypeError -> 被吞成 []
```

**委托号被完全销毁**，而这个函数正是官方「下单 → 查单 → 撤单」标准流程的第二步。`get_value_by_order_id` 同理：它返回**单个**对象不是列表，迭代它抛异常同样被吞成 `[]`，看起来像「查不到这笔委托」。

新增 `_call_qmt_scalar`（保留标量原样）和 `_call_qmt_object`（单对象归一化）。

## 3. 枚举常量被刮进返回值

修好之后 `get_value_by_order_id` 回了 120 个字段，其中 60 个是 `'0'` / `'-1'` / `'101'` 这种数字串名的枚举常量 —— QMT 委托对象上挂着它们，`dir()` 一并刮走了。`_normalize_detail_rows` 现在丢掉非标识符的属性名（真字段都是合法标识符，不会误伤）。

## 4. 一道机械闸

`tests/bigqmt_signal_trader/test_qmt_global_arity.py`：AST 扫出所有 `_call_qmt_*` 调用点，和一张按官方参考手抄的签名表比对。

同一个形态这个 session 里出现了**六次**（#96、#201、#205、本条三条），每次都是「一个失败的调用和一个从没跑过的调用长得一模一样」。所以值得一道闸：

- 写错参数个数 → 测试红，报出文件行号和期望参数数
- 新接一个全局函数不登记签名 → 也红，防止闸门慢慢失效
- 探测自己也被覆盖（#201 踩过）

在修复前跑这道闸，它精确报出了三处：

```
redis_rpc.py:1694 get_value_by_order_id 传了 1 个参数，官方签名要 4
redis_rpc.py:1697 get_last_order_id 传了 1 个参数，官方签名要 3-4
redis_rpc.py:1720 get_history_trade_detail_data 传了 4 个参数，官方签名要 5
```

## 验证

**已验证（实盘只读，未下任何单）**

- 全量 **1670 passed**，收集数 126 == 文件数 126
- 新用例修复前红（`git stash` 对照），且精确指出三处
- 终端自带 `xtquant` 预检导入通过
- `get_last_order_id`：`[{}, {}]` → `'-1'`（QMT 的「没找到」标记完整保留）
- `get_value_by_order_id(635005110)`：`[]` → 委托对象，`m_strOrderSysID=635005110`、`m_nOrderStatus=56`、`m_strInstrumentID=600722`
- 枚举常量过滤：120 字段 → 65 字段，非标识符键 0 个，真字段一个不少
- 对照未受影响：`get_asset` 5 字段、`query_account_infos` 65 字段，和修复前一致

**未验证**

- `get_history_trade_detail_data` —— 本机终端没绑定这个全局函数（`probe_capabilities` 报 not bound），参数修对了但没法实调。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
