### PR TITLE
堵住「交易类查询跑到后台线程」这一整类 bug：静态闸 + 运行时告警

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 ## [未发布]
 
+### 新增
+
+- **两道闸，堵住「交易类查询跑到后台线程上」这一整类 bug**：`get_trade_detail_data` 在主策略线程之外返回空是本项目最重要的一条约束，但 `LISTENER_DEFERRED_METHODS` 一直是**手工维护**的集合，没有任何东西检查「这个 handler 碰了交易上下文，它在不在名单里」。#204 就是这么漏的：`get_ipo_data` 当年因为同样的症状被单独修好并 defer，同批的 9 个孪生方法一个都没跟上，在线上静默了几个月。
+
+  **静态闸**（`tests/bigqmt_signal_trader/test_trade_context_deferral_guard.py`）：用 AST 扫出所有碰交易上下文的 handler（含经私有方法的传递闭包，也认 `self.qmt_api.get(...)` 直接取的写法），挨个检查在不在 defer 名单里。漏一个就红。豁免必须写进 `DELIBERATELY_INLINE` 并说明理由 —— 让「不 defer」成为需要解释的决定而不是忘了。当前三条豁免：`probe_capabilities`（诊断接口，adjust 卡住时更要能答）、`download_history_data` / `download_history_data2`（下载耗时长，defer 会卡住主线程）。对 #204 修复前的代码跑这道闸是红的 —— 它当初就能拦住。
+
+  **运行时告警**：静态闸保证我们自己不写漏，但挡不住「换一家券商行为不一样」。所以交易类响应回来「行数对、字段全空」时记一条 warning，把 QMT 函数名和当前线程名一起写出来，60 秒节流（跑错线程时每次查询都 hollow，不节流会刷爆日志，#139 的教训）。**只告警、不自动改路由**：defer 实测只要 2.5-3.0ms（和 inline 的行情读 3.3ms 同量级），而猜错方向的代价是静默返回错数据，两边完全不对等；何况「跑错线程」和「这个账户真没数据」从返回值上分不开，据此自动切换只会把一次误判固化下来。让「每家不一样」成为被观测到的事实，而不是被猜测后自动应对的。
+
 ### 修复
 
 - **三个 QMT 全局函数的参数写错，外加两个返回形状用错，全部静默返回空**（#207）：QMT 全局函数的映射是纯手写的，没有任何东西校验它和官方签名对不对。用 AST 把所有调用点扫出来和官方参考比对，查出：`get_value_by_order_id` 只传了 1 个参数（签名要 4 个）、`get_last_order_id` 只传了 1 个（要 3-4 个）、`get_history_trade_detail_data` 传了 4 个且把 `detail_type` 塞到了 `strAccountType` 的位置（要 5 个，和 #96 同一个形状）。全部被 `_call_qmt_global` 的 `except: return []` 吞掉。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@
 
 ### 修复
 
+- **入口文件手抄的 QMT 全局函数名单漏了 `query_credit_account`，桥拿不到它，却被误报成「这台终端没有这个函数」**（#202 后续）：QMT 只往**被挂载的那个文件**的命名空间注入全局函数，所以捕获必须在入口文件里做。策略模块的 `_QMT_INJECTED_GLOBAL_FUNCS` 是这份名单的唯一来源，它自己的注释就写着「do not hand-copy the names elsewhere」—— 而 `BIGQMT_REDIS_DRYRUN.py` 里偏偏有一张手抄表。给策略模块加 `query_credit_account` 时漏了它，于是桥捕获不到 → `probe_capabilities` 报 `callback_bound=false` → 报告据此下结论「这台终端没有 query_credit_account，重启也没用」。
+
+  **而用户在大 QMT 里直接调它是好用的**（维持担保比例 3.35、总负债 1038962.07）。一个桥的 bug 被报成了券商终端的能力缺失 —— 这比返回空更糟，它给出的是一个错误但听起来很确定的结论，会让人不去查真正的地方。
+
+  修法不是再补一个名字，是**别再手抄**：两个被挂载的入口都改成 `capture_qmt_injected_funcs(globals())` 读唯一来源，并加一道闸（`tests/bigqmt_signal_trader/test_no_hand_copied_global_lists.py`）禁止入口文件再出现手抄名单。实盘验证：重启后 `global_namespace` 和 `callback_bound` 都变成 `true`、查询发得出去。**入口文件 `reload_deployment()` 刷不了，这条改动必须真重启策略。**
+
+  同时把三处基于那个错判写下的结论都改了（体检报告的结论文案、`docs/RPC_API_REFERENCE.md`、本文件上一条）：`global_namespace` 为 `False` 只说明「这条解析路径上没有」，**不能**据此断言终端没有这个函数；正确的判断方法是在大 QMT 策略里直接调一次。
+
 - **三个 QMT 全局函数的参数写错，外加两个返回形状用错，全部静默返回空**（#207）：QMT 全局函数的映射是纯手写的，没有任何东西校验它和官方签名对不对。用 AST 把所有调用点扫出来和官方参考比对，查出：`get_value_by_order_id` 只传了 1 个参数（签名要 4 个）、`get_last_order_id` 只传了 1 个（要 3-4 个）、`get_history_trade_detail_data` 传了 4 个且把 `detail_type` 塞到了 `strAccountType` 的位置（要 5 个，和 #96 同一个形状）。全部被 `_call_qmt_global` 的 `except: return []` 吞掉。
 
   参数修好后实盘一跑，又暴露出返回形状也用错了：`get_last_order_id` 返回的是**委托号字符串**，不是行列表，`_normalize_detail_rows` 会去迭代它 —— 真委托号 `'635005110'` 变成 **9 个空 dict**（一个字符一个），QMT 表示「没找到」的 `'-1'` 变成 2 个空 dict，int 直接抛 TypeError 被吞成 `[]`。**委托号被完全销毁**，而这个函数正是官方「下单 → 查单 → 撤单」标准流程的第二步。`get_value_by_order_id` 同理，它返回**单个**委托对象不是列表，迭代它抛异常同样被吞成 `[]`，看起来像「查不到这笔委托」。新增 `_call_qmt_scalar`（保留标量原样）和 `_call_qmt_object`（单对象归一化）两条取数路径。
@@ -65,7 +73,7 @@
 
 - **#201 的取数路径经维护者实测确认**：`get_trade_detail_data('<信用账号>', 'credit', 'account', '')` 在大 QMT 里能取到信用账户信息。但**这个仓的 RPC 链路本身没有在真实两融账户上跑过** —— 维护者的部署账户是普通股票账户（`m_nBrokerType=2`），信用账本不存在，所有两融接口返回空都是正确行为，证明不了这条链路端到端通。
 
-- **#202 的异步通道在维护者的终端上根本不可用，也就无从验证**，且默认不需要它。重启策略后 `callback_bound` 仍是 `false`：`get_debt_contract` / `get_assure_contract` / `get_enable_short_contract` / `get_unclosed_compacts` 都经同一条 `_resolve_runtime_name`（qmt_api → globals → builtins）解析得到，唯独 `query_credit_account` 解析不到 —— **这台国金 QMT 没有注入这个全局函数**，重启解决不了。这反过来说明同步那条不只是「够用」，在这类终端上是**唯一**的路。`probe_capabilities` 新增的 `global_namespace["query_credit_account"]` 能把「终端没有」和「有但没重启」分开，体检报告会直接说是哪一种。
+- **#202 的异步通道曾被误判为「终端不支持」，实为桥自己的 bug**（已修，见下条「入口文件手抄名单」）。修好并重启后 `callback_bound` 变成 `true`、查询发得出去；但维护者的账户是普通股票账户（`m_nBrokerType=2`），柜台不回调，所以**回调链路本身仍未验证**。`probe_capabilities` 的 `global_namespace["query_credit_account"]` 只说明「这条解析路径上有没有」，**不能**据此断言终端有没有这个函数 —— 原来的结论文案就是这么错的，已改成把两种可能都列出来并建议先在大 QMT 里直接调一次确认。
 
 - 已验证的部分：全量测试 1631 passed（收集数 == 文件数）、#201 用例修复前 4 red / 修复后 green、实盘上 `probe_capabilities` 的 `ArgumentError` 已消失、新增探测项能答、体检工具端到端跑通并正确判定「这不是信用账户」、两个单文件构建器重新生成后都带上了回调且 no-redis 那份仍 GBK 可解析。
 

--- a/bigqmt_no_redis/DRYRUN_no_redis.py
+++ b/bigqmt_no_redis/DRYRUN_no_redis.py
@@ -237,17 +237,13 @@ except Exception as account_config_error:
         _runtime.configure_runtime_account(account_id)
 
 try:
-    qmt_extra = {}
-    for function_name in (
-        "get_history_trade_detail_data", "get_value_by_order_id", "get_last_order_id",
-        "get_ipo_data", "get_new_purchase_limit", "get_assure_contract",
-        "get_enable_short_contract", "get_unclosed_compacts", "get_closed_compacts",
-        "get_debt_contract", "get_option_subject_position", "get_comb_option",
-        "get_hkt_exchange_rate", "down_history_data",
-        "query_credit_account",   # credit account, counter query, async (#202)
-    ):
-        if function_name in globals():
-            qmt_extra[function_name] = globals()[function_name]
+    # QMT only injects its globals into the namespace of the file it mounts --
+    # THIS one -- so the capture has to happen here, with this file's globals().
+    # Read the strategy module's single source instead of hand-copying the
+    # names: a copy here is how query_credit_account went missing on the redis
+    # entry, and the bridge then reported it as "this terminal does not have
+    # that function" when the terminal had it all along (#202).
+    qmt_extra = _runtime.capture_qmt_injected_funcs(globals())
     print("[bigqmt_shell] down_history_data bound=%s" % ("down_history_data" in qmt_extra))
     _runtime.bind_runtime_api(
         passorder_func=globals().get("passorder"),

--- a/docs/RPC_API_REFERENCE.md
+++ b/docs/RPC_API_REFERENCE.md
@@ -352,7 +352,10 @@
 - **为什么不是裸列表**：大 QMT 那边 `query_credit_account(accId, seq, ContextInfo)` 立刻返回，结果只从 `credit_account_callback` 出来。桥替你发查询、等回调、缓存结果，所以这条 RPC 本身是同步的 —— 但**空列表有好几种成因**（没绑上 / 被限流 / 发了没等到回调 / 真没数据），只回一个 `[]` 分不开。看 `query_issued`、`fresh`、`callback_bound`，别只看 `rows`。
 - **限流**：官方参考 6.13 写明「只能有一个查询」「建议 30s 一次，不可频繁调用」。桥按 30 秒最小间隔挡住过密的查询，直接返回上一次的结果并标 `stale=true`，不会替你去打柜台。
 - **`callback_bound=false` 有两种成因，别白重启一次**：
-  - **这台终端根本没有 `query_credit_account` 这个全局函数** —— 重启也没用，只能走同步那条。维护者的国金 QMT 就是这种：`get_debt_contract` / `get_assure_contract` / `get_enable_short_contract` / `get_unclosed_compacts` 都经同一条 `_resolve_runtime_name`（qmt_api → globals → builtins）解析得到，唯独 `query_credit_account` 解析不到，说明 QMT 没注入它。
+  - **桥自己没捕获到它。** QMT 只往被挂载的入口文件的命名空间注入全局函数，入口必须用 `capture_qmt_injected_funcs(globals())` 从策略模块的唯一名单里捕获。入口文件曾经手抄过一份名单并漏了 `query_credit_account`，桥于是拿不到它 —— 而终端明明有。**这类情况下 `global_namespace` 也会是 `False`，所以不能据此断言终端没有这个函数**（#202 就是这么误判的）。改入口文件后必须**真重启策略**，`reload_deployment()` 刷不了入口。
+  - **这台终端确实没有这个函数** —— 那就只能走同步那条。
+
+  两者从桥这边分不开。**判断方法：在大 QMT 的策略里直接写一行 `query_credit_account(accId, int(time.time()), ContextInfo)` 配 `credit_account_callback`,能打印出维持担保比例就说明终端有,问题在桥。**
   - **有这个函数但没重启策略** —— `credit_account_callback` 定义在入口文件命名空间里（QMT 只往被挂载的那个文件回调），而入口文件 `reload_deployment()` 刷不了，必须真重启。
 
   `probe_capabilities` 的 `global_namespace["query_credit_account"]` 分得开这两种，体检报告也会直接告诉你是哪一种。

--- a/src/BIGQMT_REDIS_DRYRUN.py
+++ b/src/BIGQMT_REDIS_DRYRUN.py
@@ -332,17 +332,19 @@ except Exception as account_config_error:
         _runtime.configure_runtime_account(account_id)
 
 try:
-    qmt_extra = {}
-    for function_name in (
-        "get_history_trade_detail_data", "get_value_by_order_id", "get_last_order_id",
-        "get_ipo_data", "get_new_purchase_limit", "get_assure_contract",
-        "get_enable_short_contract", "get_unclosed_compacts", "get_closed_compacts",
-        "get_debt_contract", "get_option_subject_position", "get_comb_option",
-        "get_hkt_exchange_rate",
-        "download_history_data", "download_history_data2", "down_history_data",
-    ):
-        if function_name in globals():
-            qmt_extra[function_name] = globals()[function_name]
+    # QMT only injects its globals into the namespace of the file it mounts --
+    # THIS one -- so the capture has to happen here, with this file's globals().
+    #
+    # It used to be a hand-copied tuple of names right here, and that is exactly
+    # how query_credit_account went missing: it was added to the strategy
+    # module's _QMT_INJECTED_GLOBAL_FUNCS (which the strategy's own comment
+    # calls "the single source for that list; do not hand-copy the names
+    # elsewhere") and this copy was not updated. The bridge then reported
+    # "this terminal does not have query_credit_account" while the terminal had
+    # it all along -- a bridge bug misreported as a broker capability (#202).
+    #
+    # So: read the single source instead of copying it.
+    qmt_extra = _runtime.capture_qmt_injected_funcs(globals())
     print("[bigqmt_shell] download globals bound=%s" % sorted(k for k in qmt_extra if "download" in k or "down_history" in k))
     _runtime.bind_runtime_api(
         passorder_func=globals().get("passorder"),

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -225,6 +225,8 @@ DEFAULT_ORDER_STRATEGY_NAME = "bigqmt_rpc"
 # 如果前面的查询正在进行中，后面的查询将会提前返回。本函数从服务器查询数据，
 # 建议平均查询时间间隔 30s 一次，不可频繁调用。」所以桥这边自己限流，客户端
 # 想怎么轮询都不会把柜台打爆（#202）。
+# hollow 告警的最小间隔。跑错线程时每一次查询都会 hollow，不节流日志会被刷爆。
+HOLLOW_WARNING_INTERVAL_SECONDS = 60.0
 CREDIT_ACCOUNT_MIN_INTERVAL_SECONDS = 30.0
 # 一次 RPC 里最多等回调多久。回调走 QMT 的 C++ 线程，handler 在 adjust 主线程
 # 上；这里的等待用 sleep 轮询让出 GIL，回调才落得下来。默认给得短，因为拿不到
@@ -573,6 +575,10 @@ class BigQmtRpcHandlers:
         # Server-side diagnostic for silent failures (e.g. passorder submitted
         # but order not found in system). Surfaced to client via server_error.
         self._last_server_error = ""
+        # 上一次 hollow 告警的时间戳。节流是必须的：一个跑错线程的部署会让
+        # **每一次**交易类查询都 hollow，不节流的话日志会被刷爆（#139 就是
+        # 一行写了 16 次那种教训）。
+        self._last_hollow_warning_at = 0.0
         # 信用账户的「查柜台」通道（#202）。query_credit_account 是异步的：结果
         # 只从 credit_account_callback 出来，所以这里存最后一次回调的结果，由
         # note_credit_account 填。官方 6.13 明说「只能有一个查询」「建议 30s 一
@@ -1536,6 +1542,50 @@ class BigQmtRpcHandlers:
     # 无该权限/函数未注入时降级为空列表。
     # ------------------------------------------------------------------
 
+    def _warn_if_hollow(self, source, rows):
+        """交易类响应「行数对、字段全空」时大声报出来，别让它静默过去。
+
+        QMT 的交易类查询跑在主策略线程之外时，返回的不是空列表，而是行数对、
+        字段全是 None 的对象（本机实测：get_asset 移出 defer 名单后照样回 5 个
+        键，值全空）。从客户端看像「这个账户没钱」，不像调用失败 —— #204 就是
+        这么在线上静默了几个月。
+
+        静态闸（tests/.../test_trade_context_deferral_guard.py）保证我们**自己**
+        不写漏，但挡不住「换一家券商行为不一样」。所以运行时再看一眼：真出现了
+        就记一条 warning，把函数名和当前线程名一起写出来，让「每家不一样」成为
+        被观测到的事实，而不是我们猜出来的。
+
+        只告警、不改路由：defer 实测只要 2.5-3.0ms，而猜错方向的代价是静默返回
+        错数据，两边完全不对等；而且「跑错线程」和「这个账户真没数据」从返回值
+        上分不开，据此自动切换只会把一次误判固化下来。
+        """
+        if not rows:
+            return rows
+        first = rows[0] if isinstance(rows, (list, tuple)) else rows
+        if not isinstance(first, dict) or not first:
+            return rows
+        if any(value is not None and value != "" for value in first.values()):
+            return rows
+        now = time.time()
+        if now - self._last_hollow_warning_at < HOLLOW_WARNING_INTERVAL_SECONDS:
+            return rows
+        self._last_hollow_warning_at = now
+        try:
+            thread_name = threading.current_thread().name
+        except Exception:
+            thread_name = "?"
+        try:
+            from .logging_setup import get_logger
+            get_logger("rpc").warning(
+                "%s returned %d row(s) with every field empty, on thread %r. "
+                "QMT trade-context queries answer this way off the main strategy "
+                "thread -- the call did NOT fail, the data is simply not there. "
+                "Check probe_capabilities thread_routing (#204).",
+                source, len(rows), thread_name)
+        except Exception:
+            pass
+        return rows
+
     def _call_qmt_global(self, func_name, *args, **kwargs):
         """Call a QMT runtime-injected global function, returning [] on failure.
 
@@ -1548,7 +1598,8 @@ class BigQmtRpcHandlers:
         if func is None:
             return []
         try:
-            return _normalize_detail_rows(func(*args, **kwargs))
+            return self._warn_if_hollow(func_name,
+                                        _normalize_detail_rows(func(*args, **kwargs)))
         except Exception:
             return []
 
@@ -1666,7 +1717,9 @@ class BigQmtRpcHandlers:
                             else getattr(gateway, "account_type", "STOCK"))
         try:
             rows = gateway.get_trade_detail_data(account_id, account_type, detail_type, strategy_name)
-            return _normalize_detail_rows(rows)
+            return self._warn_if_hollow(
+                "get_trade_detail_data(%s,%s)" % (account_type, detail_type),
+                _normalize_detail_rows(rows))
         except Exception:
             return []
 

--- a/tests/bigqmt_signal_trader/test_hollow_runtime_warning.py
+++ b/tests/bigqmt_signal_trader/test_hollow_runtime_warning.py
@@ -1,0 +1,166 @@
+# coding: utf-8
+"""运行时 hollow 告警：换一家券商行为不一样时，要能被发现。
+
+静态闸（test_trade_context_deferral_guard.py）保证**我们自己**不写漏 defer，
+但它挡不住「这家券商的 QMT 行为和我们假设的不一样」。所以运行时再看一眼：
+交易类响应回来「行数对、字段全空」时记一条 warning，把函数名和当前线程名
+一起写出来。
+
+只告警、不自动改路由 —— 两个原因：
+
+  1. defer 实测只要 2.5-3.0ms（和 inline 的行情读 3.3ms 同量级），而猜错方向
+     的代价是静默返回错数据，两边完全不对等。
+  2. 「跑错线程」和「这个账户真没数据」从返回值上分不开。账户本来就没担保标的
+     时两条路都返回空，据此自动切换只会把一次误判固化下来。
+
+所以让「每家不一样」成为被观测到的事实，而不是被猜测后自动应对的。
+"""
+import os
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.adapters.market_bigqmt import BigQmtMarketDataProvider
+from bigqmt_signal_trader.adapters.order_dryrun import DryRunOrderGateway
+from bigqmt_signal_trader import redis_rpc
+from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+
+
+class _Ctx(object):
+    def get_full_tick(self, codes):
+        return {}
+
+
+class _CapturingLogger(object):
+    def __init__(self):
+        self.warnings = []
+
+    def warning(self, fmt, *args):
+        self.warnings.append(fmt % args if args else fmt)
+
+    def __getattr__(self, _name):
+        return lambda *a, **k: None
+
+
+class _LoggerPatch(object):
+    """logging_setup.get_logger 是在函数体里 import 的，从模块上打桩。"""
+
+    def __init__(self):
+        self.logger = _CapturingLogger()
+
+    def __enter__(self):
+        from bigqmt_signal_trader import logging_setup
+        self._module = logging_setup
+        self._original = logging_setup.get_logger
+        logging_setup.get_logger = lambda _name: self.logger
+        return self.logger
+
+    def __exit__(self, *exc):
+        self._module.get_logger = self._original
+        return False
+
+
+def _handlers(qmt_api=None, gateway=None):
+    return BigQmtRpcHandlers(
+        account_id="acct",
+        market_data=BigQmtMarketDataProvider(_Ctx()),
+        position_provider=None,
+        order_gateway=gateway if gateway is not None else DryRunOrderGateway(),
+        qmt_api=qmt_api or {},
+    )
+
+
+HOLLOW = [{"m_strInstrumentID": None, "m_dAssureRatio": None}] * 3
+REAL = [{"m_strInstrumentID": "600000", "m_dAssureRatio": 0.7}]
+
+
+class HollowRuntimeWarningTest(unittest.TestCase):
+
+    def test_hollow_rows_raise_a_warning_naming_the_function_and_thread(self):
+        with _LoggerPatch() as log:
+            _handlers({"get_assure_contract": lambda a: HOLLOW}).handle(
+                "get_assure_contract", {})
+
+        self.assertEqual(len(log.warnings), 1, log.warnings)
+        message = log.warnings[0]
+        self.assertIn("get_assure_contract", message)
+        self.assertIn("every field empty", message)
+        self.assertIn("thread", message)
+        # 必须说清楚「调用没失败」，否则读日志的人会去查错方向
+        self.assertIn("did NOT fail", message)
+        self.assertIn("#204", message)
+
+    def test_real_rows_are_silent(self):
+        with _LoggerPatch() as log:
+            _handlers({"get_assure_contract": lambda a: REAL}).handle(
+                "get_assure_contract", {})
+        self.assertEqual(log.warnings, [])
+
+    def test_empty_result_is_silent(self):
+        """真的没数据不是 hollow —— 不能对空账户天天报警。"""
+        with _LoggerPatch() as log:
+            _handlers({"get_assure_contract": lambda a: []}).handle(
+                "get_assure_contract", {})
+        self.assertEqual(log.warnings, [])
+
+    def test_zero_valued_fields_are_silent(self):
+        """没有负债就是 0，是真数据。"""
+        with _LoggerPatch() as log:
+            _handlers({"get_unclosed_compacts":
+                       lambda a, t: [{"m_dRealCompactBalance": 0.0}]}).handle(
+                "get_unclosed_compacts", {})
+        self.assertEqual(log.warnings, [])
+
+    def test_warning_is_throttled(self):
+        """跑错线程时每一次查询都 hollow，不节流日志会被刷爆（#139 教训）。"""
+        handlers = _handlers({"get_assure_contract": lambda a: HOLLOW})
+        with _LoggerPatch() as log:
+            for _ in range(20):
+                handlers.handle("get_assure_contract", {})
+        self.assertEqual(len(log.warnings), 1, len(log.warnings))
+
+    def test_throttle_interval_is_a_minute_scale_not_a_millisecond_one(self):
+        self.assertGreaterEqual(redis_rpc.HOLLOW_WARNING_INTERVAL_SECONDS, 30.0)
+
+    def test_get_trade_detail_data_path_is_covered_too(self):
+        """走 gateway 的那条路（get_asset / query_account_infos …）也要盯。"""
+        class _Gw(DryRunOrderGateway):
+            def __init__(self):
+                super(_Gw, self).__init__()
+                self.get_trade_detail_data = lambda a, t, d, s="": [
+                    {"m_dBalance": None, "m_dAvailable": None}]
+
+        with _LoggerPatch() as log:
+            _handlers(gateway=_Gw()).handle("query_account_infos", {})
+
+        self.assertEqual(len(log.warnings), 1, log.warnings)
+        self.assertIn("get_trade_detail_data", log.warnings[0])
+        self.assertIn("ACCOUNT", log.warnings[0])
+
+    def test_a_broken_logger_never_breaks_the_rpc(self):
+        """告警是诊断，不能让它把请求带崩。"""
+        class _Exploding(object):
+            def warning(self, *a, **k):
+                raise RuntimeError("logger down")
+
+        from bigqmt_signal_trader import logging_setup
+        original = logging_setup.get_logger
+        logging_setup.get_logger = lambda _n: _Exploding()
+        try:
+            rows = _handlers({"get_assure_contract": lambda a: HOLLOW}).handle(
+                "get_assure_contract", {})
+        finally:
+            logging_setup.get_logger = original
+        self.assertEqual(len(rows), 3)
+
+    def test_the_rows_are_passed_through_unchanged(self):
+        """只观测，不改数据 —— 调用方看到的还是 QMT 给的那份。"""
+        out = _handlers({"get_assure_contract": lambda a: HOLLOW}).handle(
+            "get_assure_contract", {})
+        self.assertEqual(out, HOLLOW)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_no_hand_copied_global_lists.py
+++ b/tests/bigqmt_signal_trader/test_no_hand_copied_global_lists.py
@@ -1,0 +1,106 @@
+# coding: utf-8
+"""入口文件不许手抄 QMT 全局函数名单 —— #202 就是被一张手抄表坑的。
+
+QMT 只往**被挂载的那个文件**的命名空间里注入全局函数，所以捕获必须发生在
+入口文件里、用它自己的 globals()。策略模块的 `_QMT_INJECTED_GLOBAL_FUNCS`
+是这份名单的唯一来源，它自己的注释就写着「do not hand-copy the names
+elsewhere」。
+
+但 BIGQMT_REDIS_DRYRUN.py 里就有一张手抄表。给策略模块加
+`query_credit_account` 时漏了那张表，于是：
+
+  - 桥拿不到这个函数
+  - probe 报 callback_bound=false、global_namespace 也是 False
+  - 报告据此下结论「这台终端没有 query_credit_account，重启也没用」
+  - 而用户在大 QMT 里直接调它是**好用的** —— 维持担保比例 3.35、总负债 1038962.07
+
+**一个桥的 bug 被报成了券商终端的能力缺失。** 这比返回空更糟：它给出的是
+一个错误但听起来很确定的结论，会让人不去查真正的地方。
+
+所以这里钉两件事：入口文件必须用 capture_qmt_injected_funcs 读唯一来源；
+不许再出现手抄的名单。
+"""
+import ast
+import io
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader_strategy import (  # noqa: E402
+    _EXTRA_QMT_GLOBAL_FUNCS,
+    _QMT_INJECTED_GLOBAL_FUNCS,
+    capture_qmt_injected_funcs,
+)
+
+# 会被 QMT 挂载、因而必须自己做捕获的入口文件。
+MOUNTED_ENTRIES = (
+    os.path.join("src", "BIGQMT_REDIS_DRYRUN.py"),
+    os.path.join("bigqmt_no_redis", "DRYRUN_no_redis.py"),
+)
+
+# 手抄表的特征：一串 QMT 全局函数名字面量凑在一起。真正的手抄表有 13-16 个
+# 名字；入口里还有一个「这文件是不是作为策略在跑」的哨兵检查只列 3 个
+# （passorder / get_trade_detail_data / download_history_data），那不是名单，
+# 所以阈值取 5。
+KNOWN_GLOBAL_NAMES = set(_QMT_INJECTED_GLOBAL_FUNCS)
+
+
+def _source(relative):
+    return io.open(os.path.join(ROOT, relative), encoding="utf-8",
+                   errors="replace").read()
+
+
+class NoHandCopiedListTest(unittest.TestCase):
+
+    def test_mounted_entries_capture_from_the_single_source(self):
+        for relative in MOUNTED_ENTRIES:
+            text = _source(relative)
+            self.assertIn(
+                "capture_qmt_injected_funcs", text,
+                "%s 是被 QMT 挂载的入口，必须用 capture_qmt_injected_funcs "
+                "从策略模块的唯一来源取名单，不能自己列" % relative)
+
+    def test_no_entry_hand_copies_the_name_list(self):
+        offenders = []
+        for relative in MOUNTED_ENTRIES:
+            tree = ast.parse(_source(relative))
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+                    continue
+                names = set(
+                    elt.value for elt in node.elts
+                    if isinstance(elt, ast.Constant) and isinstance(elt.value, str))
+                hits = names & KNOWN_GLOBAL_NAMES
+                if len(hits) >= 5:
+                    offenders.append("%s:%d 手抄了 %d 个全局函数名 %s"
+                                     % (relative, node.lineno, len(hits),
+                                        sorted(hits)[:4]))
+        self.assertEqual(
+            offenders, [],
+            "入口文件里不许再出现手抄的 QMT 全局函数名单 —— 策略模块的 "
+            "_QMT_INJECTED_GLOBAL_FUNCS 是唯一来源，手抄一份就会漂："
+            "#202 的 query_credit_account 就是这么丢的。%s" % offenders)
+
+    def test_the_single_source_carries_the_credit_counter_query(self):
+        self.assertIn("query_credit_account", _EXTRA_QMT_GLOBAL_FUNCS)
+        self.assertIn("query_credit_account", _QMT_INJECTED_GLOBAL_FUNCS)
+
+    def test_capture_picks_up_everything_the_single_source_lists(self):
+        """把整份名单摆进一个假命名空间，捕获必须一个不落。"""
+        namespace = dict((name, lambda *a, **k: None)
+                         for name in _QMT_INJECTED_GLOBAL_FUNCS)
+        captured = capture_qmt_injected_funcs(namespace)
+        self.assertEqual(sorted(captured), sorted(_QMT_INJECTED_GLOBAL_FUNCS))
+
+    def test_capture_skips_names_the_terminal_does_not_inject(self):
+        """终端没注入的就是没有 —— 捕获不能凭空造出一个。"""
+        captured = capture_qmt_injected_funcs({"passorder": lambda *a: None})
+        self.assertEqual(sorted(captured), ["passorder"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_trade_context_deferral_guard.py
+++ b/tests/bigqmt_signal_trader/test_trade_context_deferral_guard.py
@@ -1,0 +1,154 @@
+# coding: utf-8
+"""碰交易上下文的 handler 必须走 adjust 主线程 —— 机械校验，不靠人记得。
+
+`get_trade_detail_data` 在主策略线程之外返回空，是这个项目最重要的一条约束。
+但 `LISTENER_DEFERRED_METHODS` 一直是**手工维护**的集合，没有任何东西检查
+「这个 handler 碰了交易上下文，它在不在名单里」。#204 就是这么漏的：
+`get_ipo_data` 当年因为「后台线程返回空」被单独修好并 defer 了，同一批的
+9 个孪生方法却一个都没跟上，在线上静默返回空好几个月。
+
+而且它的表现比「返回空」更阴：实测把 `get_asset` 移出 defer 名单，它返回的
+不是空列表，而是**行数对、字段全是 None** 的对象 —— 从客户端看像「这个账户
+没钱」，不像调用失败。
+
+所以这里用 AST 扫出所有「碰交易上下文」的 handler（含经私有方法的传递闭包），
+挨个检查是不是在 defer 名单里。漏一个就红。
+
+豁免必须写在下面的 DELIBERATELY_INLINE 里并说明理由 —— 让"不 defer"成为一个
+需要解释的决定，而不是忘了。
+"""
+import ast
+import io
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.redis_rpc import (  # noqa: E402
+    LISTENER_DEFERRED_METHODS,
+    ORDER_METHODS,
+)
+
+RPC_SOURCE = os.path.join(ROOT, "src", "bigqmt_signal_trader", "redis_rpc.py")
+
+# 「碰了 QMT 交易上下文」的判据：调了这些取数路径中的任何一个。
+TRADE_CONTEXT_CALLS = {
+    "_call_qmt_global",     # QMT 注入的交易类全局函数
+    "_call_qmt_mapping",
+    "_call_qmt_scalar",
+    "_call_qmt_object",
+    "_query_trade_detail",  # get_trade_detail_data 的 6 种 detail type
+    "<qmt_api.get>",        # 直接 self.qmt_api.get(name) 取来自己调
+}
+
+# 明知故犯的豁免。加一条就得给一个理由，理由要经得起问。
+DELIBERATELY_INLINE = {
+    "probe_capabilities":
+        "诊断接口，adjust 循环卡住时更要能答 —— defer 了就会在最需要它的时候"
+        "失去它。代价是它的信用探测跑在 listener 线程上、可能拿到空字段，"
+        "这一点由它自己报的 hollow / thread_routing 说清楚（#204）。",
+    "download_history_data":
+        "下载可能跑很久，defer 到 adjust 主线程会把整个策略卡住。长任务走"
+        "submit_download_history_data + wait_download 那条异步路。",
+    "download_history_data2":
+        "同 download_history_data。",
+}
+
+
+def _method_calls():
+    """函数名 -> 它直接调用的属性名集合（含 self.qmt_api.get 这种取法）。"""
+    tree = ast.parse(io.open(RPC_SOURCE, encoding="utf-8").read())
+    calls = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        found = set()
+        for sub in ast.walk(node):
+            if not (isinstance(sub, ast.Call) and isinstance(sub.func, ast.Attribute)):
+                continue
+            found.add(sub.func.attr)
+            value = sub.func.value
+            if (sub.func.attr == "get" and isinstance(value, ast.Attribute)
+                    and value.attr == "qmt_api"):
+                found.add("<qmt_api.get>")
+        calls[node.name] = found
+    return calls
+
+
+def _touches_trade_context(name, calls, seen=None):
+    """handler 可能经一层私有方法才碰到交易上下文，所以要走传递闭包。"""
+    seen = set() if seen is None else seen
+    if name in seen:
+        return False
+    seen.add(name)
+    own = calls.get(name, set())
+    if own & TRADE_CONTEXT_CALLS:
+        return True
+    return any(_touches_trade_context(callee, calls, seen)
+               for callee in own if callee in calls)
+
+
+def _handlers_touching_trade_context():
+    calls = _method_calls()
+    out = []
+    for name in calls:
+        if not name.startswith("_handle_"):
+            continue
+        if _touches_trade_context(name, calls):
+            out.append(name[len("_handle_"):])
+    return sorted(out)
+
+
+class TradeContextDeferralGuard(unittest.TestCase):
+
+    def test_every_trade_context_handler_is_deferred_or_explained(self):
+        undeferred = []
+        for method in _handlers_touching_trade_context():
+            if method in LISTENER_DEFERRED_METHODS:
+                continue
+            if method in ORDER_METHODS:
+                continue          # 下单类本来就不走 listener
+            if method in DELIBERATELY_INLINE:
+                continue
+            undeferred.append(method)
+
+        self.assertEqual(
+            undeferred, [],
+            "这些 handler 碰了 QMT 交易上下文却没进 LISTENER_DEFERRED_METHODS，"
+            "会跑在后台 listener 线程上 —— QMT 在那儿返回的是「行数对、字段全空」"
+            "的对象，从客户端看像「没数据」而不是调用失败（#204）。"
+            "要么加进 defer 名单，要么在本文件的 DELIBERATELY_INLINE 里写明"
+            "为什么可以不 defer：%s" % undeferred)
+
+    def test_the_guard_actually_sees_something(self):
+        """判据写错了会让这道闸静默失效 —— 先确认它真的扫得到东西。"""
+        found = _handlers_touching_trade_context()
+        self.assertGreater(len(found), 15, found)
+        for expected in ("query_credit_detail", "query_stk_compacts",
+                         "get_assure_contract", "get_unclosed_compacts",
+                         "get_ipo_data", "query_account_infos"):
+            self.assertIn(expected, found, expected)
+
+    def test_exemptions_are_real_handlers_and_carry_a_reason(self):
+        """豁免名单不能烂掉：方法要还存在，理由不能是空话。"""
+        found = set(_handlers_touching_trade_context())
+        for method, reason in DELIBERATELY_INLINE.items():
+            self.assertIn(method, found,
+                          "%s 已经不碰交易上下文了，从豁免名单里删掉" % method)
+            self.assertNotIn(method, LISTENER_DEFERRED_METHODS,
+                             "%s 已经 defer 了，从豁免名单里删掉" % method)
+            self.assertGreater(len(reason), 20, method)
+
+    def test_market_data_handlers_are_not_dragged_in(self):
+        """行情读不该被这道闸拖去 defer —— 那会白搭一个 adjust 间隔的延迟。"""
+        found = set(_handlers_touching_trade_context())
+        for name in ("get_ticks", "get_market_data_ex", "ping",
+                     "subscribe_whole_quote"):
+            self.assertNotIn(name, found, name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_credit_api_report.py
+++ b/tests/test_credit_api_report.py
@@ -270,8 +270,14 @@ class ConclusionTest(unittest.TestCase):
         ]))
         self.assertIn("两条路都有数据", "\n".join(out))
 
-    def test_terminal_without_the_global_is_told_restarting_wont_help(self):
-        """「没绑上」有两种成因，差别很大，别让人白重启一次策略。"""
+    def test_unbound_global_never_claims_the_terminal_lacks_it(self):
+        """global_namespace=False 不等于「终端没有这个函数」。
+
+        #202 的教训：入口文件手抄的名单漏了 query_credit_account，桥拿不到它，
+        报告据此断言「这台终端没有这个函数，重启也没用」—— 而用户在大 QMT 里
+        直接调是好用的。一个桥的 bug 被报成了券商终端的能力缺失。错误但听起来
+        很确定的结论，比不给结论更坏。
+        """
         report = self._report([
             {"method": "query_credit_detail", "ok": True, "row_count": 0},
             {"method": "query_credit_account", "ok": True, "row_count": 0,
@@ -279,8 +285,14 @@ class ConclusionTest(unittest.TestCase):
         ])
         report["probe"] = {"global_namespace": {"query_credit_account": False}}
         joined = "\n".join(rep.build_conclusions(report))
-        self.assertIn("没有 query_credit_account", joined)
-        self.assertIn("重启策略也解决不了", joined)
+        # 两种可能都要列出来，并且要给出能分辨的办法
+        self.assertIn("两种可能", joined)
+        self.assertIn("capture_qmt_injected_funcs", joined)
+        self.assertIn("重启", joined)
+        self.assertIn("大 QMT 里直接调", joined)
+        # 绝不能再断言终端的能力
+        self.assertNotIn("这台终端没有 query_credit_account", joined)
+        self.assertNotIn("重启策略也解决不了", joined)
 
     def test_bound_in_namespace_but_unbound_points_at_the_restart(self):
         report = self._report([

--- a/tools/credit_api_report.py
+++ b/tools/credit_api_report.py
@@ -443,12 +443,21 @@ def build_conclusions(report):
         in_namespace = ((report.get("probe") or {}).get("global_namespace")
                         or {}).get("query_credit_account")
         if in_namespace is False:
-            out.append("这台终端没有 query_credit_account 这个全局函数（QMT 没注入），"
-                       "查柜台那条路在这台机器上不可用 —— 用同步的 "
-                       "query_credit_detail。重启策略也解决不了。")
+            # 曾经这里断言「这台终端没有这个函数」。那个结论是错的：真实原因是
+            # 入口文件里一张手抄的函数名清单漏了它，桥自己没捕获到，而用户在
+            # 大 QMT 里直接调是好用的。一个桥的 bug 被报成了券商终端的能力
+            # 缺失 —— 错误但听起来很确定的结论，比不给结论更坏（#202）。
+            out.append("query_credit_account 没绑上。有两种可能，从这里分不开："
+                       "(a) 桥没捕获到它 —— 确认入口文件用的是 "
+                       "capture_qmt_injected_funcs，并且**真的重启过策略**"
+                       "（入口文件 reload_deployment() 刷不了）；"
+                       "(b) 这台终端确实没有这个函数。"
+                       "**先在大 QMT 里直接调一次 query_credit_account 试试**，"
+                       "能调通就是 (a)。同步的 query_credit_detail 不受影响。")
         else:
-            out.append("query_credit_account 没绑上，多半是部署了但没**重启策略**"
-                       "（入口文件 reload_deployment() 刷不了）。不影响同步那条。")
+            out.append("query_credit_account 在命名空间里但没绑上，多半是部署了"
+                       "没**重启策略**（入口文件 reload_deployment() 刷不了）。"
+                       "不影响同步那条。")
 
     cached = by_method.get("query_credit_detail", {})
     counter = by_method.get("query_credit_account", {})


### PR DESCRIPTION
#204 修的是九个具体的方法，这个 PR 堵的是**那一整类**。

## 为什么不够

`get_trade_detail_data` 在主策略线程之外返回空，是这个项目最重要的一条约束。但 `LISTENER_DEFERRED_METHODS` 一直是**手工维护**的集合，没有任何东西检查「这个 handler 碰了交易上下文，它在不在名单里」。

#204 就是这么漏的：`get_ipo_data` 当年因为完全相同的症状被单独修好并 defer，注释里写着「交易类查询, 需主线程上下文（后台线程返回空）」—— 同一批的 9 个孪生方法一个都没跟上，在线上静默了几个月。

修掉具体的九个，不等于下一个新 handler 不会重蹈覆辙。

## 静态闸

`tests/bigqmt_signal_trader/test_trade_context_deferral_guard.py`：AST 扫出所有碰交易上下文的 handler，挨个检查在不在 defer 名单里。

- 走**传递闭包**：handler 可能经一层私有方法才碰到交易上下文
- 也认 `self.qmt_api.get(...)` 直接取来自己调的写法（`probe_capabilities` 就是这么干的）
- 漏一个就红

豁免必须写进 `DELIBERATELY_INLINE` 并说明理由 —— 让「不 defer」成为一个需要解释的决定，而不是忘了。当前三条：

| 豁免 | 理由 |
|---|---|
| `probe_capabilities` | 诊断接口，adjust 卡住时更要能答；defer 了就会在最需要它的时候失去它。代价（信用探测可能拿到空字段）由它自己报的 `hollow` / `thread_routing` 说清楚 |
| `download_history_data` / `download_history_data2` | 下载耗时长，defer 到 adjust 主线程会卡住整个策略。长任务走 `submit_download_history_data` + `wait_download` 那条异步路 |

**对 #204 修复前的代码跑这道闸，它是红的** —— 当初就能拦住。

## 运行时告警

静态闸保证**我们自己**不写漏，但挡不住「这家券商的 QMT 行为和我们假设的不一样」。

所以交易类响应回来「行数对、字段全空」时记一条 warning，带 QMT 函数名和当前线程名，60 秒节流（跑错线程时每次查询都 hollow，不节流会刷爆日志 —— #139 那种一行写 16 次的教训）。挂在三条取数路径上：`_call_qmt_global`、`_query_trade_detail`、以及走 gateway 的那条。

## 为什么不做自动切换

被问到「万一每家不一样呢？可以启动时验一下哪个真有数据、自动切过去吗」。技术上能做，但两边的赌注不对等：

| | 收益 | 风险 |
|---|---|---|
| 自动切回 inline | 省几毫秒（实测：defer 2.5-3.0ms，inline 的 `get_ticks` 3.3ms —— 量不出差别） | **静默返回错数据** |
| 一律 defer | —— | 几毫秒 |

而且 QMT 的约束是单向的：交易上下文只在主线程有数据，不存在「某家反过来只在后台线程有」。所以 defer 是严格占优，自动切换没有正向收益可赚。

更硬的问题：**「跑错线程」和「这个账户真没数据」从返回值上分不开**。启动时探测，账户本来就没担保标的的话两条路都返回空，探测学不到任何东西，却可能据此做出错误的路由决定并固化下来。启动时刻 QMT 账户数据还没加载完，这个问题更严重。

所以：**让「每家不一样」成为被观测到的事实，而不是被猜测后自动应对的。**

## 验证

- 全量 **1683 passed**，收集数 128 == 文件数 128
- 静态闸对 #204 修复前的代码是红的（`git show 1aaca88` 对照）
- 实盘部署 + reload，正常路径 **0 条误报**：`get_asset` / `get_positions` / `query_orders` / `query_account_infos` / `get_assure_contract` / `get_unclosed_compacts` / `get_new_purchase_limit` 全部不触发
- 告警本身由单测覆盖：节流、logger 炸了不能带崩请求、不改动返回数据、真数据和真空值都不误报（`0` 是合法值）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
