### PR TITLE
query_credit_account: 等待堵死了回调本身，且一次丢失就永久卡死 (#202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@
 
 ### 修复
 
+- **`query_credit_account` 的等待反而堵死了回调，且一次回调丢失就把通道永久卡死**（#202 后续，两个真 bug）：入口捕获修好后，真两融账户上仍然 `query_issued: true`、等满 8 秒、拿不到数据，而同一台机器在大 QMT 里直接调回调是能触发的。
+
+  **其一：等待可能堵住回调本身。** handler 跑在 adjust 主线程上（必须如此，否则拿不到交易上下文），原来它在**同一条线程上** sleep 轮询等回调。QMT 若把 `credit_account_callback` 投递到主线程（`order_callback` 走 C++ 线程，不能照搬），那就是用等待堵住了唯一能送达的路。默认改成**不等**：发出去即返回，回调随后落进缓存，下一次调用取到。这在两种假设下都安全；想等的人显式传 `wait_seconds`。实测默认调用从「等满 8 秒」变成 104ms 返回。
+
+  **其二：`_credit_account_inflight` 只在「回调到达」和「func 抛异常」两处被清，超时路径没人清** —— 回调丢一次，之后每次调用都撞 `a query is already in flight`，**这条通道永久失效**。现在超时释放（信封报 `inflight_released`），外加兜底：卡住超过一个最小间隔就当它丢了。
+
+  同时把「回调落在哪条线程上」记下来（`callback_thread` / `last_callback_thread`）—— 这是个事实问题，记下来就不用继续猜。
+
 - **信用账户回调的成功与失败都不出声，「QMT 没回调」和「回调来了没送到」分不开**（#202 后续）：入口捕获修好后，实盘上出现 `callback_bound: true`、`query_issued: true`，但 `fresh: false` 没数据。而 `credit_account_callback` 无论成功还是失败都静默返回 —— 又是「a failed operation looks exactly like one that never ran」，这次栽在自己的新代码上。
 
   现在每次回调都留痕：handlers 记 `callbacks_seen` 计数；转交不成功时（没有 RPC service、handlers 太旧没有 `note_credit_account`）**大声报出来**而不是默默 `return False`；归一化失败也照样计数 —— 回调来过就是来过，不能算成「没回调」。`query_credit_account` 的信封新增 `callbacks_seen` 和 `waited_seconds`，`probe_capabilities` 新增 `credit_callback` 一段（不发查询也能看）。体检报告把这两种成因分开写进结论，并把默认等待从 3 秒放宽到 8 秒（查柜台可能更慢，而这是只读查询，等久一点没有代价）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 ### 修复
 
+- **信用账户回调的成功与失败都不出声，「QMT 没回调」和「回调来了没送到」分不开**（#202 后续）：入口捕获修好后，实盘上出现 `callback_bound: true`、`query_issued: true`，但 `fresh: false` 没数据。而 `credit_account_callback` 无论成功还是失败都静默返回 —— 又是「a failed operation looks exactly like one that never ran」，这次栽在自己的新代码上。
+
+  现在每次回调都留痕：handlers 记 `callbacks_seen` 计数；转交不成功时（没有 RPC service、handlers 太旧没有 `note_credit_account`）**大声报出来**而不是默默 `return False`；归一化失败也照样计数 —— 回调来过就是来过，不能算成「没回调」。`query_credit_account` 的信封新增 `callbacks_seen` 和 `waited_seconds`，`probe_capabilities` 新增 `credit_callback` 一段（不发查询也能看）。体检报告把这两种成因分开写进结论，并把默认等待从 3 秒放宽到 8 秒（查柜台可能更慢，而这是只读查询，等久一点没有代价）。
+
 - **入口文件手抄的 QMT 全局函数名单漏了 `query_credit_account`，桥拿不到它，却被误报成「这台终端没有这个函数」**（#202 后续）：QMT 只往**被挂载的那个文件**的命名空间注入全局函数，所以捕获必须在入口文件里做。策略模块的 `_QMT_INJECTED_GLOBAL_FUNCS` 是这份名单的唯一来源，它自己的注释就写着「do not hand-copy the names elsewhere」—— 而 `BIGQMT_REDIS_DRYRUN.py` 里偏偏有一张手抄表。给策略模块加 `query_credit_account` 时漏了它，于是桥捕获不到 → `probe_capabilities` 报 `callback_bound=false` → 报告据此下结论「这台终端没有 query_credit_account，重启也没用」。
 
   **而用户在大 QMT 里直接调它是好用的**（维持担保比例 3.35、总负债 1038962.07）。一个桥的 bug 被报成了券商终端的能力缺失 —— 这比返回空更糟，它给出的是一个错误但听起来很确定的结论，会让人不去查真正的地方。

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -590,6 +590,9 @@ class BigQmtRpcHandlers:
         self._credit_account_asked = 0.0      # 上一次真的发出查询的时间
         self._credit_account_inflight = False
         self._credit_account_error = ""
+        # QMT 实际回调了多少次。0 = QMT 没回调；>0 但没数据 = 回调来了但结果
+        # 没落进来。两者的排查方向完全不同，从外面看却一样（#202）。
+        self._credit_account_callbacks = 0
         self.credit_account_min_interval_seconds = CREDIT_ACCOUNT_MIN_INTERVAL_SECONDS
         self.credit_account_max_wait_seconds = CREDIT_ACCOUNT_MAX_WAIT_SECONDS
         if allowed_methods is None:
@@ -815,6 +818,11 @@ class BigQmtRpcHandlers:
         # 3 = 信用。#201 的报告只看到「空列表」，无从判断是哪一种。
         info["credit_probe"]["get_trade_detail_data(CREDIT,ACCOUNT)"] = \
             self._probe_credit_account_object()
+        info["credit_callback"] = {
+            "note_credit_account_available": hasattr(self, "note_credit_account"),
+            "callbacks_seen": getattr(self, "_credit_account_callbacks", 0),
+            "cached_rows": len(getattr(self, "_credit_account_rows", []) or []),
+        }
         info["thread_routing"] = self._probe_thread_routing()
         info["sector_probe"] = self._probe_sector_channels()
         info["order_watch"] = self._probe_order_watch()
@@ -836,10 +844,12 @@ class BigQmtRpcHandlers:
             rows = _normalize_detail_rows([result] if result is not None else [])
         except Exception as exc:
             with self._credit_account_lock:
+                self._credit_account_callbacks += 1
                 self._credit_account_inflight = False
                 self._credit_account_error = "%s: %s" % (exc.__class__.__name__, exc)
             return False
         with self._credit_account_lock:
+            self._credit_account_callbacks += 1
             self._credit_account_rows = rows
             self._credit_account_stamp = time.time()
             self._credit_account_inflight = False
@@ -909,11 +919,13 @@ class BigQmtRpcHandlers:
                     break
             # sleep 让出 GIL，回调线程才拿得到 —— busy-wait 会把它锁死在门外。
             time.sleep(0.02)
+        waited = round(time.time() - (deadline - wait_seconds), 3)
         with self._credit_account_lock:
             rows = list(self._credit_account_rows)
             stamp = self._credit_account_stamp
             error = self._credit_account_error
             seq = self._credit_account_seq
+            callbacks = self._credit_account_callbacks
         return {
             "rows": rows,
             "count": len(rows),
@@ -925,6 +937,10 @@ class BigQmtRpcHandlers:
             "seq": seq,
             "error": error,
             "callback_bound": callable(self.qmt_api.get("query_credit_account")),
+            # 这两个才是能定位问题的：callbacks_seen=0 说明 QMT 压根没回调
+            # （等太短？账户不支持？回调没挂上？），>0 说明回调通了、问题在别处。
+            "callbacks_seen": callbacks,
+            "waited_seconds": waited,
         }
 
     def _describe_probe_rows(self, rows):

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -228,10 +228,21 @@ DEFAULT_ORDER_STRATEGY_NAME = "bigqmt_rpc"
 # hollow 告警的最小间隔。跑错线程时每一次查询都会 hollow，不节流日志会被刷爆。
 HOLLOW_WARNING_INTERVAL_SECONDS = 60.0
 CREDIT_ACCOUNT_MIN_INTERVAL_SECONDS = 30.0
-# 一次 RPC 里最多等回调多久。回调走 QMT 的 C++ 线程，handler 在 adjust 主线程
-# 上；这里的等待用 sleep 轮询让出 GIL，回调才落得下来。默认给得短，因为拿不到
-# 新的就退回上一次的缓存值，不必把主线程按住。
-CREDIT_ACCOUNT_DEFAULT_WAIT_SECONDS = 1.5
+# 一次 RPC 里最多等回调多久。**默认 0：不等。**
+#
+# handler 跑在 adjust 主线程上（它在 LISTENER_DEFERRED_METHODS 里，必须如此，
+# 否则拿不到交易上下文）。原来这里 sleep 轮询等回调，实盘上（真两融账户、
+# 已确认在大 QMT 里回调能触发）表现是：query_issued=true、等满 8 秒、
+# callbacks_seen=0、无任何报错。
+#
+# 最可能的解释：QMT 把 credit_account_callback 投递到主线程上，而我正用等待
+# 堵着这条线程 —— 用等待堵死了唯一能送达的那条路，回调只可能在 handler 返回
+# 之后才进来。order_callback 走 C++ 线程，这个不一定同理，不能照搬。
+#
+# 所以默认改成「发出去就返回」：这一次拿到的是缓存（或空），回调随后自己落下，
+# 下一次调用就能取到。在两种假设下都安全 —— 如果回调其实走的是 C++ 线程，
+# 代价也只是多一次调用。想等的人显式传 wait_seconds 即可。
+CREDIT_ACCOUNT_DEFAULT_WAIT_SECONDS = 0.0
 CREDIT_ACCOUNT_MAX_WAIT_SECONDS = 10.0
 TERMINAL_NON_CANCEL_ORDER_STATUSES = {"56", "57"}
 # 51 已报待撤 / 52 部成待撤: the exchange has ACCEPTED the cancel and it is
@@ -593,6 +604,9 @@ class BigQmtRpcHandlers:
         # QMT 实际回调了多少次。0 = QMT 没回调；>0 但没数据 = 回调来了但结果
         # 没落进来。两者的排查方向完全不同，从外面看却一样（#202）。
         self._credit_account_callbacks = 0
+        # 回调实际落在哪条线程上。adjust 线程 = 等待会把它堵死；C++ 回调线程
+        # = 等待是安全的。这是个事实问题，记下来就不用猜（#202）。
+        self._credit_account_callback_thread = ""
         self.credit_account_min_interval_seconds = CREDIT_ACCOUNT_MIN_INTERVAL_SECONDS
         self.credit_account_max_wait_seconds = CREDIT_ACCOUNT_MAX_WAIT_SECONDS
         if allowed_methods is None:
@@ -822,6 +836,7 @@ class BigQmtRpcHandlers:
             "note_credit_account_available": hasattr(self, "note_credit_account"),
             "callbacks_seen": getattr(self, "_credit_account_callbacks", 0),
             "cached_rows": len(getattr(self, "_credit_account_rows", []) or []),
+            "last_callback_thread": getattr(self, "_credit_account_callback_thread", ""),
         }
         info["thread_routing"] = self._probe_thread_routing()
         info["sector_probe"] = self._probe_sector_channels()
@@ -848,8 +863,13 @@ class BigQmtRpcHandlers:
                 self._credit_account_inflight = False
                 self._credit_account_error = "%s: %s" % (exc.__class__.__name__, exc)
             return False
+        try:
+            thread_name = threading.current_thread().name
+        except Exception:
+            thread_name = "?"
         with self._credit_account_lock:
             self._credit_account_callbacks += 1
+            self._credit_account_callback_thread = thread_name
             self._credit_account_rows = rows
             self._credit_account_stamp = time.time()
             self._credit_account_inflight = False
@@ -875,7 +895,14 @@ class BigQmtRpcHandlers:
         now = time.time()
         with self._credit_account_lock:
             if self._credit_account_inflight:
-                return False, "a query is already in flight"
+                # 兜底：inflight 卡住超过一个最小间隔就当它丢了，重新放行。
+                # 官方说「前一个查询还在进行中，后面的会提前返回」，所以重问
+                # 最坏也就是提前返回；而卡死是永久失去这条通道。
+                stuck_for = now - self._credit_account_asked
+                if stuck_for < self.credit_account_min_interval_seconds:
+                    return False, ("a query is already in flight (%.1fs)"
+                                   % stuck_for)
+                self._credit_account_inflight = False
             since = now - self._credit_account_asked
             if self._credit_account_asked and since < self.credit_account_min_interval_seconds:
                 return False, ("rate limited: %.1fs since the last query, minimum %.1fs"
@@ -917,10 +944,19 @@ class BigQmtRpcHandlers:
                     break
                 if not self._credit_account_inflight:
                     break
-            # sleep 让出 GIL，回调线程才拿得到 —— busy-wait 会把它锁死在门外。
+            # sleep 让出 GIL —— 但如果回调本来就要走这条线程，让出 GIL 也没用，
+            # 见 CREDIT_ACCOUNT_DEFAULT_WAIT_SECONDS 上面的说明。
             time.sleep(0.02)
         waited = round(time.time() - (deadline - wait_seconds), 3)
         with self._credit_account_lock:
+            # 等不到就把 inflight 放掉。原来只有「回调到达」和「func 抛异常」
+            # 两条路会清它 —— 超时路径没人清，于是**一次回调丢失就把这条通道
+            # 永久卡死**：之后每次调用都撞 "a query is already in flight"，再也
+            # 发不出去。放掉的代价只是可能重复问一次柜台，而 30s 最小间隔还在。
+            timed_out = (self._credit_account_inflight
+                         and not (self._credit_account_stamp > stamp_before))
+            if timed_out:
+                self._credit_account_inflight = False
             rows = list(self._credit_account_rows)
             stamp = self._credit_account_stamp
             error = self._credit_account_error
@@ -941,6 +977,14 @@ class BigQmtRpcHandlers:
             # （等太短？账户不支持？回调没挂上？），>0 说明回调通了、问题在别处。
             "callbacks_seen": callbacks,
             "waited_seconds": waited,
+            # 回调实际落在哪条线程上。这一条能证伪上面那个「回调走主线程、
+            # 被我的等待堵住」的假设 —— 不用再猜。
+            "callback_thread": self._credit_account_callback_thread,
+            # 这次是不是等超时并把 inflight 放掉了
+            "inflight_released": bool(timed_out),
+            "note": ("默认不等回调：查询已发出，结果随后落进缓存，下一次调用即可"
+                     "取到（handler 跑在 adjust 主线程上，等待可能把回调堵在门外）"
+                     if wait_seconds == 0 else ""),
         }
 
     def _describe_probe_rows(self, rows):

--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -131,6 +131,9 @@ _account_id = ""
 _config = {}
 _qmt_api = {}
 _adjust_logged = False
+# QMT 调了多少次 credit_account_callback。0 说明 QMT 压根没回调，
+# 大于 0 但 handlers 里没数据说明是转交那一步断了（#202）。
+_credit_callback_fired = 0
 _rpc_service = None
 _quote_subscription_service = None  # (QuoteSubscriptionManager, QuotePushChannel)
 _exec_event_redis_client = None  # reused; building a new client per trade callback leaks
@@ -1871,9 +1874,27 @@ def credit_account_callback(ContextInfo, seq, result):
     主线程上下文的事，也绝不让异常逃出去 —— 回调里抛异常在 QMT 那边表现为没有
     堆栈的 SystemError（issue #76）。
     """
+    # 这里以前成功和失败都不出声，于是「QMT 根本没回调」和「回调来了但没送到
+    # handlers」从外面看一模一样 —— 正是 CLAUDE.md 里那条「a failed operation
+    # looks exactly like one that never ran」，栽在自己的新代码上。所以每一次
+    # 触发都留痕：计数交给 handlers（probe_capabilities 报出来），送不到时
+    # 一定要吼出来。
+    global _credit_callback_fired
+    _credit_callback_fired += 1
     try:
         handlers = getattr(_rpc_service, "handlers", None) if _rpc_service else None
-        if handlers is None or not hasattr(handlers, "note_credit_account"):
+        if handlers is None:
+            _log_err("credit_account_callback",
+                     "QMT delivered a credit account detail (seq=%s) but there is "
+                     "no RPC service to hand it to -- the answer is being dropped."
+                     % (seq,))
+            return False
+        if not hasattr(handlers, "note_credit_account"):
+            _log_err("credit_account_callback",
+                     "QMT delivered a credit account detail (seq=%s) but this "
+                     "deployment's handlers have no note_credit_account -- the "
+                     "bridge package is older than the entry file. Re-sync and "
+                     "restart." % (seq,))
             return False
         return handlers.note_credit_account(seq, result)
     except Exception as exc:

--- a/tests/bigqmt_signal_trader/test_query_credit_account.py
+++ b/tests/bigqmt_signal_trader/test_query_credit_account.py
@@ -74,7 +74,8 @@ class QueryCreditAccountTest(unittest.TestCase):
 
         handlers = _handlers(query_credit_account)
         handlers_box["h"] = handlers
-        out = handlers.handle("query_credit_account", {})
+        # 显式要求等待：默认是 0（不堵 adjust 主线程），这条测的正是等待路径
+        out = handlers.handle("query_credit_account", {"wait_seconds": 2})
 
         self.assertEqual(len(seen), 1)
         self.assertEqual(seen[0][0], "acct")
@@ -240,6 +241,76 @@ class QueryCreditAccountTest(unittest.TestCase):
         handlers.note_credit_account(1, _Exploding())
         probe = handlers.handle("probe_capabilities", {})["credit_callback"]
         self.assertGreaterEqual(probe["callbacks_seen"], 1)
+
+    def test_default_does_not_block_the_adjust_thread(self):
+        """默认不等回调 —— handler 跑在 adjust 主线程上，等待可能把回调堵在门外。"""
+        from bigqmt_signal_trader.redis_rpc import CREDIT_ACCOUNT_DEFAULT_WAIT_SECONDS
+
+        self.assertEqual(CREDIT_ACCOUNT_DEFAULT_WAIT_SECONDS, 0.0)
+
+        started = time.time()
+        out = _handlers(lambda *a: None).handle("query_credit_account", {})
+        self.assertLess(time.time() - started, 0.5)
+        self.assertTrue(out["query_issued"])
+        self.assertIn("下一次调用", out["note"])
+
+    def test_result_is_available_on_the_next_call(self):
+        """不等的代价只是多一次调用：回调随后落下，第二次就取到。"""
+        handlers_box = {}
+        pending = []
+
+        def query_credit_account(account_id, seq, context_info):
+            pending.append(seq)          # 模拟回调晚于 handler 返回
+
+        handlers = _handlers(query_credit_account)
+        handlers_box["h"] = handlers
+        handlers.credit_account_min_interval_seconds = 0.0
+
+        first = handlers.handle("query_credit_account", {})
+        self.assertEqual(first["count"], 0)
+
+        handlers.note_credit_account(pending[0], _CreditResult())   # 回调后到
+
+        second = handlers.handle("query_credit_account", {})
+        self.assertEqual(second["count"], 1)
+        self.assertEqual(second["rows"][0]["m_dTotalDebt"], 12345.67)
+
+    def test_a_lost_callback_does_not_wedge_the_channel_forever(self):
+        """inflight 原来只在回调到达/抛异常时清 —— 超时没人清，一次丢失就永久卡死。"""
+        calls = []
+        handlers = _handlers(lambda a, s, c: calls.append(s))
+        handlers.credit_account_min_interval_seconds = 0.0
+
+        first = handlers.handle("query_credit_account", {"wait_seconds": 0.1})
+        self.assertTrue(first["query_issued"])
+        self.assertTrue(first["inflight_released"])
+
+        second = handlers.handle("query_credit_account", {"wait_seconds": 0.1})
+        self.assertTrue(second["query_issued"],
+                        "回调丢一次就再也发不出去了：%s" % second["not_issued_reason"])
+        self.assertEqual(len(calls), 2)
+
+    def test_a_stuck_inflight_is_released_after_the_min_interval(self):
+        """兜底：inflight 卡住超过一个最小间隔就当它丢了。"""
+        calls = []
+        handlers = _handlers(lambda a, s, c: calls.append(s))
+        handlers.credit_account_min_interval_seconds = 0.0
+        handlers._credit_account_inflight = True
+        handlers._credit_account_asked = time.time() - 999
+
+        out = handlers.handle("query_credit_account", {})
+        self.assertTrue(out["query_issued"])
+        self.assertEqual(len(calls), 1)
+
+    def test_callback_thread_is_recorded_so_the_hypothesis_is_testable(self):
+        """回调落在 adjust 线程还是 C++ 线程，是个事实问题 —— 记下来别猜。"""
+        handlers = _handlers(lambda *a: None)
+        handlers.note_credit_account(1, _CreditResult())
+
+        probe = handlers.handle("probe_capabilities", {})["credit_callback"]
+        self.assertTrue(probe["last_callback_thread"])
+        out = handlers.handle("query_credit_account", {})
+        self.assertTrue(out["callback_thread"])
 
     def test_method_is_whitelisted_and_deferred_to_the_main_thread(self):
         from bigqmt_signal_trader.redis_rpc import (

--- a/tests/bigqmt_signal_trader/test_query_credit_account.py
+++ b/tests/bigqmt_signal_trader/test_query_credit_account.py
@@ -194,6 +194,53 @@ class QueryCreditAccountTest(unittest.TestCase):
         result = handlers.note_credit_account(1, _Exploding())
         self.assertIn(result, (True, False))
 
+    def test_envelope_counts_callbacks_so_silence_is_diagnosable(self):
+        """callbacks_seen=0 和 >0 指向完全不同的排查方向，必须报出来。
+
+        实盘上出现过：绑定修好了、query_issued=true，但 fresh=false 没数据。
+        光看这些分不清「QMT 压根没回调」和「回调来了但结果没落进来」。
+        """
+        handlers_box = {}
+
+        def query_credit_account(account_id, seq, context_info):
+            handlers_box["h"].note_credit_account(seq, _CreditResult())
+
+        handlers = _handlers(query_credit_account)
+        handlers_box["h"] = handlers
+
+        before = handlers.handle("probe_capabilities", {})["credit_callback"]
+        self.assertEqual(before["callbacks_seen"], 0)
+        self.assertTrue(before["note_credit_account_available"])
+
+        out = handlers.handle("query_credit_account", {})
+        self.assertEqual(out["callbacks_seen"], 1)
+        self.assertIsInstance(out["waited_seconds"], float)
+
+        after = handlers.handle("probe_capabilities", {})["credit_callback"]
+        self.assertEqual(after["callbacks_seen"], 1)
+        self.assertEqual(after["cached_rows"], 1)
+
+    def test_a_query_that_never_calls_back_reports_zero_callbacks(self):
+        out = _handlers(lambda *a: None).handle(
+            "query_credit_account", {"wait_seconds": 0.1})
+
+        self.assertTrue(out["query_issued"])
+        self.assertFalse(out["fresh"])
+        self.assertEqual(out["callbacks_seen"], 0)      # QMT 没回调
+        self.assertGreaterEqual(out["waited_seconds"], 0.05)
+
+    def test_a_callback_that_cannot_be_normalised_still_counts(self):
+        """回调来过就要记一笔 —— 哪怕结果没能用上，那也不是「没回调」。"""
+        class _Exploding(object):
+            @property
+            def m_dTotalDebt(self):
+                raise RuntimeError("boom")
+
+        handlers = _handlers(lambda *a: None)
+        handlers.note_credit_account(1, _Exploding())
+        probe = handlers.handle("probe_capabilities", {})["credit_callback"]
+        self.assertGreaterEqual(probe["callbacks_seen"], 1)
+
     def test_method_is_whitelisted_and_deferred_to_the_main_thread(self):
         from bigqmt_signal_trader.redis_rpc import (
             LISTENER_DEFERRED_METHODS, READ_METHODS,

--- a/tools/credit_api_report.py
+++ b/tools/credit_api_report.py
@@ -383,6 +383,17 @@ def render_text(report):
             add("  这台终端没有绑上的全局函数: %s" % ", ".join(missing))
     add("")
 
+    callback = (report.get("probe") or {}).get("credit_callback") or {}
+    if callback:
+        add("-" * 72)
+        add("信用账户回调（查柜台那条路）")
+        add("-" * 72)
+        add("  note_credit_account 可用 : %s" % callback.get("note_credit_account_available"))
+        add("  QMT 实际回调次数         : %s   (0 = QMT 压根没回调)"
+            % callback.get("callbacks_seen"))
+        add("  桥里缓存的行数           : %s" % callback.get("cached_rows"))
+        add("")
+
     routing = (report.get("probe") or {}).get("thread_routing") or {}
     if routing.get("available"):
         add("-" * 72)
@@ -439,6 +450,20 @@ def build_conclusions(report):
     # probe 的 global_namespace 走的是策略侧 _resolve_runtime_name 同一条解析
     # 路径（qmt_api -> globals -> builtins），所以它能分开这两种。
     counter_entry = by_method.get("query_credit_account", {})
+    counter_env = counter_entry.get("envelope") or {}
+    if counter_env.get("query_issued") and not counter_env.get("fresh"):
+        seen = counter_env.get("callbacks_seen")
+        waited = counter_env.get("waited_seconds")
+        if seen == 0:
+            out.append("query_credit_account 发出去了，但 QMT 一次回调都没给"
+                       "（callbacks_seen=0，等了 %s 秒）。可能是等太短、这个账户"
+                       "柜台不答，或者 credit_account_callback 没挂到被挂载的"
+                       "入口文件上 —— 加大 --wait 再跑一次，仍是 0 就把这份报告"
+                       "贴上来。" % waited)
+        elif seen:
+            out.append("query_credit_account 的回调**来过 %s 次**，但这次没等到"
+                       "新结果 —— 回调链路是通的，问题在时序或限流，不在绑定。"
+                       % seen)
     if (counter_entry.get("envelope") or {}).get("callback_bound") is False:
         in_namespace = ((report.get("probe") or {}).get("global_namespace")
                         or {}).get("query_credit_account")
@@ -500,8 +525,8 @@ def main(argv=None):
     parser.add_argument("--out", default=".", help="报告输出目录")
     parser.add_argument("--full", action="store_true",
                         help="报告里带上原始数值（默认省略，便于直接贴 issue）")
-    parser.add_argument("--wait", type=float, default=3.0,
-                        help="查柜台那条路等回调的秒数（默认 3）")
+    parser.add_argument("--wait", type=float, default=8.0,
+                        help="查柜台那条路等回调的秒数（默认 8）。查柜台可能比几秒还慢，而这是只读查询，等久一点没有代价")
     args = parser.parse_args(argv)
 
     from bigqmt_signal_trader.xtquant_compat import XtQuantTrader


### PR DESCRIPTION
接 #202：入口捕获修好后，真两融账户上仍然拿不到查柜台的结果 —— `callback_bound: true`、`query_issued: true`、等满 8 秒、`fresh: false`、无任何报错。而同一台机器在大 QMT 里直接调 `query_credit_account` + `credit_account_callback` 是能打印出维持担保比例的。

先只加了诊断，被指出「你只改了测试的代码吗？为什么会调不通想过吗」。去想了，找到两个真 bug，其中一个是这套代码自己写出来的。

## 1. 等待可能堵住回调本身

handler 跑在 **adjust 主线程**上（必须如此，否则拿不到交易上下文），而它原来在**同一条线程上** sleep 轮询等回调。

QMT 若把 `credit_account_callback` 投递到主线程，那就是**用等待堵住了唯一能送达的路** —— 回调在等待期间永远到不了，只能在 handler 返回之后才进来。`order_callback` 走 C++ 线程，这一条不能照搬过来假设。

证据吻合：真两融账户、大 QMT 里回调确认能触发，桥这边却 `callbacks_seen: 0` 等满 8 秒、无报错。

**改法**：默认不等（`CREDIT_ACCOUNT_DEFAULT_WAIT_SECONDS` 1.5 → 0）。发出去即返回，回调随后落进缓存，**下一次调用取到**。这在两种假设下都安全 —— 如果回调其实走 C++ 线程，代价也只是多一次调用。想等的人显式传 `wait_seconds`。

实测：默认调用从「等满 8 秒」变成 **104ms 返回**，不再占着 adjust 主线程。

## 2. 一次回调丢失，通道永久卡死（确定的 bug，与上面的假设无关）

`_credit_account_inflight` 只在两处被清：**回调到达**、**func 抛异常**。**超时路径没人清。**

所以回调只要丢一次，`inflight` 永远是 `True`，之后每次调用都撞 `a query is already in flight`，**这条通道永久失效**。17:32 那次能发出去，只是因为那是重启后的第一次。

改了两处：超时后释放（信封报 `inflight_released`），外加兜底 —— inflight 卡住超过一个最小间隔就当它丢了。用例钉住「回调丢一次之后第二次仍然发得出去」。

## 3. 让假设可证伪，而不是继续猜

回调实际落在哪条线程上是个**事实问题**。现在记下来：`callback_thread`（信封）/ `last_callback_thread`（probe）。

- 回调来了、线程名是 adjust 线程 → 假设 1 坐实
- 是 C++ 线程 → 等待本来是安全的，得另找原因

## 4. 回调不再静默

原来 `credit_account_callback` 成功和失败都不出声，于是「QMT 压根没回调」和「回调来了但没送到 handlers」从外面看一模一样 —— 又是那条「a failed operation looks exactly like one that never ran」，这次栽在自己的新代码上。

现在：handlers 记 `callbacks_seen`；转交不成功时大声报错而不是默默 `return False`；归一化失败也计数（回调来过就是来过）；`probe_capabilities` 新增 `credit_callback` 段，不发查询也能看。体检报告按这两种成因分开写结论，默认等待 3 → 8 秒。

## 验证

- 全量 **1696 passed**，收集数 129 == 文件数 129
- 实盘部署 + reload：默认调用 104ms 返回（不再阻塞），`inflight_released: true`，`waited_seconds: 0.0`
- 新用例覆盖：默认不阻塞、结果在下一次调用取到、回调丢一次不卡死、stuck inflight 兜底、回调线程名被记录

**未验证**：回调链路本身是否真的通 —— 维护者的账户是普通股票账户（`m_nBrokerType=2`），`callbacks_seen` 恒为 0，说明不了问题出在哪。需要有两融账户的用户部署后**真重启策略**（改了 `strategy.py`，`reload_deployment()` 刷不了）再跑一次报告。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
