### PR TITLE
fix(test): 入口文件接线检查不再依赖 .gitignore 掉的构建产物（main 全量测试是红的）

### DIFF
--- a/tests/bigqmt_signal_trader/test_query_credit_account.py
+++ b/tests/bigqmt_signal_trader/test_query_credit_account.py
@@ -439,24 +439,57 @@ class MethodRegistrationTest(unittest.TestCase):
 class CreditCallbackWiringTest(unittest.TestCase):
     """QMT 只往被挂载的那个文件回调，所以每个入口文件都要再导出一次。"""
 
+    # 仓库里跟踪着的入口文件。
     ENTRY_FILES = (
         "src/BIGQMT_REDIS_DRYRUN.py",
         "src/BIGQMT_ZMQ_BACKTEST.py",
-        "src/BIGQMT_REDIS_DRYRUN_ALL_IN_ONE.py",
         "src/bigqmt_signal_trader_redis_rpc_runtime.py",
         "src/bigqmt_signal_trader_redis_dryrun.py",
         "src/bigqmt_signal_trader_dryrun.py",
         "bigqmt_no_redis/DRYRUN_no_redis.py",
     )
 
-    def test_every_entry_that_exports_deal_callback_exports_the_credit_one(self):
+    # 单文件构建产物是 .gitignore 掉的生成物，干净检出里根本不存在，
+    # 直接读它会让整条用例以 FileNotFoundError 挂掉。产物里那段导出是
+    # 构建脚本里的纯文本模板（只有被嵌入的模块源码是 base64），而构建
+    # 脚本是跟踪着的——所以事实来源是它们，不是产物。
+    GENERATED_ENTRIES = (
+        ("tools/build_single_file.py",
+         "src/BIGQMT_REDIS_DRYRUN_ALL_IN_ONE.py"),
+        ("tools/build_no_redis_single_file_flat.py",
+         "src/BIGQMT_DRYRUN_NO_REDIS_FLAT_ALL_IN_ONE.py"),
+    )
+
+    def _missing_credit_export(self, rel):
+        """rel 导出了 deal_callback 却没导出 credit_account_callback 就算漏。"""
         import io
-        missing = []
+        path = os.path.join(ROOT, rel.replace("/", os.sep))
+        text = io.open(path, encoding="utf-8", errors="replace").read()
+        return "deal_callback" in text and "credit_account_callback" not in text
+
+    def _assert_present(self, rel):
+        """文件不在了要响亮地挂，否则这条检查会静默地变成空跑。"""
+        path = os.path.join(ROOT, rel.replace("/", os.sep))
+        self.assertTrue(os.path.exists(path),
+                        "名单里的文件不在了，名单该跟着改：%s" % rel)
+
+    def test_every_entry_that_exports_deal_callback_exports_the_credit_one(self):
         for rel in self.ENTRY_FILES:
-            path = os.path.join(ROOT, rel.replace("/", os.sep))
-            text = io.open(path, encoding="utf-8", errors="replace").read()
-            if "deal_callback" in text and "credit_account_callback" not in text:
-                missing.append(rel)
+            self._assert_present(rel)
+        missing = [rel for rel in self.ENTRY_FILES
+                   if self._missing_credit_export(rel)]
+        self.assertEqual(missing, [])
+
+    def test_single_file_builders_export_the_credit_callback(self):
+        """产物没生成时查构建脚本；本地生成过就顺手把产物也查了。"""
+        missing = []
+        for builder, generated in self.GENERATED_ENTRIES:
+            self._assert_present(builder)
+            if self._missing_credit_export(builder):
+                missing.append(builder)
+            out = os.path.join(ROOT, generated.replace("/", os.sep))
+            if os.path.exists(out) and self._missing_credit_export(generated):
+                missing.append(generated)
         self.assertEqual(missing, [])
 
     def test_strategy_defines_the_callback_and_binds_the_global(self):


### PR DESCRIPTION
## 问题

`main` 上跑全量测试是红的：

```
FAILED tests/bigqmt_signal_trader/test_query_credit_account.py::CreditCallbackWiringTest::test_every_entry_that_exports_deal_callback_exports_the_credit_one
FileNotFoundError: src/BIGQMT_REDIS_DRYRUN_ALL_IN_ONE.py
```

`CreditCallbackWiringTest.ENTRY_FILES` 把 `src/BIGQMT_REDIS_DRYRUN_ALL_IN_ONE.py` 列了进去并直接 `io.open`，但那是 `.gitignore:32` 里的**单文件构建产物**，干净检出里根本不存在，于是整条用例以 `FileNotFoundError` 挂掉。

在跑过 `tools/build_single_file.py` 的工作区里产物在，所以它是绿的——这个红只在新克隆和 CI 上出现，这也是它能合进 main 的原因。

## 改法

产物里那段导出（`deal_callback = _runtime.deal_callback` / `credit_account_callback = ...`）来自 `tools/build_single_file.py` 的**纯文本模板**，只有被嵌入的模块源码是 base64。模板所在的构建脚本是跟踪着的，所以事实来源是脚本，不是产物。

- `ENTRY_FILES` 只留跟踪着的入口文件。
- 新增 `GENERATED_ENTRIES`，查两个构建脚本；产物在本地存在时顺手一起查。
- 顺带补上一直漏检的第二个入口：flat 构建产物 `BIGQMT_DRYRUN_NO_REDIS_FLAT_ALL_IN_ONE.py` 同样导出 `deal_callback`，之前完全不在名单里。
- 名单里的文件缺失现在响亮地挂（`_assert_present`）。把产物那条简单改成"不存在就跳过"会让检查静默变成空跑，那正是这类检查最容易烂掉的方式。

## 验证

**变异验证**（四条分支都确认会红/会绿，不是空跑）：

| 变异 | 结果 |
|---|---|
| `build_single_file.py` 删掉 credit 导出 | 红 |
| `build_no_redis_single_file_flat.py` 删掉 credit 导出 | 红 |
| 产物存在但缺 credit 导出 | 红 |
| 产物存在且正确 | 绿 |
| 跟踪的入口文件被移走 | 红（`_assert_present`）|

**门禁 1（离线全量）**：修复前 `1705 passed, 1 failed`，修复后 **`1707 passed`**（一条拆成两条）。收集数 **129 = 129**，对得上。

**门禁 2（只读实盘）**：10 项 0 failed，`RESULT: PASS`。注意版本号 **STALE**（repo 0.3.24 / deployed 0.3.23）——但这是 tests-only 改动，不进部署，实盘不受影响。

## 没验证到的部分

这条改的是测试对文件的取用方式，没有触碰任何运行时代码，也没有重新验证 credit 回调本身在实盘上的行为。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
