### PR TITLE
fix: futures/option query rows read the side from m_nOpType, not m_nO…

### DIFF
--- a/src/bigqmt_signal_trader/adapters/order_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/order_bigqmt.py
@@ -307,7 +307,22 @@ def credit_optype_of(order_type):
         return None
 
 
-def _action_from_offset_flag(offset_flag):
+def _action_from_offset_flag(offset_flag, op_type=None, account_type=None):
+    """BUY/SELL for a normalized query row, from m_nOffsetFlag or m_nOpType.
+
+    For stocks, m_nOffsetFlag IS the side (48=buy, 49=sell). For futures and
+    ETF options, offset means open/close instead (48=open, 49=close): a
+    sell-to-open row carries offset=48 and reads as BUY under the stock
+    mapping, and a buy-to-close row reads as SELL. When the row belongs to a
+    passthrough account (FUTURE / STOCK_OPTION), prefer the side of m_nOpType
+    via passthrough_action_of() (futures 0-15, ETF options 50-55); offset
+    stays as the fallback for rows without a usable opType (e.g. 56/57
+    exercise rows, which have no side at all).
+    """
+    if account_type and str(account_type).upper() in PASSTHROUGH_ACCOUNT_TYPES:
+        action = passthrough_action_of(op_type)
+        if action is not None:
+            return action
     return SignalAction.BUY.value if int(offset_flag or 0) == 48 else SignalAction.SELL.value
 
 
@@ -666,7 +681,11 @@ class BigQmtOrderGateway:
                     order_sys_id=str(_attr(row, ("m_strOrderSysID", "order_sys_id"), "") or ""),
                     user_order_id=str(_attr(row, ("m_strRemark", "user_order_id", "remark"), "") or ""),
                     stock_code=stock_code,
-                    action=_action_from_offset_flag(_attr(row, ("m_nOffsetFlag", "offset_flag"), 0)),
+                    action=_action_from_offset_flag(
+                        _attr(row, ("m_nOffsetFlag", "offset_flag"), 0),
+                        _attr(row, ("m_nOpType", "op_type"), None),
+                        self._resolve_account_type(account_id),
+                    ),
                     volume=int(_attr(row, ("m_nVolumeTotalOriginal", "volume"), 0) or 0),
                     traded_volume=int(_attr(row, ("m_nVolumeTraded", "traded_volume"), 0) or 0),
                     status=str(_attr(row, ("m_nOrderStatus", "status"), "") or ""),
@@ -763,7 +782,11 @@ class BigQmtOrderGateway:
                     trade_id=str(_attr(row, ("m_strTradeID", "trade_id"), "") or ""),
                     order_sys_id=str(_attr(row, ("m_strOrderSysID", "order_sys_id"), "") or ""),
                     stock_code=stock_code,
-                    action=_action_from_offset_flag(_attr(row, ("m_nOffsetFlag", "offset_flag"), 0)),
+                    action=_action_from_offset_flag(
+                        _attr(row, ("m_nOffsetFlag", "offset_flag"), 0),
+                        _attr(row, ("m_nOpType", "op_type"), None),
+                        self._resolve_account_type(account_id),
+                    ),
                     volume=int(_attr(row, ("m_nVolume", "volume"), 0) or 0),
                     price=float(_attr(row, ("m_dPrice", "m_dTradePrice", "price"), 0.0) or 0.0),
                     traded_at=str(traded_at_raw or ""),

--- a/tests/bigqmt_signal_trader/test_query_direction_futures.py
+++ b/tests/bigqmt_signal_trader/test_query_direction_futures.py
@@ -1,0 +1,85 @@
+# coding: utf-8
+"""Futures/option query rows reported the wrong BUY/SELL side.
+
+``_action_from_offset_flag`` mapped m_nOffsetFlag straight to the side
+(48=BUY, 49=SELL). That mapping is a stock fact: for futures and ETF
+options, m_nOffsetFlag is open/close (48=开仓, 49=平仓), so on those
+accounts the side must come from m_nOpType. Concretely, on a live
+futures account:
+
+  - 卖出开空 carries offset=48(开仓) and was reported as BUY
+  - 买入平仓 (ETF option opType 53) carries offset=49(平仓) and was
+    reported as SELL
+
+Every passthrough opType already has a side recorded in
+``passthrough_action_of`` (futures 0-15, ETF options 50-55); this change
+makes the query path consult it for FUTURE / STOCK_OPTION requests and
+keeps the offset fallback for rows without a usable opType (56/57
+exercise rows have no side at all). Stock requests are untouched.
+"""
+
+import os
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.adapters.order_bigqmt import _action_from_offset_flag
+
+
+class StockMappingUntouched(unittest.TestCase):
+    def test_stock_offset_is_the_side(self):
+        self.assertEqual(_action_from_offset_flag(48, None, "STOCK"), "BUY")
+        self.assertEqual(_action_from_offset_flag(49, None, "STOCK"), "SELL")
+
+    def test_stock_ignores_optype(self):
+        # A stock request keeps the offset mapping even if a stray op_type
+        # is present -- opTypes 0-15/50-55 are not stock opTypes.
+        self.assertEqual(_action_from_offset_flag(48, 24, "STOCK"), "BUY")
+        self.assertEqual(_action_from_offset_flag(49, 23, "STOCK"), "SELL")
+
+    def test_no_account_type_keeps_stock_mapping(self):
+        self.assertEqual(_action_from_offset_flag(48, 3, None), "BUY")
+        self.assertEqual(_action_from_offset_flag(49, 3, None), "SELL")
+
+
+class FuturesSideFromOptype(unittest.TestCase):
+    def test_sell_to_open_no_longer_reads_buy(self):
+        # offset=48 means 开仓 for futures; opType 3 is 开空, a SELL action.
+        self.assertEqual(_action_from_offset_flag(48, 3, "FUTURE"), "SELL")
+
+    def test_open_long_still_buy(self):
+        self.assertEqual(_action_from_offset_flag(48, 0, "FUTURE"), "BUY")
+
+    def test_close_long_still_sell(self):
+        # opType 1 平昨多 is a SELL action and offset=49 agrees by luck.
+        self.assertEqual(_action_from_offset_flag(49, 1, "FUTURE"), "SELL")
+
+    def test_close_short_reads_buy(self):
+        # opType 5 平今空 is a BUY action but offset=49(平仓) reads SELL.
+        self.assertEqual(_action_from_offset_flag(49, 5, "FUTURE"), "BUY")
+
+    def test_sideless_optype_falls_back_to_offset(self):
+        # 56 认购行权 has no side; the row keeps its offset mapping.
+        self.assertEqual(_action_from_offset_flag(48, 56, "FUTURE"), "BUY")
+
+    def test_missing_optype_falls_back_to_offset(self):
+        self.assertEqual(_action_from_offset_flag(48, None, "FUTURE"), "BUY")
+
+
+class EtfOptionSideFromOptype(unittest.TestCase):
+    def test_sell_to_open_no_longer_reads_buy(self):
+        # opType 52 卖出开仓: offset=48(开仓) read as BUY before this fix.
+        self.assertEqual(_action_from_offset_flag(48, 52, "STOCK_OPTION"), "SELL")
+
+    def test_buy_to_close_no_longer_reads_sell(self):
+        # opType 53 买入平仓: offset=49(平仓) read as SELL before this fix.
+        self.assertEqual(_action_from_offset_flag(49, 53, "STOCK_OPTION"), "BUY")
+
+    def test_covered_open_still_sell(self):
+        self.assertEqual(_action_from_offset_flag(48, 54, "STOCK_OPTION"), "SELL")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
…ffsetFlag

Problem:
- _action_from_offset_flag maps m_nOffsetFlag straight to BUY/SELL (48/49)
- For stocks offset IS the side; for futures/ETF options offset is open/close, so sell-to-open rows carry offset=48 and were reported BUY, and buy-to-close rows carry offset=49 and were reported SELL
- Every passthrough opType already has a side in passthrough_action_of; the query path just never consulted it

Fix:
1. adapters/order_bigqmt.py: _action_from_offset_flag gains optional op_type + account_type; for FUTURE / STOCK_OPTION requests it prefers passthrough_action_of(op_type), offset stays the fallback for rows without a usable opType (56/57 exercise rows have no side)
2. adapters/order_bigqmt.py: query_orders_strict / query_trades_strict call sites pass m_nOpType + the per-request account type via _resolve_account_type(account_id)
3. tests/bigqmt_signal_trader/test_query_direction_futures.py: 12 cases; all 12 red before the fix, green after; stock mapping pinned unchanged

- _action_from_offset_flag 增加 op_type + account_type 参数，复用上游现成的 passthrough_action_of() 和 PASSTHROUGH_ACCOUNT_TYPES
- 两个调用点改用 per-request _resolve_account_type(account_id)（多账号部署下正确路由）
- 测试 12 例：修复前 12 红 → 修复后 12 绿；相关现有测试 129 passed 无回归