### PR TITLE
fix: arbitrate futures/option callback direction via the passthrough …

### DIFF
--- a/src/bigqmt_signal_trader/exec_events.py
+++ b/src/bigqmt_signal_trader/exec_events.py
@@ -63,6 +63,17 @@ OFFSET_CLOSE_YESTERDAY = 52
 _BUY_DIRECTIONS = {ENTRUST_BUY, str(ENTRUST_BUY), OFFSET_OPEN, str(OFFSET_OPEN), 23, "23", "BUY", "buy", "B"}
 _SELL_DIRECTIONS = {ENTRUST_SELL, str(ENTRUST_SELL), OFFSET_CLOSE, str(OFFSET_CLOSE), OFFSET_CLOSE_TODAY, str(OFFSET_CLOSE_TODAY), OFFSET_CLOSE_YESTERDAY, str(OFFSET_CLOSE_YESTERDAY), 24, "24", "SELL", "sell", "S"}
 
+# Futures (0-15) / ETF option (50-55) opTypes never appear in _BUY/_SELL_DIRECTIONS
+# (those hold the stock opTypes 23/24 and the direction/offset enums 48/49/51/52).
+# A futures sell-to-open row arrives as direction=49 + offset=48(开仓) + op_type=3(开空):
+# without these sets the arbiter cannot decide and falls back to offset=48, which
+# reads as BUY. Sides mirror adapters.order_bigqmt._FUTURE_BUY_SIDE and friends
+# (kept local here because order_bigqmt imports from this module).
+_FUTURES_OP_BUY = frozenset({0, 4, 5, 8, 9, 12, 13, 14})
+_FUTURES_OP_SELL = frozenset({1, 2, 3, 6, 7, 10, 11, 15})
+_ETF_OPTION_OP_BUY = frozenset({50, 53, 55})
+_ETF_OPTION_OP_SELL = frozenset({51, 52, 54})
+
 
 def order_channel(account_id):
     return ORDER_CHANNEL_TEMPLATE.format(account_id=str(account_id or ""))
@@ -204,6 +215,14 @@ def _conflict_resolve(d_val, o_val, obj):
       - Futures sell+open: direction=49(sell), offset=48(open), op_type=24(sell) → sell
       - Futures buy+close: direction=48(buy), offset=49(close), op_type=23(buy) → buy
 
+    Some terminals report futures callbacks with the stock opType domain
+    (23/24, as above); others report the futures/ETF-option opType table
+    (futures 0-15, ETF options 50-55), which _BUY/_SELL_DIRECTIONS do not
+    hold. Those opTypes arbitrate through _FUTURES_OP_BUY/_SELL and
+    _ETF_OPTION_OP_BUY/_SELL instead -- without them the arbiter falls back
+    to offset, and offset is open/close on those accounts, so a futures
+    sell-to-open (offset=48) resolved as BUY.
+
     Returns a resolved value, or None if no arbiter can decide.
     """
     op = _attr(obj, ["m_nOpType", "op_type", "order_type"])
@@ -213,6 +232,12 @@ def _conflict_resolve(d_val, o_val, obj):
             if op_int in _BUY_DIRECTIONS:
                 return d_val if _is_buy(d_val) else o_val if _is_buy(o_val) else op
             if op_int in _SELL_DIRECTIONS:
+                return d_val if _is_sell(d_val) else o_val if _is_sell(o_val) else op
+            # Futures (0-15) / ETF option (50-55) opTypes: m_nDirection reliably
+            # reflects the side for futures (48=买, 49=卖), so prefer d_val.
+            if op_int in _FUTURES_OP_BUY or op_int in _ETF_OPTION_OP_BUY:
+                return d_val if _is_buy(d_val) else o_val if _is_buy(o_val) else op
+            if op_int in _FUTURES_OP_SELL or op_int in _ETF_OPTION_OP_SELL:
                 return d_val if _is_sell(d_val) else o_val if _is_sell(o_val) else op
         except (TypeError, ValueError):
             if op in _BUY_DIRECTIONS:

--- a/tests/bigqmt_signal_trader/test_callback_direction_futures.py
+++ b/tests/bigqmt_signal_trader/test_callback_direction_futures.py
@@ -1,0 +1,125 @@
+# coding: utf-8
+"""Futures/option callback rows resolved the wrong BUY/SELL direction.
+
+``_extract_direction`` arbitrates direction/offset conflicts through
+``_conflict_resolve``, which only recognized the stock opType domain
+(23/24) plus the direction/offset enums (48/49/51/52). Some terminals
+report futures/ETF-option callbacks with the futures opType table
+(futures 0-15, ETF options 50-55) instead; on those the arbiter found
+nothing it knew and fell back to offset -- but offset is open/close on
+those accounts, so:
+
+  - futures 卖出开空 arrived as direction=49 + offset=48(开仓) + op=3
+    and resolved as BUY
+  - ETF option 买入平仓 arrived as direction=48 + offset=49(平仓) + op=53
+    and resolved as SELL
+
+This change adds the passthrough opType side sets to the arbiter (same
+sides as adapters.order_bigqmt._FUTURE_BUY_SIDE and friends, kept local
+because order_bigqmt imports from this module). Terminals that report
+the stock 23/24 domain for futures rows keep the existing behavior,
+pinned below.
+"""
+
+import os
+import sys
+import types
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.exec_events import (
+    _action_from_direction,
+    _conflict_resolve,
+    _extract_direction,
+)
+
+
+def _row(direction, offset, op_type):
+    row = types.SimpleNamespace()
+    if direction is not None:
+        row.m_nDirection = direction
+    if offset is not None:
+        row.m_nOffsetFlag = offset
+    if op_type is not None:
+        row.m_nOpType = op_type
+    return row
+
+
+def _side(direction, offset, op_type):
+    return _action_from_direction(_extract_direction(_row(direction, offset, op_type)))
+
+
+class FuturesConflictResolvedByOptype(unittest.TestCase):
+    def test_sell_to_open_no_longer_reads_buy(self):
+        # 卖出开空: direction=49, offset=48(开仓), op=3(开空) -> SELL
+        self.assertEqual(_side(49, 48, 3), "SELL")
+
+    def test_buy_to_close_no_longer_reads_sell(self):
+        # 平今空(买入动作): direction=48, offset=49(平仓), op=5 -> BUY
+        self.assertEqual(_side(48, 49, 5), "BUY")
+
+    def test_open_long_still_reads_buy(self):
+        # 开多: direction=48, offset=48(开仓), op=0 -> BUY (agree, no conflict)
+        self.assertEqual(_side(48, 48, 0), "BUY")
+
+
+class EtfOptionConflictResolvedByOptype(unittest.TestCase):
+    def test_sell_to_open_no_longer_reads_buy(self):
+        # 卖出开仓: direction=49, offset=48(开仓), op=52 -> SELL
+        self.assertEqual(_side(49, 48, 52), "SELL")
+
+    def test_buy_to_close_no_longer_reads_sell(self):
+        # 买入平仓: direction=48, offset=49(平仓), op=53 -> BUY
+        self.assertEqual(_side(48, 49, 53), "BUY")
+
+    def test_covered_open_still_reads_sell(self):
+        # 备兑开仓: direction=49, offset=48, op=54 -> SELL
+        self.assertEqual(_side(49, 48, 54), "SELL")
+
+
+class StockDomainUnchanged(unittest.TestCase):
+    def test_stock_sell_conflict_keeps_offset(self):
+        # Stock sell: direction=48, offset=49, op=24 -> SELL (existing)
+        self.assertEqual(_side(48, 49, 24), "SELL")
+
+    def test_stock_buy_agree(self):
+        self.assertEqual(_side(48, 48, 23), "BUY")
+
+    def test_futures_row_on_stock_domain_terminal_keeps_behavior(self):
+        # Terminals that report futures callbacks with op 23/24 (the live
+        # diagnosis in _conflict_resolve's docstring) arbitrate as before.
+        self.assertEqual(_side(49, 48, 24), "SELL")
+        self.assertEqual(_side(48, 49, 23), "BUY")
+
+
+class NoArbiterFallbackPinned(unittest.TestCase):
+    def test_deal_row_without_optype_still_trusts_offset(self):
+        # DEAL rows carry no m_nOpType: the arbiter has nothing to consult
+        # and offset stays the fallback. A futures sell-to-open trade row
+        # therefore still reads 48 -> BUY; documented limitation, unchanged
+        # by this fix.
+        self.assertEqual(_side(49, 48, None), "BUY")
+
+
+class ConflictResolveDirect(unittest.TestCase):
+    def test_futures_sell_side_prefers_direction(self):
+        row = _row(49, 48, 3)
+        self.assertEqual(_conflict_resolve(49, 48, row), 49)
+
+    def test_futures_buy_side_prefers_direction(self):
+        row = _row(48, 49, 5)
+        self.assertEqual(_conflict_resolve(48, 49, row), 48)
+
+    def test_etf_option_sell_side_prefers_direction(self):
+        row = _row(49, 48, 52)
+        self.assertEqual(_conflict_resolve(49, 48, row), 49)
+
+    def test_no_known_optype_falls_back_to_offset(self):
+        row = _row(49, 48, 999)
+        self.assertEqual(_conflict_resolve(49, 48, row), 48)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…opType table

Problem:
- _conflict_resolve only recognized the stock opType domain (23/24) and the direction/offset enums (48/49/51/52)
- some terminals report futures/ETF-option callbacks with the futures opType table instead (futures 0-15, ETF options 50-55); on those the arbiter could not decide and fell back to offset, which is open/close on those accounts: futures sell-to-open (direction=49 + offset=48 + op=3) resolved as BUY, ETF option buy-to-close (48 + 49 + 53) as SELL

Fix:
1. exec_events.py: add _FUTURES_OP_BUY/_SELL and _ETF_OPTION_OP_BUY/_SELL side sets (mirroring adapters.order_bigqmt._FUTURE_BUY_SIDE and friends, kept local because order_bigqmt imports from this module)
2. exec_events.py: _conflict_resolve consults them after the stock checks; futures m_nDirection reliably reflects the side, so d_val stays preferred, same shape as the stock branches
3. docstring: document that terminals differ in which opType domain futures callbacks carry, and that both now arbitrate
4. tests/bigqmt_signal_trader/test_callback_direction_futures.py: 14 cases; 6 red before the fix (the new-behavior rows), 8 green pinning existing behavior (stock rows, stock-domain futures rows, and the no-opType DEAL fallback, unchanged by design)

- exec_events.py 本地定义 _FUTURES_OP_BUY/_SELL、_ETF_OPTION_OP_BUY/_SELL（order_bigqmt 导入 exec_events，反向会循环）
- _conflict_resolve 在股票 23/24 检查后追加期货/期权 opType 仲裁；docstring 说明“不同终端期货回调的 opType 域不同”这一关键现象
- 测试 14 例：修复前 6 红（新行为）/ 8 绿（锁定既有行为，含无 opType 的 DEAL 回落）；相关现有测试 141 passed 无回归