### PR TITLE
fix: submit-time identity wins over the row's strategy-name field (#216)

### DIFF
--- a/src/bigqmt_signal_trader/exec_events.py
+++ b/src/bigqmt_signal_trader/exec_events.py
@@ -564,7 +564,14 @@ def enrich_order_identity(redis_client, account_id, event):
         identity = json.loads(raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else str(raw))
     except Exception:
         return event
-    if not event.get("strategy_name") and identity.get("strategy_name"):
+    if identity.get("strategy_name"):
+        # The row's strategy-name field carries the QMT-side strategy's
+        # registered name (the bridge process, e.g. BIGQMT_REDIS_DRYRUN), not
+        # the strategy_name the caller passed at order time (#216: an order
+        # placed with strategy_name='DaBanStrategy' reported back
+        # '大QMT桥接器'). The identity was written at submit time from the
+        # caller's own value, so it wins whenever it has a name. Rows with no
+        # identity record (hand orders, other processes) keep the row's value.
         event["strategy_name"] = str(identity.get("strategy_name") or "")
     if not event.get("stock_code") and identity.get("stock_code"):
         event["stock_code"] = str(identity.get("stock_code") or "")

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -1493,22 +1493,26 @@ class BigQmtRpcHandlers:
         )
 
     def _attribute_to_strategies(self, account_id, snapshots):
-        """Put the strategy name back on rows QMT could not name (issue #133).
+        """Put the caller's strategy name on rows this bridge submitted.
 
         Neither the ORDER nor the DEAL rows get_trade_detail_data returns carry
         m_strStrategyName -- checked by listing every attribute on a live
-        terminal. QMT filters by strategy but does not report it, which is why
-        this field read as "" for everything.
+        terminal. What the row DOES carry (m_strSource) is the QMT-side
+        strategy's registered name -- this bridge process's name, e.g.
+        BIGQMT_REDIS_DRYRUN -- not the strategy_name the caller passed at order
+        time (#216: placed as 'DaBanStrategy', reported as '大QMT桥接器').
+        #174 misread that field as "passorder's strategyName coming back".
 
         Orders this bridge submitted are remembered at submit time, keyed by
-        the user_order_id that rides out as the order remark, so those can be
-        named. Orders placed by hand in the terminal have no remark and stay
-        unnamed; there is nothing to recover for them.
+        the user_order_id that rides out as the order remark, and that record
+        is authoritative -- it WINS over the row's field whenever it has a
+        name. Rows without a remark (hand-placed orders) or without an
+        identity record (another process's orders) keep the row's value.
         """
         rows = list(snapshots or [])
-        unnamed = [row for row in rows
-                   if not str(getattr(row, "strategy_name", "") or "").strip()]
-        if not unnamed:
+        candidates = [row for row in rows
+                      if str(getattr(row, "user_order_id", "") or "").strip()]
+        if not candidates:
             return rows
         redis_client = self._identity_redis()
         if redis_client is not None:
@@ -1517,8 +1521,8 @@ class BigQmtRpcHandlers:
 
                 identities = order_identity_map(
                     redis_client, account_id,
-                    [getattr(row, "user_order_id", "") for row in unnamed])
-                for row in unnamed:
+                    [getattr(row, "user_order_id", "") for row in candidates])
+                for row in candidates:
                     identity = identities.get(
                         str(getattr(row, "user_order_id", "") or "").strip())
                     if identity and identity.get("strategy_name"):
@@ -1526,13 +1530,12 @@ class BigQmtRpcHandlers:
             except Exception:
                 pass
         # No-Redis deployments still name what THIS process submitted: the
-        # in-process journal written at submit time (issue #156).
+        # in-process journal written at submit time (issue #156). It runs
+        # after the redis store so this process's own record wins a collision.
         journal = getattr(self, "_order_identity_local", None)
         if journal:
             now = time.time()
-            for row in unnamed:
-                if str(getattr(row, "strategy_name", "") or "").strip():
-                    continue
+            for row in candidates:
                 key = (str(account_id or ""),
                        str(getattr(row, "user_order_id", "") or "").strip())
                 entry = journal.get(key)

--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -1753,9 +1753,12 @@ def _enrich_event_identity(exec_events, config, account_id, event):
 
     Both branches call this. Enriching only orders is what left
     on_stock_trade's strategy_name permanently empty.
+
+    The row's own strategy-name field is NOT authoritative (#216): QMT fills
+    it with the QMT-side strategy's registered name (this bridge process),
+    not the strategy_name the caller passed at order time. So no early return
+    on a non-empty row value -- a submit-time identity with a name WINS.
     """
-    if str(event.get("strategy_name") or "").strip():
-        return event
     name = _local_identity_strategy_name(account_id, event)
     if name:
         event["strategy_name"] = name

--- a/tests/bigqmt_signal_trader/test_exec_event_strategy_name.py
+++ b/tests/bigqmt_signal_trader/test_exec_event_strategy_name.py
@@ -117,6 +117,25 @@ class EnrichWorksOnATradeEventTest(unittest.TestCase):
 
         self.assertEqual(enriched["strategy_name"], "alpha")
 
+    def test_the_store_wins_over_the_rows_bridge_process_name(self):
+        """#216: the row's strategy-name field is the QMT-side strategy's
+        registered name (the bridge process), never the caller's. An order
+        placed with strategy_name='DaBanStrategy' reported '大QMT桥接器'.
+        The submit-time identity record must override the row."""
+        import json
+
+        class Store(object):
+            def get(self, key):
+                return json.dumps({"strategy_name": "alpha"}).encode("utf-8")
+
+        event = exec_events.normalize_trade_event(
+            _deal_obj(m_strSource="大QMT桥接器"), "acct")
+        self.assertEqual(event["strategy_name"], "大QMT桥接器")  # the row's own answer
+
+        enriched = exec_events.enrich_order_identity(Store(), "acct", event)
+
+        self.assertEqual(enriched["strategy_name"], "alpha")
+
 
 # ------------------------------------------------------- the publish path
 
@@ -264,6 +283,17 @@ class LocalJournalFallbackTest(_PublishBase):
 
         self.assertEqual(self._events()[0]["strategy_name"], "alpha")
         self.assertEqual(self._fake.enriched, [])   # redis never consulted
+
+    def test_the_journal_wins_over_the_rows_bridge_process_name(self):
+        """#216 publish-path: the row came pre-named with the bridge's own
+        process name; the journal (this process's submit-time record) knows
+        the caller's real strategy name and must override it."""
+        self._wire_journal()
+
+        strategy._publish_exec_event(
+            "trade", _deal_obj(strategyName="大QMT桥接器"), None)
+
+        self.assertEqual(self._events()[0]["strategy_name"], "alpha")
 
     def test_redis_is_the_fallback_when_the_journal_misses(self):
         """Another process's order: nothing local, so redis still answers."""

--- a/tests/bigqmt_signal_trader/test_order_identity_local.py
+++ b/tests/bigqmt_signal_trader/test_order_identity_local.py
@@ -124,15 +124,18 @@ class LocalIdentityJournalTest(unittest.TestCase):
         self.assertIn(("acct", "r%d" % (handlers._ORDER_IDENTITY_LOCAL_LIMIT + 49)),
                       handlers._order_identity_local)
 
-    def test_existing_redis_answer_is_not_clobbered_by_local(self):
+    def test_the_journal_identity_wins_over_the_rows_bridge_name(self):
+        """#216 changed the precedence: the row's strategy-name field carries
+        the QMT-side strategy's registered name (the bridge process), never
+        the caller's -- so a submit-time identity record (this journal) is the
+        authoritative one and WINS over the row's value."""
         gateway = _QueryGateway([_row(user_order_id="sig-1", strategy_name="from_redis")])
         handlers = _handlers(gateway)
         _submit(handlers, "sig-1", "from_local")
 
         rows = handlers._handle_query_orders({})
 
-        # Row already named (by Redis/terminal): local journal must not overwrite.
-        self.assertEqual(rows[0].strategy_name, "from_redis")
+        self.assertEqual(rows[0].strategy_name, "from_local")
 
 
 class FilteredQueryNamesRowsTest(unittest.TestCase):

--- a/tests/bigqmt_signal_trader/test_strategy_name_attribution.py
+++ b/tests/bigqmt_signal_trader/test_strategy_name_attribution.py
@@ -281,16 +281,29 @@ class AttributionTest(unittest.TestCase):
 
         self.assertEqual(named[0].strategy_name, "")
 
-    def test_a_row_that_already_has_a_name_is_left_alone(self):
-        rows = [Row(user_order_id="bq:abc:sig-1", strategy_name="beta")]
+    def test_the_submit_time_identity_wins_over_the_rows_name(self):
+        """#216: the row's strategy-name field carries the QMT-side strategy's
+        registered name (the bridge process, e.g. '大QMT桥接器'), not the
+        caller's strategy_name. The submit-time identity record is the
+        authoritative one and must WIN over the row's value."""
+        rows = [Row(user_order_id="bq:abc:sig-1", strategy_name="大QMT桥接器")]
+
+        named = self._handlers(self.redis)._attribute_to_strategies(ACCOUNT, rows)
+
+        self.assertEqual(named[0].strategy_name, "alpha")
+
+    def test_an_unknown_remark_keeps_the_rows_name(self):
+        """An order this bridge never submitted (no identity record) keeps
+        whatever the row says -- overriding only on a hit."""
+        rows = [Row(user_order_id="someone-elses", strategy_name="beta")]
 
         named = self._handlers(self.redis)._attribute_to_strategies(ACCOUNT, rows)
 
         self.assertEqual(named[0].strategy_name, "beta")
-        self.assertEqual(self.redis.mgets, [])
 
-    def test_all_rows_named_means_no_redis_traffic(self):
-        rows = [Row(user_order_id="bq:abc:sig-1", strategy_name="beta")]
+    def test_rows_without_remarks_mean_no_redis_traffic(self):
+        """Only remarked rows can have an identity; blank ones never ask."""
+        rows = [Row(user_order_id="", strategy_name="beta")]
 
         self._handlers(self.redis)._attribute_to_strategies(ACCOUNT, rows)
 


### PR DESCRIPTION
修复 #216（#161/#174 那条线的延续）。

# 实盘证据（2026-09-07 盘中，lemo 桥）

以 `strategy_name='probe216'` 下一笔深价单，委托事件和查询行返回的都是 `'BIGQMT_REDIS_DRYRUN'`——**QMT 侧策略自己的注册名**，不是下单时传的值。#174 当时把 `m_strSource` 读作「passorder 的 strategyName 原样回来」；在这台终端（2.1.19.0）它带的是桥进程自己的策略名。#161 当年能验证通过，是因为那时行字段是空的，身份库只在空时补全正好填上——现在行字段非空（带桥进程名），身份库永远不赢。

# 修法

下单时写入的身份记录（调用方真实 strategy_name）才是权威，**三处全部翻转为身份库优先**：

1. `exec_events.enrich_order_identity`（事件路径）：身份库有名就覆盖行字段。
2. 策略文件 `_enrich_event_identity`：去掉「行已命名就提前返回」；本进程日志簿现在会覆盖。⚠️ 策略文件改动，**需要重启策略**（reload 刷不到）。
3. `_attribute_to_strategies`（查询路径）：有 remark 的行都查身份库，身份的非空名字赢。无 remark（手工单）或无身份记录（别的进程的单）的行保持原样。

# 验证

- 三条新回归用例修复前红、修复后绿；一条钉旧优先级的用例（`test_existing_redis_answer_is_not_clobbered_by_local`）前提已过时，改写为钉新契约。
- 全量 **1751 通过，133/133 模块收集**。
- 实盘复测在部署+重启后补（见下）。

# 已知边界

成交行可能不带 remark（#51 就记过）——那种成交只能靠行字段，拿不到身份库的名字，文档级局限，未夸大覆盖。
