### PR TITLE
fix: retry all-fields K-line reads on synthesis periods with explicit fields (#219)

### DIFF
--- a/src/bigqmt_signal_trader/adapters/market_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/market_bigqmt.py
@@ -166,6 +166,31 @@ def _raw_frame_columns(field_list):
     return columns
 
 
+def _market_data_answer_empty(answer):
+    """True when no code in the answer carries a single row.
+
+    Covers both shapes get_market_data_ex can return: the raw path's
+    serialisable marker dict (records list) and the plain path's pandas
+    frames (index length). Anything unrecognised counts as an answer rather
+    than as empty -- a retry must never replace data with nothing.
+    """
+    if not isinstance(answer, dict) or not answer:
+        return True
+    for value in answer.values():
+        if isinstance(value, dict) and value.get("__bigqmt_type__") == "DataFrame":
+            if value.get("records"):
+                return False
+        elif hasattr(value, "index"):
+            try:
+                if len(value.index) > 0:
+                    return False
+            except Exception:
+                return False
+        elif value:
+            return False
+    return True
+
+
 def _raw_market_data_payload(payload, field_list, stock_list):
     if not isinstance(payload, dict):
         return payload
@@ -786,7 +811,35 @@ class BigQmtMarketDataProvider:
             )
         )
 
+    # Synthesis periods (weekly and up) where an all-fields (field_list=[])
+    # answer of zero rows is not necessarily truthful: a live terminal
+    # reported 0 rows for 1mon/1q/1hy/1y with fields=[] while the same bars
+    # read fine with an explicit OHLCV list (issue #219). [] means "all
+    # columns" to QMT, and how a build expands that for synthesized periods is
+    # not trustworthy. Retry once with the explicit K-line field list from the
+    # terminal's own reference; an empty retry still means empty.
+    _SYNTH_PERIOD_FIELD_RETRY = ("1w", "1mon", "1q", "1hy", "1y")
+    _KLINE_ALL_FIELDS = (
+        "time", "open", "high", "low", "close", "volume", "amount",
+        "settle", "openInterest", "preClose", "suspendFlag",
+    )
+
     def get_market_data_ex(self, **kwargs):
+        answer = self._get_market_data_ex_once(**kwargs)
+        fields = kwargs.get("field_list") or kwargs.get("fields")
+        period = str(kwargs.get("period") or "")
+        if (fields or period not in self._SYNTH_PERIOD_FIELD_RETRY
+                or not _market_data_answer_empty(answer)):
+            return answer
+        retry = dict(kwargs)
+        retry.pop("fields", None)
+        retry["field_list"] = list(self._KLINE_ALL_FIELDS)
+        retried = self._get_market_data_ex_once(**retry)
+        # The retry is a strict improvement only when it found rows; otherwise
+        # keep the original (empty) answer, so "no data" stays "no data".
+        return retried if not _market_data_answer_empty(retried) else answer
+
+    def _get_market_data_ex_once(self, **kwargs):
         raw_method = getattr(self.context_info, "get_market_data_ex_ori", None)
         if callable(raw_method):
             raw_data = self._call_first_supported(

--- a/tests/bigqmt_signal_trader/test_bigqmt_market_raw_bridge.py
+++ b/tests/bigqmt_signal_trader/test_bigqmt_market_raw_bridge.py
@@ -68,6 +68,119 @@ class BigQmtRawMarketBridgeTest(unittest.TestCase):
         self.assertEqual([], data["600276.SH"]["records"])
         self.assertEqual(["stime", "close"], data["600276.SH"]["columns"])
 
+
+class _PlainFrame(object):
+    """Duck-typed stand-in for the plain path's per-code DataFrame."""
+
+    def __init__(self, rows):
+        self.index = list(rows)
+
+
+class PlainMarketContext(object):
+    """No get_market_data_ex_ori -- the plain shape path, per-period answers."""
+
+    def __init__(self, empty_periods=()):
+        self.empty_periods = set(empty_periods)
+        self.calls = []
+
+    def get_market_data_ex(self, fields=None, stock_code=None, period="1d", **kwargs):
+        self.calls.append({"fields": fields, "period": period})
+        code = list(stock_code or ["000001.SZ"])[0]
+        if period in self.empty_periods:
+            return {code: _PlainFrame([])}
+        return {code: _PlainFrame([[1, 2]])}
+
+
+class SynthPeriodAllFieldsRetryTest(unittest.TestCase):
+    """#219: a terminal answered 0 rows for 1mon+ when field_list=[] while the
+    same bars read fine with an explicit field list. Retry once with the
+    explicit K-line fields; an empty retry still means empty."""
+
+    def test_empty_all_fields_synth_period_retries_with_explicit_fields(self):
+        context = RawMarketContext({"000001.SZ": []})
+        provider = BigQmtMarketDataProvider(context)
+        # First call (fields=[]) empty, second (explicit) has rows: sequence.
+        answers = [{"000001.SZ": []}, {"000001.SZ": [[1784014200000, 55.1]]}]
+        context.payload = None
+        original = context.get_market_data_ex_ori
+
+        def sequenced(*args, **kwargs):
+            context.calls.append(kwargs)
+            return answers.pop(0) if answers else {"000001.SZ": []}
+
+        context.get_market_data_ex_ori = sequenced
+
+        data = provider.get_market_data_ex(
+            field_list=[], stock_list=["000001.SZ"], period="1mon", count=10)
+
+        self.assertEqual(len(context.calls), 2)
+        self.assertEqual(context.calls[1]["fields"],
+                         list(BigQmtMarketDataProvider._KLINE_ALL_FIELDS))
+        self.assertEqual(data["000001.SZ"]["records"], [[1784014200000, 55.1]])
+        self.assertNotEqual(data["000001.SZ"]["columns"], [])
+        context.get_market_data_ex_ori = original
+
+    def test_empty_retry_keeps_the_original_empty_answer(self):
+        context = RawMarketContext({"000001.SZ": []})
+        provider = BigQmtMarketDataProvider(context)
+
+        data = provider.get_market_data_ex(
+            field_list=[], stock_list=["000001.SZ"], period="1q", count=10)
+
+        self.assertEqual(data["000001.SZ"]["records"], [])
+        self.assertEqual(len(context.calls), 2, "exactly one retry")
+
+    def test_explicit_fields_never_retry(self):
+        context = RawMarketContext({"000001.SZ": []})
+        provider = BigQmtMarketDataProvider(context)
+
+        provider.get_market_data_ex(
+            field_list=["close"], stock_list=["000001.SZ"], period="1mon", count=10)
+
+        self.assertEqual(len(context.calls), 1)
+
+    def test_daily_period_never_retries(self):
+        context = RawMarketContext({"000001.SZ": []})
+        provider = BigQmtMarketDataProvider(context)
+
+        provider.get_market_data_ex(
+            field_list=[], stock_list=["000001.SZ"], period="1d", count=10)
+
+        self.assertEqual(len(context.calls), 1)
+
+    def test_a_nonempty_first_answer_never_retries(self):
+        rows = [[1784014200000, 55.1]]
+        context = RawMarketContext({"000001.SZ": rows})
+        provider = BigQmtMarketDataProvider(context)
+
+        data = provider.get_market_data_ex(
+            field_list=[], stock_list=["000001.SZ"], period="1mon", count=10)
+
+        self.assertEqual(len(context.calls), 1)
+        self.assertEqual(data["000001.SZ"]["records"], rows)
+
+    def test_plain_shape_path_retries_too(self):
+        context = PlainMarketContext(empty_periods=("1mon",))
+        provider = BigQmtMarketDataProvider(context)
+
+        # fields=[] empties only when the period is empty AND fields are empty
+        # on this fake; emulate "all-fields broken, explicit fine" by keying
+        # on the fields actually passed.
+        def by_fields(fields=None, stock_code=None, period="1d", **kwargs):
+            context.calls.append({"fields": fields, "period": period})
+            code = list(stock_code or ["000001.SZ"])[0]
+            if period == "1mon" and not fields:
+                return {code: _PlainFrame([])}
+            return {code: _PlainFrame([[1, 2]])}
+
+        context.get_market_data_ex = by_fields
+        data = provider.get_market_data_ex(
+            field_list=[], stock_list=["000001.SZ"], period="1mon", count=10)
+
+        self.assertEqual(len(context.calls), 2)
+        self.assertEqual(context.calls[1]["fields"],
+                         list(BigQmtMarketDataProvider._KLINE_ALL_FIELDS))
+
     def test_trading_date_context_fallback_maps_market_to_representative_stock(self):
         """ContextInfo 路径必须把市场代码转换为其要求的证券代码。"""
         class CalendarContext:


### PR DESCRIPTION
修复 #219。

# 问题

报告方终端（两端 0.3.24）：`get_market_data_ex` 对 `1mon/1q/1hy/1y` 在**空 field_list**（"全部列"，走 RPC）下返回 0 行；显式 OHLCV（走 FormulaServer 直连）有数据；1w/1d 两路都正常。`qmt.py kline` 默认不传 `--fields`，把这条路径的空应答渲染成「K 线数据为空」——把「路径丢数」误报成「没有这个周期」。

# 定位

- 空 field_list 按设计必走 RPC（FormulaServer 对四个日线元数据列只会回 NaN，有注释钉着），所以差异落在服务端对「全列 + 合成周期」的处理。
- 维护者终端（国金 2.1.19.0）**复现不了**：同代码 1mon RPC 全列 10 行。说明「[] 为全部」在合成周期上的展开行为因终端/版本而异——不可信赖。
- 顺带发现 raw（`get_market_data_ex_ori`）路径在 field_list=[] 时会给载荷配**空 columns**（`_raw_frame_columns`），客户端重建的 DataFrame 是「有行无列」的畸形。

# 修法

`get_market_data_ex`：当且仅当 ① 周期是 1w/1mon/1q/1hy/1y ② 没给 field_list ③ 应答零行 —— 用终端官方参考里的显式 K 线字段表（time/open/high/low/close/volume/amount/settle/openInterest/preClose/suspendFlag）重试一次。重试也为空就维持原答案（空就是空）；显式字段和日线的调用永不重试。raw 路径重试后 columns 也顺带填上了。

# 验证

- 6 条新用例：重试触发/恰好一次/显式字段不重试/日线不重试/首答非空不重试/plain 路径同样生效；3 条对修复前代码为红。
- 全量 **1757 通过，133/133 模块**。
- **维护者终端无回归**（部署 + reload 后实测）：1mon RPC/ALL 10 行、1q 10、1hy 9、1y 5，与修复前一致——重试只在出问题的地方触发。

# 未验证项（如实）

出问题的终端不在这边。修复只在「曾经为空」的地方触发，但「该终端 1mon 全列现在返回真实行数」需要报告方用 main（或下个发布版）重跑他们的探针确认。issue 里附了逐字段探测脚本用来定位是哪一列展开坏的（如果他们想知道根因而不仅是修好）。
