### PR TITLE
fix: get_divid_factors downloads the daily window itself before giving up (#222)

### DIFF
--- a/src/bigqmt_signal_trader/adapters/market_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/market_bigqmt.py
@@ -919,6 +919,26 @@ class BigQmtMarketDataProvider:
             return None
         return func(stock_code, start_time, end_time)
 
+    def _download_daily_window(self, stock_code, start_time, end_time):
+        """One terminal-side daily-bars download for a window that scanned
+        empty (#222).
+
+        Uses the terminal's own downloader (the injected
+        ``download_history_data`` / ``down_history_data`` global), never the
+        embedded xtdata SDK -- that one has no reachable data service in the
+        full terminal. True when a downloader answered; False when there is no
+        channel or it raised -- the caller keeps the original honest error.
+        """
+        download = (self.qmt_api.get("download_history_data")
+                    or self.qmt_api.get("down_history_data"))
+        if not callable(download):
+            return False
+        try:
+            download(stock_code, "1d", start_time, end_time)
+        except Exception:
+            return False
+        return True
+
     def _divid_candidate_days(self, stock_code, start_time, end_time):
         """Days in the window that look like ex-dividend days.
 
@@ -958,22 +978,46 @@ class BigQmtMarketDataProvider:
         tell, and saying so is the only honest answer.
         """
         self._divid_scan_rows = 0
+        # Set before the scan so the error can say what was tried (#222).
+        self._divid_download_note = (
+            ". Download the daily history first (download_history_data), or "
+            "ask one date at a time")
         try:
             candidates = self._divid_candidate_days(stock_code, start_time, end_time)
         except Exception:
             candidates = []
+        if self._divid_scan_rows < 2 and self._download_daily_window(
+                stock_code, start_time, end_time):
+            # #222: the bridge knows what is missing, so it fetches it rather
+            # than telling the caller to. The downloader may answer before the
+            # bars are actually local, so rescan a few times on a short leash
+            # before concluding anything.
+            self._divid_download_note = (
+                ". The bridge downloaded the daily window itself "
+                "(download_history_data) and the terminal still returned %d "
+                "daily bar(s)" )
+            for _attempt in range(3):
+                try:
+                    candidates = self._divid_candidate_days(
+                        stock_code, start_time, end_time)
+                except Exception:
+                    candidates = []
+                if self._divid_scan_rows >= 2:
+                    break
+                time.sleep(1.0)
+            self._divid_download_note %= self._divid_scan_rows
         if self._divid_scan_rows < 2:
             raise RuntimeError(
                 "get_divid_factors(%r, %s, %s) cannot answer a range here: big "
                 "QMT's ContextInfo takes only (code, single date), so the range "
                 "is expanded by scanning daily bars for ex-dividend days -- and "
                 "this terminal returned %d daily bar(s) for that window, too "
-                "few to compare even one preClose against the previous close. "
-                "Download "
-                "the daily history first (download_history_data), or ask one "
-                "date at a time. Returning {} would have been indistinguishable "
-                "from 'no dividends in this range' (issue #165)."
-                % (stock_code, start_time, end_time, self._divid_scan_rows))
+                "few to compare even one preClose against the previous close"
+                "%s. Returning {} would have been indistinguishable from 'no "
+                "dividends in this range' (issue #165)."
+                % (stock_code, start_time, end_time, self._divid_scan_rows,
+                   self._divid_download_note))
+        merged = {}
         merged = {}
         for day in candidates[:self._DIVID_MAX_PROBES]:
             try:

--- a/tests/bigqmt_signal_trader/test_divid_factors_range.py
+++ b/tests/bigqmt_signal_trader/test_divid_factors_range.py
@@ -199,6 +199,66 @@ class PrefersARealRangeWhenOneExistsTest(unittest.TestCase):
         self.assertEqual(context.calls, [], "context should not be touched")
 
 
+class MissingDailyBarsSelfHealTest(unittest.TestCase):
+    """#222: with <2 daily bars the bridge downloads the window itself, then
+    rescans; only a STILL-short scan raises. The reporter's loop had daily
+    bars in their own DuckDB but none on the terminal, so "the library already
+    has them" never helped -- the scan reads the terminal's local bars.
+    """
+
+    def _provider_with_download(self, bars_before, bars_after):
+        provider = _provider(Context({"20260612": {"x": DIVIDEND}}), bars=bars_before)
+        calls = []
+
+        def fake_download(stock_code, period, start_time, end_time):
+            calls.append((stock_code, period, start_time, end_time))
+            # The terminal now has the daily bars.
+            provider.get_market_data_ex = (
+                lambda **kw: {kw["stock_list"][0]: bars_after})
+            return True
+
+        provider.qmt_api = {"download_history_data": fake_download}
+        return provider, calls
+
+    def test_it_downloads_then_rescans_instead_of_raising(self):
+        provider, calls = self._provider_with_download([], BARS)
+
+        answer = provider.get_divid_factors("600036.SH", "20260401", "20260904")
+
+        self.assertEqual(calls, [("600036.SH", "1d", "20260401", "20260904")])
+        self.assertIn("x", answer)   # the event the empty scan would have lost
+
+    def test_still_short_after_the_download_raises_with_the_honest_note(self):
+        provider, calls = self._provider_with_download([], [])
+
+        with self.assertRaises(RuntimeError) as caught:
+            provider.get_divid_factors("600036.SH", "20260401", "20260904")
+
+        self.assertEqual(len(calls), 1)
+        message = " ".join(str(caught.exception).split())
+        self.assertIn("The bridge downloaded the daily window itself", message)
+        self.assertIn("#165", message)
+
+    def test_a_failing_download_keeps_the_original_error(self):
+        provider = _provider(Context(), bars=[])
+        provider.qmt_api = {
+            "download_history_data": lambda *a: (_ for _ in ()).throw(OSError("down"))}
+
+        with self.assertRaises(RuntimeError) as caught:
+            provider.get_divid_factors("600036.SH", "20260401", "20260904")
+
+        self.assertIn("Download the daily history first", str(caught.exception))
+
+    def test_no_download_channel_raises_the_original_error(self):
+        provider = _provider(Context(), bars=[])
+        provider.qmt_api = {}
+
+        with self.assertRaises(RuntimeError) as caught:
+            provider.get_divid_factors("600036.SH", "20260401", "20260904")
+
+        self.assertIn("Download the daily history first", str(caught.exception))
+
+
 class NoDailyBarsMustNotLookEmptyTest(unittest.TestCase):
     """The failure this issue is about, reintroduced in miniature if we let it.
 


### PR DESCRIPTION
修复 #222（#165 后续，@yucejade 的报告）。

# 问题

`get_divid_factors(code, start, end)` 的区间展开要扫**终端本地**日线找昨收跳变（#165 的正确机制）。终端窗口内日线不足 2 根时直接 `RuntimeError("Download the daily history first")`——把自救推给了调用方。而调用方 DuckDB 里日线是齐的：库越齐 → 增量下载越跳过 → 终端越没数 → 越容易撞 0 根 → 整只票因子缺失。

# 修法

桥既然知道缺什么就自己下：扫描不足 2 根时，调**终端自己的下载器**（注入的 `download_history_data` / `down_history_data` 全局——不是内嵌 xtdata SDK，那个在大 QMT 里没有可达数据服务）下一截日线，然后短缰绳重扫几次（下载器应答和数据落本地之间可能有空窗），仍不足才抛。#165 的底线不动：抛错保留，因为静默 `{}` 和「这段没除权」分不开。报错文案现在说清是哪种——没有下载通道，还是下过但还是缺。

# 验证

- 4 条新用例（下载后重扫出数 / 下过仍缺才抛且措辞诚实 / 下载失败回落原措辞 / 无通道回落原措辞），2 条对修复前代码为红
- 全量 **1761 通过，133/133 模块**
- 维护者终端实测：下载 RPC 0.3s 应答、数据立即可读；既有区间查询无回归（000001.SZ 5 个事件不变）

# 未验证项

自救路径只在「旧代码会抛错」的地方触发——报告方终端（那些终端真缺日线的票）重跑盘前同步才能确认闭环。issue 保持开放等确认。
