### PR TITLE
增加批量取消订单操作

### DIFF
--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -115,6 +115,7 @@ ORDER_METHODS = {
     "submit_order",
     "submit_orders_batch",
     "cancel_order",
+    "cancel_orders_batch",
     # Raw native-passorder passthrough (route 2). Gated behind
     # allow_order_methods like every other write, and deferred to the adjust
     # thread by virtue of not being in READ_METHODS.
@@ -208,6 +209,7 @@ METHOD_ALIASES = {
     "order_stock_batch": "submit_orders_batch",
     "cancel_order_stock": "cancel_order",
     "cancel_order_stock_sysid": "cancel_order",
+    "cancel_order_stock_batch": "cancel_orders_batch",
 }
 
 BUY_ORDER_TYPES = {"23", "STOCK_BUY", "BUY", "B"}
@@ -2675,6 +2677,49 @@ class BigQmtRpcHandlers:
         else:
             self._pending_settlement = settlement
         return result
+
+    def _handle_cancel_orders_batch(self, params):
+        """Cancel N orders in one RPC.
+
+        Settlement lookups are skipped (same reason as submit_orders_batch:
+        get_trade_detail_data is empty off the adjust thread). The cancel
+        callback on the client confirms the outcome asynchronously.
+        """
+        if self.order_gateway is None:
+            raise RuntimeError("order_gateway is not configured")
+        items = params.get("items") or []
+        if not isinstance(items, list) or not items:
+            raise ValueError("items must be a non-empty list")
+        if len(items) > 500:
+            raise ValueError("items exceeds batch limit 500")
+        results = []
+        for index, item in enumerate(items):
+            item = dict(item or {})
+            account_id = item.get("account_id") or self._request_account_id(params)
+            order_sys_id = str(
+                item.get("order_sysid")
+                or item.get("order_sys_id")
+                or item.get("order_id")
+                or ""
+            )
+            market = str(item.get("market") or "")
+            entry = {"index": index, "success": False}
+            if not order_sys_id:
+                entry["error"] = "order_sysid is required"
+                results.append(entry)
+                continue
+            order_ref = OrderRef(
+                order_sys_id=order_sys_id,
+                user_order_id=str(item.get("user_order_id") or ""),
+            )
+            try:
+                result = self.order_gateway.cancel(order_ref, account_id=account_id)
+                entry["success"] = bool(getattr(result, "success", result))
+                entry["message"] = str(getattr(result, "message", "") or "")
+            except Exception as exc:
+                entry["error"] = "%s: %s" % (type(exc).__name__, exc)
+            results.append(entry)
+        return results
 
     def _settle_cancel_from_status(self, settlement, status, order_sys_id, final):
         """One status answer, from the watch table or the snapshot row."""

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -2826,6 +2826,13 @@ class BigQmtXtTrader:
         # order id -- never holds up the next submit (issue #181).
         self._async_callback_queue = _queue.Queue()
         self._async_callback_thread = None
+        # Async cancel submission — same worker-queue pattern as async orders.
+        # cancel_order_stock_async used to call the blocking RPC inline, which
+        # made 15 cancels take ~30s.  Now the cancel runs on a worker thread
+        # and batches a backlog into one RPC.
+        self._async_cancel_queue = _queue.Queue()
+        self._async_cancel_thread = None
+        # Reuses _async_order_lock for start-up serialisation.
         # int -> 合同编号 for ids handed out as OrderId (issue #113).
         self._order_sys_ids = _OrderedDict()
         # on_account_status used to report a hardcoded "STOCK" even for a
@@ -3799,6 +3806,188 @@ class BigQmtXtTrader:
             pass
 
     # ------------------------------------------------------------------
+    # Async cancel — worker-queue pattern mirroring async orders.
+    # cancel_order_stock_async used to block on the RPC for each cancel;
+    # now it enqueues and returns immediately.  The worker drains the
+    # queue and batches a backlog into one cancel_orders_batch RPC.
+    # ------------------------------------------------------------------
+
+    def _async_cancel_worker(self):
+        """Drain queued async cancels; batches when backlog allows."""
+        while True:
+            job = self._async_cancel_queue.get()
+            if job is None:
+                self._async_cancel_queue.task_done()
+                return
+            jobs = [job]
+            stopping = False
+            while len(jobs) < self.ASYNC_CANCEL_BATCH_MAX:
+                try:
+                    extra = self._async_cancel_queue.get_nowait()
+                except _queue.Empty:
+                    break
+                if extra is None:
+                    stopping = True
+                    self._async_cancel_queue.task_done()
+                    break
+                jobs.append(extra)
+            try:
+                self._submit_async_cancel_jobs(jobs)
+            except Exception:
+                log.exception("async cancel submit failed for %d job(s)", len(jobs))
+            finally:
+                for _ in jobs:
+                    self._async_cancel_queue.task_done()
+            if stopping:
+                return
+
+    def _ensure_async_cancel_worker(self):
+        with self._async_order_lock:
+            if self._async_callback_thread is None or not self._async_callback_thread.is_alive():
+                self._async_callback_thread = threading.Thread(
+                    target=self._async_callback_worker,
+                    name="bigqmt-async-callback", daemon=True,
+                )
+                self._async_callback_thread.start()
+            if self._async_cancel_thread is not None and self._async_cancel_thread.is_alive():
+                return
+            thread = threading.Thread(
+                target=self._async_cancel_worker,
+                name="bigqmt-async-cancel", daemon=True,
+            )
+            self._async_cancel_thread = thread
+            thread.start()
+
+    def _submit_async_cancel_jobs(self, jobs):
+        """Submit cancels one-at-a-time or batched by account."""
+        if len(jobs) < self.ASYNC_CANCEL_BATCH_MIN:
+            self._submit_async_cancel_single(jobs[0])
+            return
+        groups = {}
+        for job in jobs:
+            seq, args, kwargs = job
+            account_id = _account_id(args[0], self.client.account_id)
+            groups.setdefault(account_id, []).append(job)
+        for account_id, group in groups.items():
+            if len(group) < self.ASYNC_CANCEL_BATCH_MIN:
+                for job in group:
+                    self._submit_async_cancel_single(job)
+            else:
+                self._submit_async_cancel_batch(account_id, group)
+
+    def _submit_async_cancel_single(self, job):
+        """One cancel on the worker thread; enqueue its callback."""
+        seq, args, kwargs = job
+        account = args[0]
+        order_id = args[1] if len(args) > 1 else kwargs.get("order_id", "")
+        market = args[2] if len(args) > 2 else kwargs.get("market", "")
+        account_id = _account_id(account, self.client.account_id)
+        try:
+            data = self.client.call(
+                "cancel_order_stock_sysid",
+                {
+                    "account_id": account_id,
+                    "market": market,
+                    "order_sysid": self._resolve_order_sys_id(order_id),
+                },
+                account_id=account_id,
+            ) or {}
+            ok = bool(data.get("success", data))
+        except Exception as exc:
+            self._enqueue_async_outcome({
+                "kind": "cancel_error", "seq": seq,
+                "order_id": order_id, "market": market,
+                "error_id": getattr(exc, "errno", 0),
+                "error_msg": str(exc),
+            })
+            return
+        self._enqueue_async_outcome({
+            "kind": "cancel_response", "seq": seq,
+            "order_id": order_id, "market": market,
+            "success": ok,
+        })
+
+    def _submit_async_cancel_batch(self, account_id, group):
+        """N cancels in one RPC; one callback per item."""
+        payload = []
+        for seq, args, kwargs in group:
+            order_id = args[1] if len(args) > 1 else kwargs.get("order_id", "")
+            market = args[2] if len(args) > 2 else kwargs.get("market", "")
+            payload.append({
+                "account_id": account_id,
+                "order_sysid": self._resolve_order_sys_id(order_id),
+                "market": market,
+            })
+        try:
+            results = self.client.call(
+                "cancel_order_stock_batch",
+                {"account_id": account_id, "items": payload},
+                account_id=account_id,
+            ) or []
+        except Exception as exc:
+            for seq, args, kwargs in group:
+                order_id = args[1] if len(args) > 1 else kwargs.get("order_id", "")
+                market = args[2] if len(args) > 2 else kwargs.get("market", "")
+                self._enqueue_async_outcome({
+                    "kind": "cancel_error", "seq": seq,
+                    "order_id": order_id, "market": market,
+                    "error_id": -1,
+                    "error_msg": "cancel batch failed: %s: %s"
+                                 % (exc.__class__.__name__, exc),
+                })
+            return
+        by_index = {}
+        for position, entry in enumerate(results):
+            if isinstance(entry, dict):
+                by_index[int(entry.get("index", position))] = entry
+        for index, (seq, args, kwargs) in enumerate(group):
+            order_id = args[1] if len(args) > 1 else kwargs.get("order_id", "")
+            market = args[2] if len(args) > 2 else kwargs.get("market", "")
+            entry = by_index.get(index) or {}
+            if entry.get("success", False):
+                self._enqueue_async_outcome({
+                    "kind": "cancel_response", "seq": seq,
+                    "order_id": order_id, "market": market,
+                    "success": True,
+                })
+            else:
+                self._enqueue_async_outcome({
+                    "kind": "cancel_error", "seq": seq,
+                    "order_id": order_id, "market": market,
+                    "error_id": int(entry.get("code") or -1),
+                    "error_msg": str(entry.get("error")
+                                     or entry.get("message")
+                                     or "cancel batch item failed"),
+                })
+
+    def cancel_order_stock_batch(self, account, cancels, timeout_seconds=None):
+        """Cancel N orders in one RPC.
+
+        Each item in *cancels* is a dict with ``order_sysid`` (or
+        ``order_sys_id`` / ``order_id``) and optional ``market``.
+        Returns a list of per-item result dicts.
+        """
+        account_id = _account_id(account, self.client.account_id)
+        payload = []
+        for item in cancels or []:
+            entry = dict(item or {})
+            entry.setdefault("account_id", account_id)
+            payload.append(entry)
+        params = {"account_id": account_id, "items": payload}
+        if timeout_seconds is None:
+            timeout_seconds = max(
+                float(getattr(self.client, "timeout_seconds",
+                              DEFAULT_RPC_TIMEOUT_SECONDS)),
+                2.0 + 0.5 * len(payload),
+            )
+        return self.client.call(
+            "cancel_order_stock_batch",
+            params,
+            account_id=account_id,
+            timeout_seconds=timeout_seconds,
+        ) or []
+
+    # ------------------------------------------------------------------
     # issue #51 A: 同一笔委托的 async_response 必须先于它的 order/trade 到达。
     #
     # 两条回调走的是不同线程和不同通道: async_response 在异步下单的工作线程上
@@ -3825,6 +4014,11 @@ class BigQmtXtTrader:
     # 在途 response 触发回调的宽限（issue #156）。
     ASYNC_EXIT_DRAIN_SECONDS = 5.0
     ASYNC_EXIT_CALLBACK_GRACE_SECONDS = 3.0
+    # Async cancel: same queue-and-batch pattern as async orders (issue #50
+    # applied to cancel_order_stock_async).  A batch of N cancels in one RPC
+    # instead of N round trips: 15 cancels drop from ~30s to ~2s.
+    ASYNC_CANCEL_BATCH_MIN = 2
+    ASYNC_CANCEL_BATCH_MAX = 500
 
     def _order_barrier(self):
         barrier = getattr(self, "_async_barrier", None)
@@ -4122,6 +4316,10 @@ class BigQmtXtTrader:
         the #51 contract -- a委托's async_response before its held order/trade
         events -- is unchanged from when everything ran on one thread.
         """
+        kind = unit.get("kind", "")
+        if kind in ("cancel_response", "cancel_error"):
+            self._fire_async_cancel_outcome(unit)
+            return
         callback = self.callback
         seq = unit["seq"]
         remark = unit["remark"]
@@ -4181,6 +4379,44 @@ class BigQmtXtTrader:
             # response/error 已触发 -> 放行这笔委托暂存的 order/trade (issue #51)。
             self._release_order_barrier(remark, seq)
 
+    def _fire_async_cancel_outcome(self, unit):
+        """Fire on_cancel_order_stock_async_response / on_cancel_error."""
+        callback = self.callback
+        seq = unit["seq"]
+        order_id = unit.get("order_id", "")
+        try:
+            if unit["kind"] == "cancel_error":
+                if callback is not None:
+                    callback.on_cancel_error(
+                        CompatObject(
+                            error_id=unit["error_id"],
+                            error_msg=unit["error_msg"],
+                            order_sysid=str(order_id or ""),
+                            order_sys_id=str(order_id or ""),
+                            order_id=self._order_object_id(order_id),
+                            stock_code="",
+                        )
+                    )
+            elif callback is not None:
+                ok = unit.get("success", False)
+                callback.on_cancel_order_stock_async_response(
+                    CompatObject(
+                        account_id=self.client.account_id,
+                        seq=seq,
+                        success=bool(ok),
+                        cancel_result=0 if ok else -1,
+                        error_msg="" if ok else "cancel_order_stock rejected by server",
+                        order_sysid=str(order_id or ""),
+                        order_sys_id=str(order_id or ""),
+                        order_id=self._order_object_id(order_id),
+                    ),
+                )
+        except Exception:
+            log.exception(
+                "user callback failed: async cancel outcome seq=%s kind=%s",
+                seq, unit.get("kind"),
+            )
+
     def order_stock_async(self, *args, **kwargs):
         """Queue an order and return its seq immediately (MiniQMT semantics).
 
@@ -4217,7 +4453,8 @@ class BigQmtXtTrader:
         not merely the drained queues.
         """
         deadline = time.time() + float(timeout)
-        for name in ("_async_order_queue", "_async_callback_queue"):
+        for name in ("_async_order_queue", "_async_cancel_queue",
+                      "_async_callback_queue"):
             queue_obj = getattr(self, name, None)
             if queue_obj is None:
                 continue
@@ -4652,94 +4889,30 @@ class BigQmtXtTrader:
         return self._async_query(self.query_appointment_info, account, callback)
 
     def cancel_order_stock_async(self, account, order_id):
-        # MiniQMT: returns seq, result comes back via on_cancel_order_stock_async_response.
+        """Queue a cancel and return its seq immediately (non-blocking).
+
+        Used to call cancel_order_stock inline, blocking for the full RPC
+        round trip per cancel.  15 cancels serialised at ~2s each = 30s.
+        Now the cancel runs on a worker thread and a backlog is batched
+        into one RPC (cancel_orders_batch), so 15 cancels take ~2s total.
+
+        The outcome arrives through on_cancel_order_stock_async_response
+        or on_cancel_error on the callback worker thread.
+        """
         seq = self._next_async_seq()
-        try:
-            # 0 == success now (MiniQMT contract, issue #113), so a bare
-            # truthiness test on the return would read backwards.
-            ok = self.cancel_order_stock(account, order_id) == 0
-        except Exception as exc:
-            callback = self.callback
-            if callback is not None:
-                try:
-                    callback.on_cancel_error(
-                        CompatObject(
-                            error_id=getattr(exc, "errno", 0),
-                            error_msg=str(exc),
-                            order_sysid=str(order_id or ""),
-                            order_sys_id=str(order_id or ""),
-                            order_id=self._order_object_id(order_id),
-                            stock_code="",
-                        )
-                    )
-                except Exception:
-                    log.exception("user callback failed: on_cancel_error")
-            return seq
-        callback = self.callback
-        if callback is not None:
-            try:
-                callback.on_cancel_order_stock_async_response(
-                    CompatObject(
-                        account_id=self.client.account_id,
-                        seq=seq,
-                        success=bool(ok),
-                        # MiniQMT XtCancelOrderResponse 契约: cancel_result=0 成功,
-                        # 失败时给出非零错误码和可读 error_msg。
-                        cancel_result=0 if ok else -1,
-                        error_msg="" if ok else "cancel_order_stock rejected by server",
-                        order_sysid=str(order_id or ""),
-                        order_sys_id=str(order_id or ""),
-                        order_id=self._order_object_id(order_id),
-                    ),
-                )
-            except Exception:
-                log.exception(
-                    "user callback failed: on_cancel_order_stock_async_response seq=%s", seq
-                )
+        self._ensure_async_cancel_worker()
+        self._register_exit_drain()
+        self._async_cancel_queue.put((seq, (account, order_id), {}))
         return seq
 
     def cancel_order_stock_sysid_async(self, account, market, order_sysid):
+        """Queue a cancel-by-sysid and return its seq immediately."""
         seq = self._next_async_seq()
-        try:
-            ok = self.cancel_order_stock_sysid(account, market, order_sysid) == 0
-        except Exception as exc:
-            callback = self.callback
-            if callback is not None:
-                try:
-                    callback.on_cancel_error(
-                        CompatObject(
-                            error_id=getattr(exc, "errno", 0),
-                            error_msg=str(exc),
-                            order_sysid=str(order_sysid or ""),
-                            order_sys_id=str(order_sysid or ""),
-                            order_id=self._order_object_id(order_sysid),
-                            stock_code="",
-                        )
-                    )
-                except Exception:
-                    log.exception("user callback failed: on_cancel_error")
-            return seq
-        callback = self.callback
-        if callback is not None:
-            try:
-                callback.on_cancel_order_stock_async_response(
-                    CompatObject(
-                        account_id=self.client.account_id,
-                        seq=seq,
-                        success=bool(ok),
-                        # MiniQMT XtCancelOrderResponse 契约: cancel_result=0 成功,
-                        # 失败时给出非零错误码和可读 error_msg。
-                        cancel_result=0 if ok else -1,
-                        error_msg="" if ok else "cancel_order_stock rejected by server",
-                        order_sysid=str(order_sysid or ""),
-                        order_sys_id=str(order_sysid or ""),
-                        order_id=self._order_object_id(order_sysid),
-                    ),
-                )
-            except Exception:
-                log.exception(
-                    "user callback failed: on_cancel_order_stock_async_response seq=%s", seq
-                )
+        self._ensure_async_cancel_worker()
+        self._register_exit_drain()
+        self._async_cancel_queue.put(
+            (seq, (account, order_sysid, market), {})
+        )
         return seq
 
     def set_relaxed_response_order_enabled(self, enabled=True):

--- a/tests/bigqmt_signal_trader/test_exec_events.py
+++ b/tests/bigqmt_signal_trader/test_exec_events.py
@@ -820,18 +820,16 @@ class ExecEventsClientDispatchTest(unittest.TestCase):
 
     def test_cancel_order_stock_async_fires_response(self):
         trader, cb = self._trader()
-        original = trader.cancel_order_stock_sysid
+        trader.client.account_id = "acct"
 
-        def fake_cancel(account, market, sysid):
-            return 0        # MiniQMT: 0 == success (issue #113)
+        def fake_call(method, params=None, account_id=None, timeout_seconds=None):
+            return {"success": True}
 
-        trader.cancel_order_stock_sysid = fake_cancel
-        try:
-            seq = trader.cancel_order_stock_sysid_async("acct", "SH", "sys-1")
-        finally:
-            trader.cancel_order_stock_sysid = original
+        trader.client.call = fake_call
+        seq = trader.cancel_order_stock_sysid_async("acct", "SH", "sys-1")
 
         self.assertGreater(seq, 0)
+        self.assertTrue(trader.wait_async_orders(timeout=5.0))
         self.assertEqual(len(cb.cancel_async_responses), 1)
         resp = cb.cancel_async_responses[0]
         self.assertTrue(resp.success)

--- a/tests/bigqmt_signal_trader/test_xtquant_compat_contract.py
+++ b/tests/bigqmt_signal_trader/test_xtquant_compat_contract.py
@@ -193,6 +193,7 @@ class CallbackContractTest(unittest.TestCase):
         client = _CancelFakeClient(cancel_exc=RuntimeError("boom"))
         trader = self._trader(cb, client)
         trader.cancel_order_stock_async("acct", "sys-9")
+        trader.wait_async_orders(timeout=5.0)
         self.assertEqual(len(cb.cancel_errors), 1)
         self.assertEqual(str(cb.cancel_errors[0].order_id), "sys-9")
 
@@ -201,6 +202,7 @@ class CallbackContractTest(unittest.TestCase):
         client = _CancelFakeClient(cancel_result={"success": True})
         trader = self._trader(cb, client)
         trader.cancel_order_stock_async("acct", "sys-9")
+        trader.wait_async_orders(timeout=5.0)
         self.assertEqual(len(cb.cancel_responses), 1)
         resp = cb.cancel_responses[0]
         self.assertEqual(resp.cancel_result, 0)
@@ -212,6 +214,7 @@ class CallbackContractTest(unittest.TestCase):
         client = _CancelFakeClient(cancel_result={"success": False})
         trader = self._trader(cb, client)
         trader.cancel_order_stock_async("acct", "sys-9")
+        trader.wait_async_orders(timeout=5.0)
         self.assertEqual(len(cb.cancel_responses), 1)
         resp = cb.cancel_responses[0]
         self.assertNotEqual(resp.cancel_result, 0)


### PR DESCRIPTION
参照order_stock_async新增了cancel_order_stock_async函数可以实现异步撤单，也是通过队列Queue的方式实现的，经实盘测试不用等3秒，用的是国产模型需要您好好review。
<img width="740" height="851" alt="a8077fbf-226f-4e3a-a487-e71bb406c9f6" src="https://github.com/user-attachments/assets/63caea67-7217-472b-8651-3a0707860b47" />
