### PR TITLE
fix: cancel batch answers carry accepted/confirmed, never claim rejection (#224 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/) 和 [语义化版本](https://semver.org/)。
 
 
+## [未发布]
+
+### 新增
+
+- **异步撤单与批量撤单**（#224，贡献者 @shihaibi）：`cancel_order_stock_async` / `cancel_order_stock_sysid_async` 从内联阻塞改为队列异步（复用异步下单的 worker + 回调分发线程），积压按账户分组成一次 `cancel_order_stock_batch` RPC（单项上限 500，超时随 N 缩放）。`cancel_order_stock_batch(account, cancels)` 同步批量接口同批新增，每项应答带 `accepted`/`confirmed`。**行为变化**：`cancel_order_stock_async` 的回调不再在返回前内联触发，改为回调线程异步到达。
+
+### 修复
+
+- **批量撤单应答不再复述原生返回值当结论**（#224 跟修）：原生 cancel 返回值两个方向都会说谎（#148 假失败 / #151 假成功），批量逐项应答现在区分 `accepted`（网关已受理）与 `confirmed`（恒 False——此路径不读回确认，撤单确认看委托状态推送 54 或查询）；失败文案不再写「rejected」，改为明说「未被确认，单子可能仍会撤掉，以状态推送/查询为准」。批量超时/断连不重提（#195 的撤单侧镜像）；服务端明确拒绝或返回空才回退逐笔。`on_cancel_error` 回调补上 `seq`（此前无法关联是哪笔）。
+
 ## [0.3.26] - 2026-09-07
 
 ### 修复

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -2703,7 +2703,17 @@ class BigQmtRpcHandlers:
                 or ""
             )
             market = str(item.get("market") or "")
-            entry = {"index": index, "success": False}
+            # accepted/confirmed mirror the submit batch's vocabulary: the
+            # native cancel return answers "the request went out", not "the
+            # order is cancelled" -- and it lies in BOTH directions live
+            # (#148: false while the order was cancelled 67ms later; #151:
+            # true for an order that did not exist). The single-cancel path
+            # settles against the order snapshot; this batch path skips that
+            # (it is the latency the batch exists to avoid), so nothing here
+            # may claim "cancelled". The confirmation is the order-status push
+            # (54) or a query read-back.
+            entry = {"index": index, "success": False,
+                     "accepted": False, "confirmed": False}
             if not order_sys_id:
                 entry["error"] = "order_sysid is required"
                 results.append(entry)
@@ -2715,6 +2725,7 @@ class BigQmtRpcHandlers:
             try:
                 result = self.order_gateway.cancel(order_ref, account_id=account_id)
                 entry["success"] = bool(getattr(result, "success", result))
+                entry["accepted"] = True
                 entry["message"] = str(getattr(result, "message", "") or "")
             except Exception as exc:
                 entry["error"] = "%s: %s" % (type(exc).__name__, exc)

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -3908,7 +3908,14 @@ class BigQmtXtTrader:
         })
 
     def _submit_async_cancel_batch(self, account_id, group):
-        """N cancels in one RPC; one callback per item."""
+        """N cancels in one RPC; one callback per item.
+
+        Failure taxonomy mirrors the order batch (#195): a batch the server
+        REFUSED (answered with an error -- the handler raises before its
+        per-item loop, so nothing ran) or answered empty is safe to retry as
+        singles; a timeout/transport failure means the cancels may be running
+        and retrying would double-cancel -- report unknown-outcome per item
+        instead."""
         payload = []
         for seq, args, kwargs in group:
             order_id = args[1] if len(args) > 1 else kwargs.get("order_id", "")
@@ -3924,17 +3931,42 @@ class BigQmtXtTrader:
                 {"account_id": account_id, "items": payload},
                 account_id=account_id,
             ) or []
+        except RpcServerRepliedError as exc:
+            log.warning("cancel batch of %d refused by the server (%s); "
+                        "submitting one at a time", len(group), exc)
+            for job in group:
+                try:
+                    self._submit_async_cancel_single(job)
+                except Exception:
+                    log.exception("async cancel failed after batch refusal")
+            return
         except Exception as exc:
+            log.exception("cancel batch of %d outcome unknown; NOT resubmitting",
+                          len(group))
             for seq, args, kwargs in group:
                 order_id = args[1] if len(args) > 1 else kwargs.get("order_id", "")
                 market = args[2] if len(args) > 2 else kwargs.get("market", "")
                 self._enqueue_async_outcome({
                     "kind": "cancel_error", "seq": seq,
                     "order_id": order_id, "market": market,
-                    "error_id": -1,
-                    "error_msg": "cancel batch failed: %s: %s"
-                                 % (exc.__class__.__name__, exc),
+                    "error_id": -4,
+                    "error_msg": ("cancel batch outcome unknown (%s: %s); the "
+                                  "cancels MAY BE RUNNING -- check the order "
+                                  "status before retrying"
+                                  % (exc.__class__.__name__, exc)),
                 })
+            return
+        if not results:
+            # The server appends one result per item, so nothing back means the
+            # batch never ran -- not that every cancel failed. Fall back to
+            # singles, which is what would have happened anyway.
+            log.warning("cancel batch of %d returned no results; submitting "
+                        "one at a time", len(group))
+            for job in group:
+                try:
+                    self._submit_async_cancel_single(job)
+                except Exception:
+                    log.exception("async cancel failed after empty batch")
             return
         by_index = {}
         for position, entry in enumerate(results):
@@ -4391,6 +4423,10 @@ class BigQmtXtTrader:
                         CompatObject(
                             error_id=unit["error_id"],
                             error_msg=unit["error_msg"],
+                            # seq was missing here while the response path had
+                            # it -- an uncorrelatable error is how "which
+                            # cancel failed?" goes unanswered.
+                            seq=seq,
                             order_sysid=str(order_id or ""),
                             order_sys_id=str(order_id or ""),
                             order_id=self._order_object_id(order_id),
@@ -4405,7 +4441,16 @@ class BigQmtXtTrader:
                         seq=seq,
                         success=bool(ok),
                         cancel_result=0 if ok else -1,
-                        error_msg="" if ok else "cancel_order_stock rejected by server",
+                        # The native cancel return answers "the request went
+                        # out", not "the order is cancelled" -- it has been
+                        # false while the cancel landed (#148) and true for a
+                        # nonexistent order (#151). Never word it as a
+                        # rejection; the order-status push (54) or a query is
+                        # the confirmation.
+                        error_msg="" if ok else (
+                            "cancel not confirmed by the counter; the order may "
+                            "still get cancelled -- check the order-status push "
+                            "or query before assuming either way"),
                         order_sysid=str(order_id or ""),
                         order_sys_id=str(order_id or ""),
                         order_id=self._order_object_id(order_id),

--- a/tests/bigqmt_signal_trader/test_async_cancel_batch.py
+++ b/tests/bigqmt_signal_trader/test_async_cancel_batch.py
@@ -1,0 +1,222 @@
+# coding: utf-8
+"""#224 follow-up: the async cancel batch must inherit the order batch's
+hard-won rules (#148/#151/#195), which the contributed PR missed.
+
+The native cancel return answers "the request went out", not "the order is
+cancelled" -- it has been false while the cancel landed (#148) and true for
+a nonexistent order (#151). So: per-item answers carry accepted/confirmed
+vocabulary, failure wording never claims rejection, and a timed-out batch is
+never silently resubmitted (#195).
+"""
+import os
+import sys
+import threading
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.models import CancelResult
+from bigqmt_signal_trader.redis_rpc import BigQmtRpcHandlers
+from bigqmt_signal_trader.xtquant_compat import (
+    BigQmtXtTrader, RpcServerRepliedError, XtQuantTraderCallback,
+)
+from test_redis_rpc import FakeMarketData, FakePositionProvider
+
+
+class _CancelGateway(object):
+    """order_gateway stand-in: records cancels, answers what it's told."""
+
+    def __init__(self, answer=True):
+        self.cancelled = []
+        self.answer = answer
+
+    def cancel(self, order_ref, account_id=None):
+        self.cancelled.append((account_id, order_ref.order_sys_id))
+        return CancelResult(success=bool(self.answer), message="")
+
+
+def _handlers(gateway):
+    return BigQmtRpcHandlers(
+        account_id="acct", market_data=FakeMarketData(),
+        position_provider=FakePositionProvider(), order_gateway=gateway,
+        allow_order_methods=True,
+    )
+
+
+class BatchCancelAnswerSemanticsTest(unittest.TestCase):
+    """Server side: per-item answers must not claim what the native return
+    cannot know."""
+
+    def test_each_item_marks_accepted_and_never_confirmed(self):
+        gateway = _CancelGateway()
+        results = _handlers(gateway)._handle_cancel_orders_batch({
+            "account_id": "acct",
+            "items": [{"order_sysid": "sys-%d" % i} for i in range(3)],
+        })
+
+        self.assertEqual(len(gateway.cancelled), 3)
+        for entry in results:
+            self.assertTrue(entry["accepted"])
+            self.assertFalse(entry["confirmed"],
+                             "nothing in this path may claim the cancel landed")
+
+    def test_a_native_false_still_marks_accepted(self):
+        """#148's shape: the native return said false, the cancel landed."""
+        gateway = _CancelGateway(answer=False)
+        results = _handlers(gateway)._handle_cancel_orders_batch({
+            "account_id": "acct", "items": [{"order_sysid": "sys-1"}],
+        })
+
+        self.assertFalse(results[0]["success"])   # the native value, kept
+        self.assertTrue(results[0]["accepted"])   # the request went out
+        self.assertFalse(results[0]["confirmed"])
+
+    def test_a_missing_sysid_is_an_item_error_without_a_cancel(self):
+        gateway = _CancelGateway()
+        results = _handlers(gateway)._handle_cancel_orders_batch({
+            "account_id": "acct",
+            "items": [{"order_sysid": "sys-1"}, {"order_sysid": ""}],
+        })
+
+        self.assertEqual(len(gateway.cancelled), 1)
+        self.assertFalse(results[1]["accepted"])
+        self.assertIn("order_sysid", results[1]["error"])
+
+
+class _CancelRec(XtQuantTraderCallback):
+    def __init__(self):
+        self.responses = []
+        self.errors = []
+        self.lock = threading.Lock()
+
+    def on_cancel_order_stock_async_response(self, r):
+        with self.lock:
+            self.responses.append(r)
+
+    def on_cancel_error(self, e):
+        with self.lock:
+            self.errors.append(e)
+
+
+class _Client(object):
+    def __init__(self, behavior):
+        self.account_id = "acct"
+        self.timeout_seconds = 30.0
+        self.calls = []
+        self.behavior = behavior
+
+    def call(self, method, params=None, account_id=None, timeout_seconds=None):
+        self.calls.append((method, params or {}, timeout_seconds))
+        return self.behavior(method, params or {})
+
+
+class AsyncCancelBatchClientTest(unittest.TestCase):
+    def _trader(self, client):
+        trader = BigQmtXtTrader(account_id="acct")
+        trader.client = client
+        rec = _CancelRec()
+        trader.register_callback(rec)
+        return trader, rec
+
+    def test_a_backlog_goes_out_as_one_batch(self):
+        client = _Client(lambda m, p: [
+            {"index": i, "success": True, "accepted": True, "confirmed": False}
+            for i in range(len(p["items"]))] if m == "cancel_order_stock_batch" else {})
+        trader, rec = self._trader(client)
+        seqs = [trader.cancel_order_stock_async("acct", "sys-%d" % i)
+                for i in range(3)]
+
+        self.assertTrue(trader.wait_async_orders(timeout=5.0))
+
+        batches = [c for c in client.calls if c[0] == "cancel_order_stock_batch"]
+        self.assertEqual(len(batches), 1)
+        self.assertEqual(len(batches[0][1]["items"]), 3)
+        self.assertEqual([r.seq for r in rec.responses], seqs)
+
+    def test_a_lone_cancel_takes_the_single_path(self):
+        client = _Client(lambda m, p: {"success": True})
+        trader, rec = self._trader(client)
+        trader.cancel_order_stock_async("acct", "sys-1")
+
+        self.assertTrue(trader.wait_async_orders(timeout=5.0))
+
+        self.assertEqual([c[0] for c in client.calls], ["cancel_order_stock_sysid"])
+        self.assertEqual(len(rec.responses), 1)
+
+    def test_a_refused_batch_falls_back_to_singles(self):
+        """A server-answered refusal means nothing ran, so singles are safe."""
+        def behavior(method, params):
+            if method == "cancel_order_stock_batch":
+                raise RpcServerRepliedError("order_gateway is not configured")
+            return {"success": True}
+
+        client = _Client(behavior)
+        trader, rec = self._trader(client)
+        seqs = [trader.cancel_order_stock_async("acct", "sys-%d" % i)
+                for i in range(3)]
+
+        self.assertTrue(trader.wait_async_orders(timeout=5.0))
+
+        singles = [c for c in client.calls if c[0] == "cancel_order_stock_sysid"]
+        self.assertEqual(len(singles), 3)
+        self.assertEqual([r.seq for r in rec.responses], seqs)
+
+    def test_a_timed_out_batch_is_never_resubmitted(self):
+        """#195 for cancels: a timeout means the cancels MAY BE RUNNING;
+        resubmitting double-cancels. Report unknown-outcome per item."""
+        def behavior(method, params):
+            if method == "cancel_order_stock_batch":
+                raise TimeoutError("redis rpc timeout: cancel_order_stock_batch")
+            return {"success": True}
+
+        client = _Client(behavior)
+        trader, rec = self._trader(client)
+        seqs = [trader.cancel_order_stock_async("acct", "sys-%d" % i)
+                for i in range(3)]
+
+        self.assertTrue(trader.wait_async_orders(timeout=5.0))
+
+        singles = [c for c in client.calls if c[0] == "cancel_order_stock_sysid"]
+        self.assertEqual(singles, [], "a timed-out batch must NOT be resubmitted")
+        self.assertEqual([e.seq for e in rec.errors], seqs)
+        for err in rec.errors:
+            self.assertIn("MAY BE RUNNING", err.error_msg)
+
+    def test_a_failed_item_errors_alone(self):
+        def behavior(method, params):
+            entries = [{"index": i, "success": True, "accepted": True,
+                        "confirmed": False} for i in range(len(params["items"]))]
+            entries[1] = {"index": 1, "success": False, "accepted": True,
+                          "confirmed": False, "message": "native false"}
+            return entries
+
+        client = _Client(behavior)
+        trader, rec = self._trader(client)
+        seqs = [trader.cancel_order_stock_async("acct", "sys-%d" % i)
+                for i in range(3)]
+
+        self.assertTrue(trader.wait_async_orders(timeout=5.0))
+
+        self.assertEqual([r.seq for r in rec.responses], [seqs[0], seqs[2]])
+        self.assertEqual([e.seq for e in rec.errors], [seqs[1]])
+
+    def test_the_failure_wording_never_claims_rejection(self):
+        """Native false used to render as "rejected by server" -- the #148
+        false-failure direction. The message must say unconfirmed, not dead."""
+        client = _Client(lambda m, p: {"success": False})
+        trader, rec = self._trader(client)
+        trader.cancel_order_stock_async("acct", "sys-1")
+
+        self.assertTrue(trader.wait_async_orders(timeout=5.0))
+
+        self.assertEqual(len(rec.responses), 1)
+        resp = rec.responses[0]
+        self.assertNotEqual(resp.cancel_result, 0)
+        self.assertNotIn("rejected", resp.error_msg.lower())
+        self.assertIn("not confirmed", resp.error_msg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#224 的跟修（fork PR 推不上去，按仓库惯例合并后从本仓分支补）。

#224 已合并，架构没问题；这个跟修补上评审里指出的语义问题——撤单应答复述了原生返回值，而原生返回值两个方向都会说谎（#148 假失败：返回 false 但 67ms 后已撤；#151 假成功：不存在的单子返回 true）。

# 改动

1. **服务端逐项应答**：加 `accepted`（网关已受理）/ `confirmed`（恒 False——此路径不读回确认）词汇，与 submit 批量对齐；`success` 保留为原生值。
2. **客户端文案**：`success=False` 不再渲染成「rejected by server」，改为「未被确认；单子可能仍会撤掉——以委托状态推送（54）/查询为准」。对撤单来说，假失败意味着调用方以为死单还活着，这是最坏的方向。
3. **超时分类**（#195 的撤单侧镜像）：服务端明确拒绝 / 返回空 → 回退逐笔（批量根本没跑）；超时/断连 → 逐项报「MAY BE RUNNING」，绝不重提（撤单重提=重复撤单）。
4. **`on_cancel_error` 补 `seq`**——新测试在评审中发现撤单错误回调根本无法关联是哪笔。

# 测试

新增 `test_async_cancel_batch.py` 9 例：应答语义（accepted/confirmed/confirmed 恒 False）、原生 false 仍标 accepted、缺 sysid 逐项报错、积压成批、单笔走单路、拒绝回退、超时不重提、单项失败隔离、措辞不含 rejected。其中 7 例对#224 合并态为红。

全量 **1770 通过，134/134 模块收集**。
