### PR TITLE
fix: rebuild the ongoing multi-day bar from the period's daily bars (#226)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## [未发布]
 
+### 修复
+
+- **进行中的多日周期 Bar（1w/1mon/1q/1hy/1y）按请求窗口截断**（#226）。盘中大 QMT 把进行中的周线按请求窗口内的基础数据现场合成——窗口只含当日时，周线的 volume/OHLC 只剩当日部分，本周前几天的量丢失（miniQMT 的 `get_local_data` 语义是从本地全部数据合成、窗口只过滤返回行）。现在客户端在返回前对进行中的 Bar 用周期内日线重造（volume/amount 求和、high/low 取极值、open 取周期首日开盘、close 取最新收盘；preClose/time 不动）。结构性触发：周期集合钉死 + 最后一根 Bar 的自然周期包含今天 + 请求窗口切进周期 + 盘中时段——收盘后已定型、窗口已覆盖周期、日线请求失败或为空时都原样放行（失败保留原值并告警，不抛错）。`resynth_ongoing_multiday=False` 可关。盘后实测：重造值与定型 Bar 逐值一致。
+
 ### 新增
 
 - **异步撤单与批量撤单**（#224，贡献者 @shihaibi）：`cancel_order_stock_async` / `cancel_order_stock_sysid_async` 从内联阻塞改为队列异步（复用异步下单的 worker + 回调分发线程），积压按账户分组成一次 `cancel_order_stock_batch` RPC（单项上限 500，超时随 N 缩放）。`cancel_order_stock_batch(account, cancels)` 同步批量接口同批新增，每项应答带 `accepted`/`confirmed`。**行为变化**：`cancel_order_stock_async` 的回调不再在返回前内联触发，改为回调线程异步到达。

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -570,6 +570,66 @@ def _iso_week_start_label(value):
     return (day - _dt.timedelta(days=day.weekday())).strftime("%Y%m%d")
 
 
+def _month_start_label(value):
+    """The 1st of the month a bar label belongs to, as YYYYMMDD."""
+    parsed = _parse_qmt_stime(value)
+    if parsed is None:
+        return None
+    return parsed.strftime("%Y%m") + "01"
+
+
+def _quarter_start_label(value):
+    """The 1st of the quarter's first month a bar label belongs to."""
+    parsed = _parse_qmt_stime(value)
+    if parsed is None:
+        return None
+    month = ((parsed.month - 1) // 3) * 3 + 1
+    return "%04d%02d01" % (parsed.year, month)
+
+
+def _halfyear_start_label(value):
+    """Jan 1 or Jul 1 of the half-year a bar label belongs to."""
+    parsed = _parse_qmt_stime(value)
+    if parsed is None:
+        return None
+    return "%04d0101" % parsed.year if parsed.month <= 6 else "%04d0701" % parsed.year
+
+
+def _year_start_label(value):
+    """Jan 1 of the year a bar label belongs to."""
+    parsed = _parse_qmt_stime(value)
+    if parsed is None:
+        return None
+    return "%04d0101" % parsed.year
+
+
+def _period_end_label(period, value):
+    """The last calendar day of the natural period a bar label belongs to.
+
+    Used only to tell an in-progress bar (its period is not over yet) from a
+    finalized one. Returns None for anything unparseable.
+    """
+    parsed = _parse_qmt_stime(value)
+    if parsed is None:
+        return None
+    day = parsed.date()
+    if period == "1w":
+        return (day - _dt.timedelta(days=day.weekday()) + _dt.timedelta(days=6)).strftime("%Y%m%d")
+    if period == "1mon":
+        year, month = parsed.year, parsed.month
+        end = _dt.date(year + month // 12, month % 12 + 1, 1) - _dt.timedelta(days=1)
+        return end.strftime("%Y%m%d")
+    if period == "1q":
+        month = ((parsed.month - 1) // 3) * 3 + 3
+        end = _dt.date(parsed.year + month // 12, month % 12 + 1, 1) - _dt.timedelta(days=1)
+        return end.strftime("%Y%m%d")
+    if period == "1hy":
+        return "%04d0630" % parsed.year if parsed.month <= 6 else "%04d1231" % parsed.year
+    if period == "1y":
+        return "%04d1231" % parsed.year
+    return None
+
+
 def _bar_float(value):
     """A bar cell as a float, or None for anything that is not a number.
 
@@ -1187,6 +1247,32 @@ PRE_CLOSE_BACKFILL_PERIODS = ("1w",)
 _PRE_CLOSE_PERIOD_STARTS = {"1w": _iso_week_start_label}
 _PRE_CLOSE_NOTICE = {"shown": False}
 
+# Periods whose ongoing bar QMT synthesizes from the request window instead
+# of from all local data (#226). Pinned as a set the way #172 pinned its
+# period list -- a new period enters only with a measurement behind it.
+RESYNTH_ONGOING_PERIODS = ("1w", "1mon", "1q", "1hy", "1y")
+RESYNTH_PERIOD_STARTS = {
+    "1w": _iso_week_start_label,
+    "1mon": _month_start_label,
+    "1q": _quarter_start_label,
+    "1hy": _halfyear_start_label,
+    "1y": _year_start_label,
+}
+_RESYNTH_NOTICE = {"shown": False}
+
+
+def _in_trading_session(now):
+    """Weekday inside the continuous-auction window (with a settle margin
+    after close). After the close the ongoing multi-day bar is finalized and
+    passes through untouched (#226's after-close control)."""
+    if now.weekday() > 4:
+        return False
+    return _dt.time(9, 30) <= now.time() <= _dt.time(15, 5)
+
+
+def _now():
+    return _dt.datetime.now()
+
 
 def _notice_field_list_cost(field_list):
     """Say once that naming fields is what enables the fast path.
@@ -1731,6 +1817,154 @@ class BigQmtXtData:
         rows.sort()
         return rows
 
+    def _resynth_ongoing_multiday_bars(self, data, period, start_time,
+                                       end_time, dividend_type,
+                                       timeout_seconds=None, use_formula=True):
+        """Rebuild the in-progress multi-day bar from the period's daily bars (#226).
+
+        Big QMT synthesizes an ongoing 1w/1mon/1q/1hy/1y bar from the bars in
+        the REQUEST window, so a window covering only today answers the weekly
+        bar with today's volume and the week's earlier days lost. MiniQMT's
+        get_local_data synthesizes from ALL local base data and start/end only
+        filters the returned rows -- this rebuild is what makes the bridge
+        match that.
+
+        Structural triggers only, never a value guess: the period is in
+        RESYNTH_ONGOING_PERIODS, the last bar's natural period contains today,
+        the request window cuts into the period (start_time past its start),
+        and the clock is inside a weekday session -- after close the bar is
+        finalized and passes through untouched.
+
+        Degrades like the preClose backfill (#166): a failed or empty daily
+        read keeps the terminal's answer and warns once; nothing raises.
+        """
+        if str(period or "") not in RESYNTH_ONGOING_PERIODS or not isinstance(data, dict):
+            return data
+        start_text = str(start_time or "")
+        if not start_text:
+            return data          # count-based reads never showed the truncation
+        now = _now()
+        if not _in_trading_session(now):
+            return data
+        today = now.strftime("%Y%m%d")
+
+        targets = {}
+        for code, frame in data.items():
+            labels = _frame_bar_labels(frame)
+            if not labels:
+                continue
+            label = labels[-1]
+            period_start = RESYNTH_PERIOD_STARTS[period](label)
+            period_end = _period_end_label(period, label)
+            if period_start is None or period_end is None:
+                continue
+            if not (period_start <= today <= period_end):
+                continue          # the last bar is finalized history
+            if _digits_only(start_text)[:8] <= period_start:
+                continue          # the window already covers the period
+            targets[code] = period_start
+        if not targets:
+            return data
+
+        try:
+            daily = self.get_market_data_ex(
+                field_list=["open", "high", "low", "close", "volume", "amount"],
+                stock_list=sorted(targets), period="1d",
+                start_time=min(targets.values()), end_time=today, count=-1,
+                dividend_type=dividend_type, fill_data=False,
+                timeout_seconds=timeout_seconds, use_formula=use_formula,
+                backfill_pre_close=False, resynth_ongoing_multiday=False,
+            )
+        except Exception as exc:
+            # The terminal's answer was good enough to serve; taking the whole
+            # read down over the rebuild would be the worse bug.
+            log.warning("ongoing %s bar rebuild skipped: %s", period, exc)
+            return data
+
+        rebuilt = 0
+        for code, period_start in targets.items():
+            frame = data.get(code)
+            daily_frame = daily.get(code) if isinstance(daily, dict) else None
+            summary = self._sum_daily_bars(daily_frame, period_start, today)
+            if summary is None:
+                continue
+            if self._write_last_bar(frame, summary):
+                rebuilt += 1
+        if rebuilt:
+            self._notice_resynth_ongoing(period, rebuilt)
+        return data
+
+    @staticmethod
+    def _sum_daily_bars(frame, period_start, today):
+        """open/high/low/close/volume/amount for one ongoing period from its
+        daily bars, or None when there is nothing to sum."""
+        labels = _frame_bar_labels(frame) if frame is not None else None
+        if not labels:
+            return None
+        try:
+            columns = {name: list(frame[name]) for name in
+                       ("open", "high", "low", "close", "volume", "amount")}
+        except Exception:
+            return None
+        rows = []
+        for index, label in enumerate(labels):
+            day = _digits_only(label)[:8]
+            if not day or day < period_start or day > today:
+                continue
+            rows.append({name: _bar_float(columns[name][index])
+                         for name in columns})
+        rows = [row for row in rows if row["close"] is not None]
+        if not rows:
+            return None
+        out = {
+            "open": next((row["open"] for row in rows if row["open"] is not None), None),
+            "high": max((row["high"] for row in rows if row["high"] is not None), default=None),
+            "low": min((row["low"] for row in rows if row["low"] is not None), default=None),
+            "close": next((row["close"] for row in reversed(rows) if row["close"] is not None), None),
+        }
+        for name in ("volume", "amount"):
+            values = [row[name] for row in rows if row[name] is not None]
+            out[name] = sum(values) if values else None
+        return out
+
+    @staticmethod
+    def _write_last_bar(frame, summary):
+        """Write the rebuilt values into the last bar, only into columns the
+        caller actually asked for. True when anything was written."""
+        wrote = False
+        for name, value in summary.items():
+            if value is None:
+                continue
+            try:
+                values = list(frame[name])
+            except Exception:
+                continue          # the column was never requested
+            if not values:
+                continue
+            values[-1] = value
+            try:
+                frame[name] = values
+                wrote = True
+            except Exception:
+                continue
+        return wrote
+
+    @staticmethod
+    def _notice_resynth_ongoing(period, count):
+        """Say once that ongoing bars are rebuilt here, not answered by QMT."""
+        if _RESYNTH_NOTICE["shown"]:
+            return
+        _RESYNTH_NOTICE["shown"] = True
+        try:
+            log.info(
+                "the ongoing %s bar(s) of %d code(s) were rebuilt from the "
+                "period's daily bars (issue #226): big QMT synthesizes them "
+                "from the request window, miniQMT from all local data. Pass "
+                "resynth_ongoing_multiday=False to serve the raw window "
+                "answer.", period, count)
+        except Exception:
+            pass
+
     @staticmethod
     def _notice_pre_close_backfill(period):
         """Say once that these preClose values are derived, not the terminal's."""
@@ -1762,6 +1996,7 @@ class BigQmtXtData:
         timeout_seconds=None,
         use_formula=True,
         backfill_pre_close=True,
+        resynth_ongoing_multiday=True,
     ):
         """Pull bars over RPC, in batches of ``chunk_size`` codes.
 
@@ -1837,6 +2072,15 @@ class BigQmtXtData:
             data = self._backfill_pre_close(
                 data, period=period, dividend_type=dividend_type,
                 timeout_seconds=timeout_seconds, use_formula=use_formula,
+            )
+
+        if resynth_ongoing_multiday:
+            # Same rule as the backfill: the cache keeps the rebuilt bar, not
+            # the window-truncated one (#226).
+            data = self._resynth_ongoing_multiday_bars(
+                data, period=period, start_time=start_time, end_time=end_time,
+                dividend_type=dividend_type, timeout_seconds=timeout_seconds,
+                use_formula=use_formula,
             )
 
         cache = self._local_cache()

--- a/tests/bigqmt_signal_trader/test_resynth_ongoing_multiday.py
+++ b/tests/bigqmt_signal_trader/test_resynth_ongoing_multiday.py
@@ -1,0 +1,207 @@
+# coding: utf-8
+"""#226: an ongoing multi-day bar must be rebuilt from the period's daily
+bars, not truncated to the request window.
+
+Reported live (国金模拟, 2026-09-04 09:40): a 1w read with start=end=today
+answered the in-progress weekly bar with TODAY's volume (the week's earlier
+days lost); a window covering the whole week answered correctly; after close
+the narrow window answered correctly (the bar is finalized). MiniQMT's
+get_local_data semantics -- start/end filter the returned rows, never the
+synthesis material -- is what this rebuild restores.
+"""
+import datetime as dt
+import os
+import sys
+import unittest
+from unittest import mock
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader import xtquant_compat
+from bigqmt_signal_trader.xtquant_compat import (
+    BigQmtXtData, _halfyear_start_label, _in_trading_session,
+    _iso_week_start_label, _month_start_label, _period_end_label,
+    _quarter_start_label, _year_start_label,
+)
+
+# A Tuesday in session: the last 1w bar (label = the week's Sunday in big
+# QMT, 20260913 here covers Mon 09-07..Sun 09-13) is in progress on 09-08.
+TODAY = dt.datetime(2026, 9, 8, 13, 30)
+WEEK_LABEL = "20260913"   # the Sunday of the week containing TODAY
+WEEK_START = "20260907"   # Monday
+
+
+def _frame(labels, columns):
+    """A pandas frame the way the client holds one."""
+    import pandas as pd
+    data = {name: values for name, values in columns.items()}
+    return pd.DataFrame(data, index=labels)
+
+
+def _weekly_frame(volume, high, low, open_, close, amount):
+    return _frame(
+        [WEEK_LABEL],
+        {"open": [open_], "high": [high], "low": [low], "close": [close],
+         "volume": [volume], "amount": [amount]},
+    )
+
+
+def _daily_frame():
+    """Monday + Tuesday of the ongoing week."""
+    return _frame(
+        ["20260907", "20260908"],
+        {"open": [10.0, 11.0], "high": [10.8, 11.9], "low": [9.9, 10.9],
+         "close": [10.5, 11.5], "volume": [1000, 2000], "amount": [10500.0, 22600.0]},
+    )
+
+
+class _XtData(BigQmtXtData):
+    """Just enough wiring for the resynth method: a stub inner read."""
+
+    def __init__(self, daily_frame):
+        self._daily_frame = daily_frame
+        self.daily_calls = []
+
+    def get_market_data_ex(self, **kwargs):
+        self.daily_calls.append(kwargs)
+        return {"000001.SZ": self._daily_frame}
+
+
+class TriggerGatesTest(unittest.TestCase):
+    def _resynth(self, data, **kwargs):
+        xt = _XtData(_daily_frame())
+        params = dict(period="1w", start_time="20260908", end_time="20260908",
+                      dividend_type="none")
+        params.update(kwargs)
+        with mock.patch.object(xtquant_compat, "_in_trading_session", lambda now: True):
+            with mock.patch.object(xtquant_compat, "_now", lambda: TODAY):
+                return xt._resynth_ongoing_multiday_bars(data, **params), xt.daily_calls
+
+    def test_an_ongoing_bar_with_a_cut_window_is_rebuilt(self):
+        data = {"000001.SZ": _weekly_frame(6763, 11.0, 10.2, 10.9, 10.8, 7000.0)}
+
+        out, calls = self._resynth(data)
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["period"], "1d")
+        self.assertEqual(calls[0]["start_time"], WEEK_START)
+        self.assertEqual(calls[0]["end_time"], "20260908")
+        frame = out["000001.SZ"]
+        self.assertEqual(list(frame["volume"]), [3000])          # 1000+2000
+        self.assertEqual(list(frame["amount"]), [33100.0])       # summed
+        self.assertEqual(list(frame["high"]), [11.9])            # week high
+        self.assertEqual(list(frame["low"]), [9.9])              # week low
+        self.assertEqual(list(frame["open"]), [10.0])            # Monday's open
+        self.assertEqual(list(frame["close"]), [11.5])           # latest close
+
+    def test_a_window_covering_the_period_does_not_trigger(self):
+        data = {"000001.SZ": _weekly_frame(6763, 11.0, 10.2, 10.9, 10.8, 7000.0)}
+
+        out, calls = self._resynth(data, start_time="20260907")
+
+        self.assertEqual(calls, [])
+        self.assertEqual(list(out["000001.SZ"]["volume"]), [6763])
+
+    def test_a_finalized_bar_does_not_trigger(self):
+        # Last week's bar (label 20260906) does not contain today.
+        frame = _weekly_frame(6763, 11.0, 10.2, 10.9, 10.8, 7000.0)
+        frame.index = ["20260906"]
+        data = {"000001.SZ": frame}
+
+        out, calls = self._resynth(data)
+
+        self.assertEqual(calls, [])
+        self.assertEqual(list(out["000001.SZ"]["volume"]), [6763])
+
+    def test_no_start_time_never_triggers(self):
+        data = {"000001.SZ": _weekly_frame(6763, 11.0, 10.2, 10.9, 10.8, 7000.0)}
+
+        out, calls = self._resynth(data, start_time="")
+
+        self.assertEqual(calls, [])
+
+    def test_daily_read_failure_keeps_the_terminal_answer(self):
+        xt = _XtData(None)
+        xt.get_market_data_ex = None
+
+        def raising(**kwargs):
+            raise RuntimeError("redis down")
+
+        xt.get_market_data_ex = raising
+        data = {"000001.SZ": _weekly_frame(6763, 11.0, 10.2, 10.9, 10.8, 7000.0)}
+        with mock.patch.object(xtquant_compat, "_in_trading_session", lambda now: True):
+            with mock.patch.object(xtquant_compat, "_now", lambda: TODAY):
+                out = xt._resynth_ongoing_multiday_bars(
+                    data, period="1w", start_time="20260908",
+                    end_time="20260908", dividend_type="none")
+
+        self.assertEqual(list(out["000001.SZ"]["volume"]), [6763])
+
+    def test_a_daily_read_with_no_bars_keeps_the_terminal_answer(self):
+        xt = _XtData(_daily_frame().iloc[0:0])
+        data = {"000001.SZ": _weekly_frame(6763, 11.0, 10.2, 10.9, 10.8, 7000.0)}
+        with mock.patch.object(xtquant_compat, "_in_trading_session", lambda now: True):
+            with mock.patch.object(xtquant_compat, "_now", lambda: TODAY):
+                out = xt._resynth_ongoing_multiday_bars(
+                    data, period="1w", start_time="20260908",
+                    end_time="20260908", dividend_type="none")
+
+        self.assertEqual(list(out["000001.SZ"]["volume"]), [6763])
+
+    def test_out_of_session_never_triggers(self):
+        data = {"000001.SZ": _weekly_frame(6763, 11.0, 10.2, 10.9, 10.8, 7000.0)}
+        xt = _XtData(_daily_frame())
+        with mock.patch.object(xtquant_compat, "_in_trading_session", lambda now: False):
+            out = xt._resynth_ongoing_multiday_bars(
+                data, period="1w", start_time="20260908", end_time="20260908",
+                dividend_type="none")
+        self.assertEqual(list(out["000001.SZ"]["volume"]), [6763])
+        self.assertEqual(xt.daily_calls, [])
+
+    def test_minute_and_daily_periods_never_trigger(self):
+        data = {"000001.SZ": _weekly_frame(6763, 11.0, 10.2, 10.9, 10.8, 7000.0)}
+        xt = _XtData(_daily_frame())
+        with mock.patch.object(xtquant_compat, "_in_trading_session", lambda now: True):
+            out = xt._resynth_ongoing_multiday_bars(
+                data, period="1d", start_time="20260908", end_time="20260908",
+                dividend_type="none")
+        self.assertEqual(list(out["000001.SZ"]["volume"]), [6763])
+        self.assertEqual(xt.daily_calls, [])
+
+
+class PeriodSpanHelpersTest(unittest.TestCase):
+    def test_period_starts(self):
+        self.assertEqual(_iso_week_start_label("20260913"), "20260907")
+        self.assertEqual(_month_start_label("20260930"), "20260901")
+        self.assertEqual(_quarter_start_label("20261120"), "20261001")
+        self.assertEqual(_quarter_start_label("20260205"), "20260101")
+        self.assertEqual(_halfyear_start_label("20260315"), "20260101")
+        self.assertEqual(_halfyear_start_label("20260915"), "20260701")
+        self.assertEqual(_year_start_label("20261231"), "20260101")
+
+    def test_period_ends(self):
+        self.assertEqual(_period_end_label("1w", "20260913"), "20260913")
+        self.assertEqual(_period_end_label("1mon", "20260930"), "20260930")
+        self.assertEqual(_period_end_label("1q", "20261120"), "20261231")
+        self.assertEqual(_period_end_label("1hy", "20260315"), "20260630")
+        self.assertEqual(_period_end_label("1hy", "20260915"), "20261231")
+        self.assertEqual(_period_end_label("1y", "20261231"), "20261231")
+
+    def test_unparseable_labels_answer_none_not_a_guess(self):
+        self.assertIsNone(_month_start_label("not-a-date"))
+        self.assertIsNone(_period_end_label("1mon", "not-a-date"))
+
+
+class SessionGateTest(unittest.TestCase):
+    def test_the_gate(self):
+        self.assertTrue(_in_trading_session(TODAY))                       # Tue 13:30
+        self.assertTrue(_in_trading_session(dt.datetime(2026, 9, 8, 9, 30)))
+        self.assertFalse(_in_trading_session(dt.datetime(2026, 9, 8, 15, 6)))
+        self.assertFalse(_in_trading_session(dt.datetime(2026, 9, 5, 13, 30)))  # Sat
+        self.assertFalse(_in_trading_session(dt.datetime(2026, 9, 8, 9, 29)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
修复 #226（报告方 @yucejade 给了完整的修复设计，本 PR 就是它的实现——客户端补齐层，仿 #172/#166 先例）。

# 问题

盘中大 QMT 把**进行中**的多日周期 Bar 按请求窗口内的基础数据现场合成：当日窗口的 1w 量 ≈ 当日 1d 量，本周前几天的量丢失；窗口覆盖整周才正确；收盘后（定型）当日窗口也正确。miniQMT `get_local_data` 的语义是从本地全部数据合成、窗口只过滤返回行。

# 修法（按报告方的设计）

`get_market_data_ex` 返回前，对进行中的多日周期 Bar 用周期内日线重造 volume/amount（求和）、high/low（极值）、open（周期首日开盘）、close（最新收盘）；preClose（#172 管）和 time 不动。

**触发只用结构性判断**：周期 ∈ 钉死的集合 + 最后一根 Bar 的自然周期包含今天 + 请求窗口切进周期（start_time 晚于周期起点）+ 盘中时段（工作日 09:30–15:05）。收盘后/窗口已覆盖/count 型请求/分钟线与日线，全部不触发。

**开关与降级**：`resynth_ongoing_multiday=True` 默认开可关；日线读失败/为空 → 保留终端原值 + 告警（不抛错）；额外的一次日线读走 FormulaServer 快路径。

**已否决的备选**（同报告方结论）：改服务端窗口语义影响所有调用方；让调用方自己放宽窗口是把兼容负担推给下游。

# 验证

- 12 条新用例：窗口切进才触发、覆盖不触发、定型不触发、日线失败/为空保留原值、门禁（周末/盘前/收盘后）不触发、1d/分钟不触发、周期起点/终点助手、不可解析标签不猜。对修复前代码为红（新模块不存在）。
- **盘后实盘 A/B**（维护者终端，000001.SZ 1mon）：重造值与已定型 Bar **逐字段一致**（volume 5,041,776 两边相同）——聚合数学对实盘数据正确。
- 全量 **1782 通过，135/135 模块**。

# 未验证项（如实）

「盘中当日窗口 == 整周窗口 == 周内日线之和」的判别性验证**只能在周二至周五盘中**做（周一结构上不可判别）。明天（09-08）交易时段跑报告方的复现脚本，判定应变「未复现」——我也会在维护者终端同时跑一次。issue 保持开放到那一刻。
