### PR TITLE
fix: propagate native POSITION, ORDER and DEAL query failures through RPC

### DIFF
--- a/src/bigqmt_signal_trader/adapters/order_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/order_bigqmt.py
@@ -655,10 +655,7 @@ class BigQmtOrderGateway:
         return CancelResult(success=bool(ok), message="" if ok else "cancel returned false")
 
     def query_orders(self, account_id, strategy_name):
-        try:
-            return self.query_orders_strict(account_id, strategy_name)
-        except Exception:
-            return []
+        return self.query_orders_strict(account_id, strategy_name)
 
     def query_orders_strict(self, account_id, strategy_name):
         query = self._require_query_func()
@@ -742,28 +739,16 @@ class BigQmtOrderGateway:
         return result
 
     def query_trades(self, account_id, strategy_name):
-        try:
-            return self.query_trades_strict(account_id, strategy_name)
-        except Exception:
-            return []
+        return self.query_trades_strict(account_id, strategy_name)
 
     def query_trades_strict(self, account_id, strategy_name):
         query = self._require_query_func()
         account_type = self._resolve_account_type(account_id)
-        rows = []
-        last_error = None
-        for detail_type in ("DEAL", "TRADE"):
-            try:
-                if str(strategy_name or "").strip():
-                    rows = query(account_id, account_type, detail_type, strategy_name) or []
-                else:
-                    rows = query(account_id, account_type, detail_type) or []
-                if rows:
-                    break
-            except Exception as exc:
-                last_error = exc
-        if not rows and last_error is not None:
-            raise last_error
+        # DEAL is the documented trade detail type; an empty result is a success.
+        if str(strategy_name or "").strip():
+            rows = query(account_id, account_type, "DEAL", strategy_name) or []
+        else:
+            rows = query(account_id, account_type, "DEAL") or []
         result = []
         account_type_code = self._account_type_code(account_id)
         name_cache = {}

--- a/src/bigqmt_signal_trader/adapters/position_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/position_bigqmt.py
@@ -156,12 +156,8 @@ class BigQmtPositionProvider:
 
     def get_positions(self, account_id):
         query = self._require_query_func()
-        # QMT's get_trade_detail_data can raise on POSITION queries in some
-        # states (e.g. context not bound). Degrade to empty like get_asset does.
-        try:
-            rows = query(account_id, self._resolve_account_type(account_id), "POSITION") or []
-        except Exception:
-            return {}
+        # Let query failures reach the RPC error handler instead of reporting empty positions.
+        rows = query(account_id, self._resolve_account_type(account_id), "POSITION") or []
         positions = {}
         for row in rows:
             try:

--- a/tests/bigqmt_signal_trader/test_redis_rpc.py
+++ b/tests/bigqmt_signal_trader/test_redis_rpc.py
@@ -10,6 +10,7 @@ sys.path.insert(0, os.path.join(ROOT, "src"))
 
 from bigqmt_signal_trader.adapters.market_bigqmt import BigQmtMarketDataProvider
 from bigqmt_signal_trader.adapters.order_dryrun import DryRunOrderGateway
+from bigqmt_signal_trader.adapters.position_bigqmt import BigQmtPositionProvider
 from bigqmt_signal_trader.models import (
     AssetSnapshot,
     CancelResult,
@@ -945,6 +946,50 @@ class RedisRpcTest(unittest.TestCase):
         self.assertTrue(response["ok"])
         self.assertEqual(response["data"]["600000.SH"]["available"], 800)
         self.assertEqual(redis_client.published[0][0], "bigqmt:rpc:resp:acct:req-1")
+
+    def test_native_position_query_failure_becomes_rpc_error(self):
+        def query(account_id, account_type, detail_type):
+            self.assertEqual((account_id, account_type, detail_type),
+                             ("acct", "STOCK", "POSITION"))
+            raise RuntimeError("simulated native POSITION query failure")
+
+        redis_client, service = _service()
+        service.handlers.position_provider = BigQmtPositionProvider(query)
+
+        for method in ("get_positions", "query_stock_positions"):
+            with self.subTest(method=method):
+                service.enqueue_payload({
+                    "request_id": method,
+                    "account_id": "acct",
+                    "method": method,
+                    "params": {},
+                })
+                self.assertEqual(service.drain_pending(), 1)
+                response = json.loads(redis_client.kv["bigqmt:rpc:resp:acct:" + method])
+                self.assertFalse(response["ok"])
+                self.assertIsNone(response["data"])
+                self.assertEqual(response["error"],
+                                 "RuntimeError: simulated native POSITION query failure")
+
+    def test_native_empty_positions_remain_successful_rpc_result(self):
+        redis_client, service = _service()
+        provider = BigQmtPositionProvider(lambda *args: [])
+        service.handlers.position_provider = provider
+        self.assertEqual(provider.get_positions("acct"), {})
+
+        for method in ("get_positions", "query_stock_positions"):
+            with self.subTest(method=method):
+                service.enqueue_payload({
+                    "request_id": method,
+                    "account_id": "acct",
+                    "method": method,
+                    "params": {},
+                })
+                self.assertEqual(service.drain_pending(), 1)
+                response = json.loads(redis_client.kv["bigqmt:rpc:resp:acct:" + method])
+                self.assertTrue(response["ok"], response["error"])
+                self.assertEqual(response["data"], {})
+                self.assertEqual(response["error"], "")
 
     def test_process_in_listener_handles_request_without_waiting_for_drain(self):
         redis_client, service = _service(process_in_listener=True)

--- a/tests/bigqmt_signal_trader/test_redis_rpc.py
+++ b/tests/bigqmt_signal_trader/test_redis_rpc.py
@@ -9,6 +9,7 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(ROOT, "src"))
 
 from bigqmt_signal_trader.adapters.market_bigqmt import BigQmtMarketDataProvider
+from bigqmt_signal_trader.adapters.order_bigqmt import BigQmtOrderGateway
 from bigqmt_signal_trader.adapters.order_dryrun import DryRunOrderGateway
 from bigqmt_signal_trader.adapters.position_bigqmt import BigQmtPositionProvider
 from bigqmt_signal_trader.models import (
@@ -523,6 +524,38 @@ class AsyncOrderSettlementTest(unittest.TestCase):
         self.assertTrue(response["ok"])
         self.assertIn("not found in system", response["server_error"])
 
+    def test_native_lookup_error_keeps_submission_without_resubmitting(self):
+        submissions = []
+        queries = []
+
+        def query(*args):
+            queries.append(args)
+            raise RuntimeError("simulated native ORDER query failure")
+
+        gateway = BigQmtOrderGateway(
+            context_info=None,
+            passorder_func=lambda *args: submissions.append(args),
+            get_trade_detail_data_func=query,
+        )
+        redis_client, service = self._service(gateway)
+        self._submit(service)
+        service.drain_pending()
+
+        response_key = "bigqmt:rpc:resp:acct:ord-1"
+        self.assertIn(response_key, redis_client.kv)
+        response = json.loads(redis_client.kv[response_key])
+        self.assertTrue(response["ok"], response["error"])
+        self.assertEqual(response["data"]["status"], "SUBMITTED")
+        self.assertIsNone(response["data"]["order_sys_id"])
+        self.assertEqual(response["data"]["message"], "passorder submitted")
+        self.assertEqual(response["server_error"], "")
+        self.assertEqual(service.pending_settlement_count(), 0)
+
+        service.drain_pending()
+        service.drain_pending()
+        self.assertEqual(len(submissions), 1)
+        self.assertEqual(queries, [("acct", "STOCK", "ORDER", "")])
+
     def test_settlement_error_does_not_leak_into_other_responses(self):
         """issue #43 again, by another route: settling happens long after the
         order left the handler, so its diagnostic must ride on the settlement
@@ -947,17 +980,28 @@ class RedisRpcTest(unittest.TestCase):
         self.assertEqual(response["data"]["600000.SH"]["available"], 800)
         self.assertEqual(redis_client.published[0][0], "bigqmt:rpc:resp:acct:req-1")
 
-    def test_native_position_query_failure_becomes_rpc_error(self):
-        def query(account_id, account_type, detail_type):
-            self.assertEqual((account_id, account_type, detail_type),
-                             ("acct", "STOCK", "POSITION"))
-            raise RuntimeError("simulated native POSITION query failure")
+    def test_native_query_failure_becomes_rpc_error(self):
+        cases = (
+            ("get_positions", "POSITION"), ("query_stock_positions", "POSITION"),
+            ("query_orders", "ORDER"), ("query_stock_orders", "ORDER"),
+            ("query_trades", "DEAL"), ("query_stock_trades", "DEAL"),
+            ("query_execution_snapshot", "ORDER"), ("query_execution_snapshot", "DEAL"),
+        )
+        for method, failed_type in cases:
+            with self.subTest(method=method, failed_type=failed_type):
+                calls = []
 
-        redis_client, service = _service()
-        service.handlers.position_provider = BigQmtPositionProvider(query)
+                def query(account_id, account_type, detail_type, *args):
+                    self.assertEqual((account_id, account_type), ("acct", "STOCK"))
+                    calls.append(detail_type)
+                    if detail_type == failed_type:
+                        raise RuntimeError("simulated native %s query failure" % failed_type)
+                    return []
 
-        for method in ("get_positions", "query_stock_positions"):
-            with self.subTest(method=method):
+                redis_client, service = _service()
+                service.handlers.position_provider = BigQmtPositionProvider(query)
+                service.handlers.order_gateway = BigQmtOrderGateway(
+                    context_info=None, get_trade_detail_data_func=query)
                 service.enqueue_payload({
                     "request_id": method,
                     "account_id": "acct",
@@ -969,16 +1013,34 @@ class RedisRpcTest(unittest.TestCase):
                 self.assertFalse(response["ok"])
                 self.assertIsNone(response["data"])
                 self.assertEqual(response["error"],
-                                 "RuntimeError: simulated native POSITION query failure")
+                                 "RuntimeError: simulated native %s query failure" % failed_type)
+                expected_calls = (["ORDER", "DEAL"]
+                                  if method == "query_execution_snapshot" and failed_type == "DEAL"
+                                  else [failed_type])
+                self.assertEqual(calls, expected_calls)
 
-    def test_native_empty_positions_remain_successful_rpc_result(self):
-        redis_client, service = _service()
-        provider = BigQmtPositionProvider(lambda *args: [])
-        service.handlers.position_provider = provider
-        self.assertEqual(provider.get_positions("acct"), {})
-
-        for method in ("get_positions", "query_stock_positions"):
+    def test_native_empty_queries_remain_successful_rpc_results(self):
+        cases = (
+            ("get_positions", ["POSITION"], {}),
+            ("query_stock_positions", ["POSITION"], {}),
+            ("query_orders", ["ORDER"], []), ("query_stock_orders", ["ORDER"], []),
+            ("query_trades", ["DEAL"], []), ("query_stock_trades", ["DEAL"], []),
+            ("query_execution_snapshot", ["ORDER", "DEAL"], None),
+        )
+        for method, expected_calls, empty_result in cases:
             with self.subTest(method=method):
+                calls = []
+
+                def query(account_id, account_type, detail_type, *args):
+                    calls.append(detail_type)
+                    if detail_type not in ("POSITION", "ORDER", "DEAL"):
+                        raise ValueError("unsupported detail type: " + detail_type)
+                    return []
+
+                redis_client, service = _service()
+                service.handlers.position_provider = BigQmtPositionProvider(query)
+                service.handlers.order_gateway = BigQmtOrderGateway(
+                    context_info=None, get_trade_detail_data_func=query)
                 service.enqueue_payload({
                     "request_id": method,
                     "account_id": "acct",
@@ -988,8 +1050,13 @@ class RedisRpcTest(unittest.TestCase):
                 self.assertEqual(service.drain_pending(), 1)
                 response = json.loads(redis_client.kv["bigqmt:rpc:resp:acct:" + method])
                 self.assertTrue(response["ok"], response["error"])
-                self.assertEqual(response["data"], {})
+                if method == "query_execution_snapshot":
+                    self.assertEqual(response["data"]["orders"], [])
+                    self.assertEqual(response["data"]["trades"], [])
+                else:
+                    self.assertEqual(response["data"], empty_result)
                 self.assertEqual(response["error"], "")
+                self.assertEqual(calls, expected_calls)
 
     def test_process_in_listener_handles_request_without_waiting_for_drain(self):
         redis_client, service = _service(process_in_listener=True)


### PR DESCRIPTION
原生 POSITION / ORDER / DEAL 整次查询失败原先会被吞成成功空集合。现在异常进入既有 RPC error（`ok=false`、`data=null`，保留异常类型和消息）；成功空查询仍返回 `{}` / `[]`。`query_execution_snapshot` 的任一组成查询失败也返回 RPC error。Fixes #229。

成交只查询官方 `DEAL`，删除 `TRADE` 探测及 `last_error`，避免成功空 DEAL 被后续 unsupported 异常误判，也避免替换原始 DEAL 异常。有无策略过滤时的调用参数保持不变。依据：[迅投交易函数文档](https://dict.thinktrader.net/innerApi/trading_function.html)、[本仓 API 参考 §6.8](https://github.com/litaolemo/xtquant_big_convert/blob/e2f9ce758879b8172696a117fb9bfc51756d16ea/docs/BIGQMT_INNER_PYTHON_API_REFERENCE.md#L1798)。

共用 gateway 的必要影响：发单后 ORDER 回查异常会进入既有 `_apply_order_lookup` 异常分支并结束确认等待，保留 `ok=true`、`SUBMITTED`、`order_sys_id=null`，无回查错误诊断；这不是成交确认。针对性回归确认 passorder 只调用一次，后续 drain 不重发、不补造委托号。`query_submission_identities_strict` 共用 DEAL 查询，调用方已有的异常保护未修改。

生产改动限于两个查询 adapter。ACCOUNT、字段映射、逐行坏行跳过及日志去重规则未修改；删除外层包装后，其余未被既有规则捕获的异常也会传播。未新增状态机、客户端 fallback 或缓存逻辑。

- 定向验证 **24 passed**：3 个失败/空成功/发单后回查回归，9 个相邻 adapter 用例，12 个相邻 RPC 用例；`git diff --check` 通过。
- 修复前红测 **3 failed**，证实错误成功标记、额外 `TRADE` 探测及原有回查等待行为。
- 使用内存夹具与注入函数；未运行在线 QMT/券商、全量测试或客户端后续策略验证。
