### PR TITLE
第五种传输：Windows 命名管道（ctypes/kernel32，零第三方依赖）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### 新增
 
+- **Windows 命名管道传输**（`transport="pipe"`，零第三方依赖，本机同主机）：给 import 白名单拒 `socket` 且不许 `pip install` 的券商终端一条活路——`ctypes.WinDLL("kernel32")` 就够，不碰套接字。同名管道的同步句柄不容并发读写（实测写会永久阻塞或报 err=232），所以每条连接**只有它的工作线程能写**：任意线程的应答只进 outbox 并 CancelIoEx 唤醒，由工作线程自己写出；客户端超时靠看门狗取消阻塞读（而非读后查超时）；停机先 CancelIoEx 再关句柄；写失败（可证未发出）自动重连重发一次，读失败（生死未知）照旧抛给调用方。实盘验证（2026-09-08，国金终端）：ping/get_asset/get_positions/query_orders/reload_deployment/reload_status 全部正常应答，deferred 三件套 110-405ms（adjust tick 节奏）。裸管道往返 ~0.012ms；选它是为了**依赖**，不是为了速度。
+
 - **全推订阅的状态查询与一键强拆**（`quote_subscription_status` / `quote_unsubscribe_all`，客户端同名方法）：忘了 seq 也有救。状态报每个组合的标的、客户端数、距上次心跳秒数——**一直保活的组合说明有心跳在喂（有客户端进程还活着），逐渐变冷的就是收割器正在收的路上**（实盘实测：客户端死后 ~30 秒收割器自动拆订阅）。强拆不需要 seq，关掉全部组合；keepalive 对未知 sub_id 是 no-op，清掉的组合不会复活。
 
 ### 修复

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/) 和 [语义化版本](https://semver.org/)。
 
 
-## [未发布]
+## [0.3.27] - 2026-09-08
 
 ### 新增
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xtquant-big-convert"
-version = "0.3.26"
+version = "0.3.27"
 description = "Big QMT RPC bridge and MiniQMT-compatible adapter layer (redis/zmq/mysql transports)"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -854,6 +854,7 @@ class BigQmtRpcHandlers:
             "cached_rows": len(getattr(self, "_credit_account_rows", []) or []),
             "last_callback_thread": getattr(self, "_credit_account_callback_thread", ""),
         }
+        info["ctypes_probe"] = self._probe_ctypes_named_pipe()
         info["thread_routing"] = self._probe_thread_routing()
         info["sector_probe"] = self._probe_sector_channels()
         info["order_watch"] = self._probe_order_watch()
@@ -1078,6 +1079,73 @@ class BigQmtRpcHandlers:
             report["hollow"] = True
             report["note"] = ("行数对但字段全空 —— QMT 交易类查询在主策略线程"
                               "之外就是这个样子，查 thread_routing")
+        return report
+
+    def _probe_ctypes_named_pipe(self):
+        """QMT 的导入白名单放不放行 ctypes + kernel32 命名管道。
+
+        白名单拒过 socket（还包括 logging.handlers 间接引入的那次），所以在
+        某些券商终端上 redis / pyzmq 都装不进去，桥根本没有线可用。命名管道
+        走 ctypes.WinDLL("kernel32")，是标准库、也不是 socket —— 如果放行，
+        它就是那类终端上唯一能用的传输。
+
+        这一条只能在 QMT 沙箱里问：用终端自带解释器 import 只测得到解释器，
+        测不到 QMT 运行时的白名单。逐级探测，每一级失败都记下原因，因为
+        「import 过了」不等于「建得出管道」——DLL 载入和内核对象创建是两回事。
+        """
+        report = {}
+        try:
+            import ctypes
+            report["import_ctypes"] = True
+        except Exception as exc:
+            report["import_ctypes"] = False
+            report["error"] = "%s: %s" % (exc.__class__.__name__, exc)
+            return report
+        try:
+            from ctypes import wintypes  # noqa: F401
+            report["import_wintypes"] = True
+        except Exception as exc:
+            report["import_wintypes"] = False
+            report["error"] = "%s: %s" % (exc.__class__.__name__, exc)
+            return report
+        try:
+            dll = ctypes.WinDLL("kernel32", use_last_error=True)
+            report["load_kernel32"] = True
+        except Exception as exc:
+            report["load_kernel32"] = False
+            report["error"] = "%s: %s" % (exc.__class__.__name__, exc)
+            return report
+        for func in ("CreateNamedPipeW", "ConnectNamedPipe", "ReadFile",
+                     "WriteFile", "CancelIoEx", "CreateFileW"):
+            try:
+                report["fn_" + func] = bool(getattr(dll, func))
+            except Exception:
+                report["fn_" + func] = False
+        # 真去建一个管道再立刻关掉。这一步才是「能不能用」的答案：DLL 载入
+        # 成功不代表内核允许创建命名管道对象（组策略/沙箱可能单独拦）。
+        try:
+            from ctypes import wintypes
+
+            dll.CreateNamedPipeW.restype = wintypes.HANDLE
+            path = "%s%s" % (chr(92) * 2 + "." + chr(92) + "pipe" + chr(92),
+                             "bigqmt_whitelist_probe")
+            handle = dll.CreateNamedPipeW(path, 0x00000003,
+                                          0x00000004 | 0x00000002 | 0x00000000,
+                                          1, 4096, 4096, 0, None)
+            invalid = ctypes.c_void_p(-1).value
+            if handle == invalid:
+                report["create_pipe"] = False
+                report["create_pipe_error"] = ctypes.get_last_error()
+            else:
+                report["create_pipe"] = True
+                report["pipe_path"] = path
+                try:
+                    dll.CloseHandle(handle)
+                except Exception:
+                    pass
+        except Exception as exc:
+            report["create_pipe"] = False
+            report["create_pipe_error"] = "%s: %s" % (exc.__class__.__name__, exc)
         return report
 
     def _probe_thread_routing(self):

--- a/src/bigqmt_signal_trader/transports/factory.py
+++ b/src/bigqmt_signal_trader/transports/factory.py
@@ -11,7 +11,7 @@ from .base import RpcTransport
 from .redis_transport import RedisTransport
 
 
-KNOWN_TRANSPORTS = ("redis", "zmq", "mysql", "shm")
+KNOWN_TRANSPORTS = ("redis", "zmq", "mysql", "shm", "pipe")
 
 
 def build_transport(
@@ -36,6 +36,20 @@ def build_transport(
         return _build_zmq(config, account_id, print_prefix)
     if name == "mysql":
         return _build_mysql(config, account_id, print_prefix)
+    if name == "pipe":
+        # Windows named pipe: no third-party package, no socket. The only wire
+        # that works on a terminal whose import whitelist rejects socket and
+        # whose bundled Python cannot pip install.
+        from .pipe_transport import NamedPipeTransport
+
+        pipe_config = dict(config.get("pipe") or {})
+        return NamedPipeTransport(
+            account_id=account_id,
+            print_prefix=print_prefix,
+            pipe_name=pipe_config.get("pipe_name") or "bigqmt_rpc",
+            connect_timeout_seconds=float(
+                pipe_config.get("connect_timeout_seconds") or 5.0),
+        )
     if name == "shm":
         return _build_shm(config, account_id, print_prefix)
     raise ValueError(

--- a/src/bigqmt_signal_trader/transports/factory.py
+++ b/src/bigqmt_signal_trader/transports/factory.py
@@ -14,6 +14,39 @@ from .redis_transport import RedisTransport
 KNOWN_TRANSPORTS = ("redis", "zmq", "mysql", "shm", "pipe")
 
 
+def transport_supports_drain(name):
+    """这个传输自己实现了 drain_request_queue 吗（不构造实例）。
+
+    调用方要判断「能不能走 adjust 轮询」，而**构造实例是有副作用的** ——
+    建 redis 连接、起线程。用它做探测污染过测试环境一次，所以这里只导入
+    模块、比对类属性，不 build。
+
+    工厂是「有哪些传输」的唯一来源，这个判断也该在这里，而不是让调用方
+    各自维护一张名单（pipe 就是在别处的名单里漏掉，导致 drain 从未生效）。
+    """
+    from .base import RpcTransport
+
+    name = str(name or "redis").lower()
+    try:
+        if name in ("redis", "", "default"):
+            from .redis_transport import RedisTransport as cls
+        elif name == "zmq":
+            from .zmq_transport import ZmqTransport as cls
+        elif name == "mysql":
+            from .mysql_transport import MysqlTransport as cls
+        elif name == "pipe":
+            from .pipe_transport import NamedPipeTransport as cls
+        else:
+            return False
+    except ImportError:
+        # 缺依赖（没装 pyzmq / mysql 驱动）是合法的「不支持」。但类名写错也会
+        # 走到这里 —— MySqlTransport / MysqlTransport 就错过一次，被静默吞成
+        # False。所以只吞 ImportError，AttributeError 之类必须炸出来。
+        return False
+    own = getattr(cls, "drain_request_queue", None)
+    return own is not None and own is not getattr(RpcTransport, "drain_request_queue", None)
+
+
 def build_transport(
     name,
     config=None,

--- a/src/bigqmt_signal_trader/transports/pipe_transport.py
+++ b/src/bigqmt_signal_trader/transports/pipe_transport.py
@@ -60,6 +60,7 @@ ERROR_MORE_DATA = 234
 ERROR_OPERATION_ABORTED = 995
 ERROR_INVALID_HANDLE = 6
 ERROR_BROKEN_PIPE = 109
+ERROR_FILE_NOT_FOUND = 2
 
 _BUFFER_BYTES = 1 << 20      # 1MB: whole-market quote frames are large
 _CONNECT_POLL_SECONDS = 0.05
@@ -115,6 +116,14 @@ class NamedPipeTransport(RpcTransport):
         # DEALER, and the reason that fix is not worth repeating here.
         self._client_local = threading.local()
         self._client_handles = []
+        # One lock per server-side connection: inline answers are written from
+        # the connection's worker thread while deferred answers (orders,
+        # positions, anything in LISTENER_DEFERRED_METHODS) are written from
+        # the adjust thread. Two threads writing one message-mode handle at
+        # once interleave frames and the client sees garbage -- the live
+        # "deferred methods never get a response" defect. Message mode does
+        # NOT make cross-thread writes atomic.
+        self._write_locks = {}
         # 读缓冲也按线程持有 —— 见 _read_buffer 里的实测数字。
         self._io_local = threading.local()
 
@@ -190,7 +199,11 @@ class NamedPipeTransport(RpcTransport):
             if handle != INVALID_HANDLE_VALUE:
                 break
             err = self._last_error()
-            if err != ERROR_PIPE_BUSY or time.time() >= deadline:
+            # FILE_NOT_FOUND is the startup race: start_receiving has spawned
+            # the accept thread but it has not created the first instance yet.
+            # Retrying it is exactly as legitimate as retrying PIPE_BUSY.
+            if err not in (ERROR_PIPE_BUSY, ERROR_FILE_NOT_FOUND) \
+                    or time.time() >= deadline:
                 raise TransportError(
                     "cannot connect to %s (err=%s). Is the QMT-side strategy "
                     "running with transport=pipe?" % (self.path, err))
@@ -202,27 +215,60 @@ class NamedPipeTransport(RpcTransport):
             self._client_handles.append(handle)
         return handle
 
-    def send_request(self, request, timeout_seconds):
-        handle = self._client_handle()
-        payload = json.dumps(request, ensure_ascii=False, default=str).encode("utf-8")
-        started = time.time()
+    def _cancel_read(self, handle):
+        """Abort whatever ReadFile is pending on the handle -- the timeout
+        mechanism for the client (#236 defect 3).
+
+        The first design put a pump thread between the caller and the pipe so
+        the caller could wait on a queue instead. That dead-locked on the very
+        first request: a synchronous (non-overlapped) handle serializes I/O,
+        so a WriteFile issued while the pump sat in a blocking ReadFile on the
+        SAME handle never completes. The alternatives were overlapped I/O or a
+        second pipe per direction; a watchdog that cancels the blocking read
+        at the deadline keeps single-threaded I/O and gets the same real
+        timeout with none of that surgery. CancelIoEx is already the proven
+        shutdown mechanism on the server side (the stop() deadlock fix).
+        """
         try:
-            self._write(handle, payload)
+            self._dll().CancelIoEx(handle, None)
+        except Exception:
+            pass
+
+    def send_request(self, request, timeout_seconds):
+        payload = json.dumps(request, ensure_ascii=False, default=str).encode("utf-8")
+        try:
+            self._write(self._client_handle(), payload)
+        except TransportError:
+            # A write-side failure is provable: nothing left this process, so
+            # ONE reconnect-and-resend is safe (never a duplicate). A read-side
+            # failure is the unknown-outcome case and is NOT retried here --
+            # that is the #195 class of bug. The caller decides on those.
+            self._drop_client_handle()
+            self._write(self._client_handle(), payload)
+        return json.loads(decode_text(
+            self._read_with_watchdog(self._client_handle(), timeout_seconds)))
+
+    def _read_with_watchdog(self, handle, timeout_seconds):
+        watchdog = None
+        if timeout_seconds:
+            watchdog = threading.Timer(
+                float(timeout_seconds), self._cancel_read, args=(handle,))
+            watchdog.daemon = True
+            watchdog.start()
+        try:
             raw = self._read(handle)
         except TransportError:
-            # A broken pipe means the bridge restarted. Drop the handle so the
-            # next call reconnects instead of failing forever on a dead one.
             self._drop_client_handle()
             raise
+        finally:
+            if watchdog is not None:
+                watchdog.cancel()
         if not raw:
+            # Empty read is the watchdog's ERROR_OPERATION_ABORTED, a closed
+            # handle, or a broken pipe -- all mean the answer is not coming.
             self._drop_client_handle()
-            raise TransportTimeout(
-                "named pipe closed while waiting for %s"
-                % (request or {}).get("method"))
-        if timeout_seconds and (time.time() - started) > float(timeout_seconds):
-            raise TransportTimeout(
-                "named pipe rpc timeout: %s" % (request or {}).get("method"))
-        return json.loads(decode_text(raw))
+            raise TransportTimeout("named pipe rpc timeout")
+        return raw
 
     def _drop_client_handle(self):
         handle = getattr(self._client_local, "handle", None)
@@ -259,6 +305,7 @@ class NamedPipeTransport(RpcTransport):
                 continue
             with self._server_lock:
                 self._server_handles.append(handle)
+                self._write_locks[handle] = threading.Lock()
             connected = dll.ConnectNamedPipe(handle, None)
             if not connected and self._last_error() != ERROR_PIPE_CONNECTED:
                 self._close_server_handle(handle)
@@ -310,7 +357,13 @@ class NamedPipeTransport(RpcTransport):
         if handle is None:
             raise TransportError("no pipe handle on the request to reply to")
         payload = json.dumps(response, ensure_ascii=False, default=str).encode("utf-8")
-        self._write(handle, payload)
+        with self._server_lock:
+            lock = self._write_locks.get(handle)
+        if lock is not None:
+            with lock:
+                self._write(handle, payload)
+        else:
+            self._write(handle, payload)
 
     def _close_server_handle(self, handle):
         # 先把句柄从表里摘掉，摘到的那个线程才负责真正关闭。stop() 和工作线程
@@ -320,6 +373,7 @@ class NamedPipeTransport(RpcTransport):
             if handle not in self._server_handles:
                 return
             self._server_handles.remove(handle)
+            self._write_locks.pop(handle, None)
         dll = self._dll()
         # **必须先取消挂起的 I/O。** DisconnectNamedPipe 会等同一句柄上挂起的
         # 同步 ReadFile 完成，而工作线程正阻塞在那个 ReadFile 上等下一个请求 ——
@@ -356,9 +410,20 @@ class NamedPipeTransport(RpcTransport):
                 pass
         for handle in server:
             self._close_server_handle(handle)
+        dll = self._dll()
         for handle in clients:
             try:
-                self._dll().CloseHandle(handle)
+                # CancelIoEx BEFORE CloseHandle even though there is no pump:
+                # a send_request on another thread can have a blocking
+                # ReadFile pending on this handle, and CloseHandle on a
+                # synchronous handle with pending I/O blocks until it
+                # completes -- i.e. stop() hangs for as long as the server
+                # stays silent (this test's exact failure).
+                dll.CancelIoEx(handle, None)
+            except Exception:
+                pass
+            try:
+                dll.CloseHandle(handle)
             except Exception:
                 pass
         with self._server_lock:

--- a/src/bigqmt_signal_trader/transports/pipe_transport.py
+++ b/src/bigqmt_signal_trader/transports/pipe_transport.py
@@ -34,6 +34,7 @@ Deployments that need those keep Redis or ZMQ.
 import ctypes
 import json
 import os
+import queue
 import threading
 import time
 
@@ -116,14 +117,6 @@ class NamedPipeTransport(RpcTransport):
         # DEALER, and the reason that fix is not worth repeating here.
         self._client_local = threading.local()
         self._client_handles = []
-        # One lock per server-side connection: inline answers are written from
-        # the connection's worker thread while deferred answers (orders,
-        # positions, anything in LISTENER_DEFERRED_METHODS) are written from
-        # the adjust thread. Two threads writing one message-mode handle at
-        # once interleave frames and the client sees garbage -- the live
-        # "deferred methods never get a response" defect. Message mode does
-        # NOT make cross-thread writes atomic.
-        self._write_locks = {}
         # 读缓冲也按线程持有 —— 见 _read_buffer 里的实测数字。
         self._io_local = threading.local()
 
@@ -160,15 +153,20 @@ class NamedPipeTransport(RpcTransport):
         return buf
 
     def _read(self, handle):
+        """Read one message; b"" only for a CancelIoEx wake, raise for a real close.
+
+        Two outcomes MUST be told apart now that writes are driven by waking
+        the reader: CancelIoEx (a writer woke us so we can write) returns
+        ERROR_OPERATION_ABORTED -- that is a wake, not a close; a peer going
+        away (ERROR_BROKEN_PIPE / ERROR_INVALID_HANDLE) IS a close and the
+        connection is over.
+        """
         dll = self._dll()
         buf = self._read_buffer()
         read = self._wintypes.DWORD()
         chunks = []
         while True:
             ok = dll.ReadFile(handle, buf, _BUFFER_BYTES, ctypes.byref(read), None)
-            # string_at 只拷实际读到的字节。buf.raw 会先把整个 1MB 缓冲区
-            # 复制成 bytes 再切片 —— 和上面那个每次分配 1MB 是同一类错误，
-            # 实测占掉往返的一半时间。
             if read.value:
                 chunks.append(ctypes.string_at(buf, read.value))
             if ok:
@@ -176,10 +174,11 @@ class NamedPipeTransport(RpcTransport):
             err = self._last_error()
             if err == ERROR_MORE_DATA:
                 continue
-            # 停机路径：CancelIoEx 取消了这次读、句柄被关掉、或对端断开。
-            # 这些都是正常收尾，不该当成错误抛出去把日志刷满。
-            if err in (ERROR_OPERATION_ABORTED, ERROR_INVALID_HANDLE,
-                       ERROR_BROKEN_PIPE) or not self._running:
+            if err == ERROR_OPERATION_ABORTED:
+                return b""          # a writer woke us to write; not a close
+            if err in (ERROR_INVALID_HANDLE, ERROR_BROKEN_PIPE):
+                raise TransportError("pipe closed (err=%s)" % err)
+            if not self._running:
                 return b""
             if not chunks or not chunks[0]:
                 return b""
@@ -305,7 +304,6 @@ class NamedPipeTransport(RpcTransport):
                 continue
             with self._server_lock:
                 self._server_handles.append(handle)
-                self._write_locks[handle] = threading.Lock()
             connected = dll.ConnectNamedPipe(handle, None)
             if not connected and self._last_error() != ERROR_PIPE_CONNECTED:
                 self._close_server_handle(handle)
@@ -320,24 +318,50 @@ class NamedPipeTransport(RpcTransport):
             worker.start()
 
     def _serve_connection(self, handle):
+        """One connection, single-threaded I/O: reads AND writes happen here.
+
+        This is the deferred-answer defect, finally explained: a deferred
+        answer is produced on the adjust thread while this worker sits in a
+        blocking ReadFile -- and a synchronous handle does not tolerate a
+        WriteFile concurrent with a pending ReadFile (measured: the write
+        blocks forever, or fails err=232 ERROR_NO_DATA). So nobody may write
+        except this thread. send_response on any thread only QUEUES into the
+        outbox and CancelIoEx's the pending read; this loop then writes the
+        payload itself. Write-before-read ordering plus the writer's
+        queue-before-cancel ordering means a cancelled-for payload is always
+        visible when the aborted read returns.
+        """
+        outbox = queue.Queue()
         try:
             while self._running:
+                while not outbox.empty():
+                    self._write(handle, outbox.get())
                 try:
                     raw = self._read(handle)
                 except TransportError:
-                    break
+                    return
                 if not raw:
-                    break
+                    # Woken by a writer (payload comes out at the top of the
+                    # loop) or by stop(). Not a close -- a real close raises.
+                    continue
                 try:
                     request = json.loads(decode_text(raw))
                 except Exception:
-                    break
-                # Remember which handle to answer on. send_response reads it
-                # back, so a handler that replies inline reaches the right peer
-                # even with several clients connected at once.
+                    return
+                # Remember which outbox to answer on. send_response reads it
+                # back, so inline and deferred answers both reach this peer.
                 request["_pipe_handle"] = handle
+                request["_pipe_outbox"] = outbox
                 self.deliver(request)
         finally:
+            # Flush whatever is queued before closing: the reload reply is a
+            # deferred answer, and a stop() that swallows it is exactly the
+            # reload self-teardown defect.
+            try:
+                while not outbox.empty():
+                    self._write(handle, outbox.get())
+            except Exception:
+                pass
             self._close_server_handle(handle)
 
     def drain_request_queue(self, max_items=20):
@@ -353,17 +377,21 @@ class NamedPipeTransport(RpcTransport):
         return 0
 
     def send_response(self, request, response):
+        """Queue the answer onto the connection's outbox and wake its worker.
+
+        Never writes directly: only the connection worker may write (a
+        synchronous handle does not tolerate a WriteFile concurrent with a
+        pending ReadFile -- the deferred-answer defect). The worker queues
+        BEFORE cancelling, so the payload is always visible by the time the
+        aborted read returns.
+        """
         handle = (request or {}).get("_pipe_handle")
-        if handle is None:
+        outbox = (request or {}).get("_pipe_outbox")
+        if handle is None or outbox is None:
             raise TransportError("no pipe handle on the request to reply to")
         payload = json.dumps(response, ensure_ascii=False, default=str).encode("utf-8")
-        with self._server_lock:
-            lock = self._write_locks.get(handle)
-        if lock is not None:
-            with lock:
-                self._write(handle, payload)
-        else:
-            self._write(handle, payload)
+        outbox.put(payload)
+        self._cancel_read(handle)
 
     def _close_server_handle(self, handle):
         # 先把句柄从表里摘掉，摘到的那个线程才负责真正关闭。stop() 和工作线程
@@ -373,7 +401,6 @@ class NamedPipeTransport(RpcTransport):
             if handle not in self._server_handles:
                 return
             self._server_handles.remove(handle)
-            self._write_locks.pop(handle, None)
         dll = self._dll()
         # **必须先取消挂起的 I/O。** DisconnectNamedPipe 会等同一句柄上挂起的
         # 同步 ReadFile 完成，而工作线程正阻塞在那个 ReadFile 上等下一个请求 ——

--- a/src/bigqmt_signal_trader/transports/pipe_transport.py
+++ b/src/bigqmt_signal_trader/transports/pipe_transport.py
@@ -293,6 +293,18 @@ class NamedPipeTransport(RpcTransport):
         finally:
             self._close_server_handle(handle)
 
+    def drain_request_queue(self, max_items=20):
+        """没有队列要排空 —— 请求由每连接的工作线程直接投递。
+
+        **必须存在，哪怕是空实现。** 服务端 drain_request_queue 的兜底分支是
+        Redis 的 ``listen_redis.lpop``，而 pipe 部署上 listen_redis 是 None：
+        传输少了这个方法，adjust 每个 tick 都会撞
+        ``AttributeError: 'NoneType' object has no attribute 'lpop'``。
+        实盘上就是这么炸的 —— 单测抓不到，只有端到端能暴露。zmq 的
+        drain_request_queue 在 router 线程存在时同样是 no-op。
+        """
+        return 0
+
     def send_response(self, request, response):
         handle = (request or {}).get("_pipe_handle")
         if handle is None:

--- a/src/bigqmt_signal_trader/transports/pipe_transport.py
+++ b/src/bigqmt_signal_trader/transports/pipe_transport.py
@@ -1,0 +1,356 @@
+# coding: utf-8
+"""Windows named-pipe transport (same-host, zero third-party dependencies).
+
+Why this exists
+---------------
+Some broker QMT builds enforce an import whitelist that rejects ``socket``
+(directly and indirectly -- ``logging.handlers`` pulled it in once) and forbid
+``pip install`` into the bundled Python. On those terminals neither the Redis
+client nor ``pyzmq`` can be installed, so the bridge has no wire at all.
+
+A named pipe needs neither: ``ctypes.WinDLL("kernel32")`` is standard library,
+and named pipes are not sockets, so they sit outside the whitelist that blocks
+networking. Same trick the cfquant project uses.
+
+What it buys, measured
+----------------------
+Raw round trip on this machine, 108-byte payload, 500 iterations::
+
+    named pipe    median 0.012ms
+    zmq REQ/REP   median 0.109ms
+    redis list    median 0.798ms
+
+66x faster than Redis **at the wire**. But the wire is not where the time goes:
+end-to-end RPC against the live bridge measures 3-12ms median, so replacing
+Redis with a pipe saves ~0.79ms of that -- 25% on the fastest calls, 7% on the
+slowest. Pick this transport for the *dependency* story, not the speed story.
+
+Limits
+------
+Windows only, same host only. No cross-machine, no Linux client, no Docker.
+Deployments that need those keep Redis or ZMQ.
+"""
+
+import ctypes
+import json
+import os
+import threading
+import time
+
+from .base import RpcTransport, TransportError, TransportTimeout
+from ..adapters.redis_common import decode_text
+
+
+DEFAULT_PIPE_NAME = "bigqmt_rpc"
+_PIPE_ROOT = "\\\\.\\pipe\\"
+
+# kernel32 constants (winbase.h)
+PIPE_ACCESS_DUPLEX = 0x00000003
+PIPE_TYPE_MESSAGE = 0x00000004
+PIPE_READMODE_MESSAGE = 0x00000002
+PIPE_WAIT = 0x00000000
+PIPE_UNLIMITED_INSTANCES = 255
+GENERIC_READ = 0x80000000
+GENERIC_WRITE = 0x40000000
+OPEN_EXISTING = 3
+INVALID_HANDLE_VALUE = ctypes.c_void_p(-1).value
+ERROR_PIPE_CONNECTED = 535
+ERROR_PIPE_BUSY = 231
+ERROR_MORE_DATA = 234
+ERROR_OPERATION_ABORTED = 995
+ERROR_INVALID_HANDLE = 6
+ERROR_BROKEN_PIPE = 109
+
+_BUFFER_BYTES = 1 << 20      # 1MB: whole-market quote frames are large
+_CONNECT_POLL_SECONDS = 0.05
+
+
+def _kernel32():
+    if os.name != "nt":
+        raise TransportError(
+            "named-pipe transport is Windows-only (os.name=%r). Use redis or "
+            "zmq for cross-platform deployments." % os.name)
+    from ctypes import wintypes
+
+    dll = ctypes.WinDLL("kernel32", use_last_error=True)
+    dll.CreateNamedPipeW.restype = wintypes.HANDLE
+    dll.CreateFileW.restype = wintypes.HANDLE
+    return dll, wintypes
+
+
+def pipe_path(name=DEFAULT_PIPE_NAME, account_id=""):
+    """Full pipe path. The account id is part of the name so two bridges --
+    one live account, one simulated -- never share a wire (the same mistake
+    that gave two deployments one log file, #144)."""
+    suffix = ("_" + str(account_id)) if account_id else ""
+    return _PIPE_ROOT + str(name or DEFAULT_PIPE_NAME) + suffix
+
+
+class NamedPipeTransport(RpcTransport):
+    """Request/response over a Windows named pipe in message mode.
+
+    Message mode (not byte mode) is deliberate: each WriteFile is one message
+    and each ReadFile returns exactly one, so there is no framing protocol to
+    get wrong. A message larger than the read buffer surfaces as
+    ERROR_MORE_DATA rather than a silently truncated payload.
+    """
+
+    name = "pipe"
+
+    def __init__(self, account_id="", print_prefix="[bigqmt_rpc]",
+                 pipe_name=DEFAULT_PIPE_NAME, connect_timeout_seconds=5.0,
+                 **kwargs):
+        super(NamedPipeTransport, self).__init__(
+            account_id=account_id, print_prefix=print_prefix)
+        self.pipe_name = str(pipe_name or DEFAULT_PIPE_NAME)
+        self.connect_timeout_seconds = float(connect_timeout_seconds)
+        self.path = pipe_path(self.pipe_name, account_id)
+        self._k32 = None
+        self._wintypes = None
+        self._listener = None
+        self._server_handles = []
+        self._server_lock = threading.RLock()
+        # Per-thread client handle. A single shared handle would serialise every
+        # caller behind one round trip -- exactly the bug #186 fixed for the ZMQ
+        # DEALER, and the reason that fix is not worth repeating here.
+        self._client_local = threading.local()
+        self._client_handles = []
+        # 读缓冲也按线程持有 —— 见 _read_buffer 里的实测数字。
+        self._io_local = threading.local()
+
+    # -- ctypes plumbing ---------------------------------------------------
+    def _dll(self):
+        if self._k32 is None:
+            self._k32, self._wintypes = _kernel32()
+        return self._k32
+
+    def _last_error(self):
+        return ctypes.get_last_error()
+
+    def _write(self, handle, payload):
+        dll = self._dll()
+        written = self._wintypes.DWORD()
+        ok = dll.WriteFile(handle, payload, len(payload),
+                           ctypes.byref(written), None)
+        if not ok:
+            raise TransportError("WriteFile failed (err=%s)" % self._last_error())
+        return written.value
+
+    def _read_buffer(self):
+        """按线程复用读缓冲。
+
+        原来每次 _read 都 create_string_buffer(1MB) —— 分配并清零 1MB，一次
+        往返两侧各一次就是 2MB。实测：裸管道往返 0.012ms、两侧 JSON 合计
+        0.010ms，预期总共 0.022ms，而传输层实测中位 0.765ms —— 多出来的
+        0.74ms 全在这里。缓冲区按线程持有一份即可，读多少用多少。
+        """
+        buf = getattr(self._io_local, "buf", None)
+        if buf is None:
+            buf = ctypes.create_string_buffer(_BUFFER_BYTES)
+            self._io_local.buf = buf
+        return buf
+
+    def _read(self, handle):
+        dll = self._dll()
+        buf = self._read_buffer()
+        read = self._wintypes.DWORD()
+        chunks = []
+        while True:
+            ok = dll.ReadFile(handle, buf, _BUFFER_BYTES, ctypes.byref(read), None)
+            # string_at 只拷实际读到的字节。buf.raw 会先把整个 1MB 缓冲区
+            # 复制成 bytes 再切片 —— 和上面那个每次分配 1MB 是同一类错误，
+            # 实测占掉往返的一半时间。
+            if read.value:
+                chunks.append(ctypes.string_at(buf, read.value))
+            if ok:
+                break
+            err = self._last_error()
+            if err == ERROR_MORE_DATA:
+                continue
+            # 停机路径：CancelIoEx 取消了这次读、句柄被关掉、或对端断开。
+            # 这些都是正常收尾，不该当成错误抛出去把日志刷满。
+            if err in (ERROR_OPERATION_ABORTED, ERROR_INVALID_HANDLE,
+                       ERROR_BROKEN_PIPE) or not self._running:
+                return b""
+            if not chunks or not chunks[0]:
+                return b""
+            raise TransportError("ReadFile failed (err=%s)" % err)
+        return b"".join(chunks)
+
+    # -- client side -------------------------------------------------------
+    def _client_handle(self):
+        handle = getattr(self._client_local, "handle", None)
+        if handle is not None:
+            return handle
+        dll = self._dll()
+        deadline = time.time() + self.connect_timeout_seconds
+        while True:
+            handle = dll.CreateFileW(self.path, GENERIC_READ | GENERIC_WRITE,
+                                     0, None, OPEN_EXISTING, 0, None)
+            if handle != INVALID_HANDLE_VALUE:
+                break
+            err = self._last_error()
+            if err != ERROR_PIPE_BUSY or time.time() >= deadline:
+                raise TransportError(
+                    "cannot connect to %s (err=%s). Is the QMT-side strategy "
+                    "running with transport=pipe?" % (self.path, err))
+            time.sleep(_CONNECT_POLL_SECONDS)
+        mode = self._wintypes.DWORD(PIPE_READMODE_MESSAGE)
+        dll.SetNamedPipeHandleState(handle, ctypes.byref(mode), None, None)
+        self._client_local.handle = handle
+        with self._server_lock:
+            self._client_handles.append(handle)
+        return handle
+
+    def send_request(self, request, timeout_seconds):
+        handle = self._client_handle()
+        payload = json.dumps(request, ensure_ascii=False, default=str).encode("utf-8")
+        started = time.time()
+        try:
+            self._write(handle, payload)
+            raw = self._read(handle)
+        except TransportError:
+            # A broken pipe means the bridge restarted. Drop the handle so the
+            # next call reconnects instead of failing forever on a dead one.
+            self._drop_client_handle()
+            raise
+        if not raw:
+            self._drop_client_handle()
+            raise TransportTimeout(
+                "named pipe closed while waiting for %s"
+                % (request or {}).get("method"))
+        if timeout_seconds and (time.time() - started) > float(timeout_seconds):
+            raise TransportTimeout(
+                "named pipe rpc timeout: %s" % (request or {}).get("method"))
+        return json.loads(decode_text(raw))
+
+    def _drop_client_handle(self):
+        handle = getattr(self._client_local, "handle", None)
+        if handle is None:
+            return
+        try:
+            self._dll().CloseHandle(handle)
+        except Exception:
+            pass
+        self._client_local.handle = None
+        with self._server_lock:
+            if handle in self._client_handles:
+                self._client_handles.remove(handle)
+
+    # -- server side -------------------------------------------------------
+    def start_receiving(self, on_request, **kwargs):
+        super(NamedPipeTransport, self).start_receiving(on_request)
+        self._listener = threading.Thread(
+            target=self._accept_loop, name="bigqmt-pipe-accept")
+        self._listener.daemon = True
+        self._listener.start()
+
+    def _accept_loop(self):
+        dll = self._dll()
+        while self._running:
+            handle = dll.CreateNamedPipeW(
+                self.path, PIPE_ACCESS_DUPLEX,
+                PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT,
+                PIPE_UNLIMITED_INSTANCES, _BUFFER_BYTES, _BUFFER_BYTES, 0, None)
+            if handle == INVALID_HANDLE_VALUE:
+                if not self._running:
+                    return
+                time.sleep(_CONNECT_POLL_SECONDS)
+                continue
+            with self._server_lock:
+                self._server_handles.append(handle)
+            connected = dll.ConnectNamedPipe(handle, None)
+            if not connected and self._last_error() != ERROR_PIPE_CONNECTED:
+                self._close_server_handle(handle)
+                continue
+            if not self._running:
+                self._close_server_handle(handle)
+                return
+            worker = threading.Thread(
+                target=self._serve_connection, args=(handle,),
+                name="bigqmt-pipe-conn")
+            worker.daemon = True
+            worker.start()
+
+    def _serve_connection(self, handle):
+        try:
+            while self._running:
+                try:
+                    raw = self._read(handle)
+                except TransportError:
+                    break
+                if not raw:
+                    break
+                try:
+                    request = json.loads(decode_text(raw))
+                except Exception:
+                    break
+                # Remember which handle to answer on. send_response reads it
+                # back, so a handler that replies inline reaches the right peer
+                # even with several clients connected at once.
+                request["_pipe_handle"] = handle
+                self.deliver(request)
+        finally:
+            self._close_server_handle(handle)
+
+    def send_response(self, request, response):
+        handle = (request or {}).get("_pipe_handle")
+        if handle is None:
+            raise TransportError("no pipe handle on the request to reply to")
+        payload = json.dumps(response, ensure_ascii=False, default=str).encode("utf-8")
+        self._write(handle, payload)
+
+    def _close_server_handle(self, handle):
+        # 先把句柄从表里摘掉，摘到的那个线程才负责真正关闭。stop() 和工作线程
+        # 的 finally 会同时走到这里，重复 CloseHandle 会关掉一个已被回收复用的
+        # 句柄 —— 那种 bug 只会在高并发下偶发，最难查。
+        with self._server_lock:
+            if handle not in self._server_handles:
+                return
+            self._server_handles.remove(handle)
+        dll = self._dll()
+        # **必须先取消挂起的 I/O。** DisconnectNamedPipe 会等同一句柄上挂起的
+        # 同步 ReadFile 完成，而工作线程正阻塞在那个 ReadFile 上等下一个请求 ——
+        # 谁也等不到谁，主线程和 20 个工作线程一起卡死（实测线程栈确认）。
+        # CancelIoEx 让那次读带 ERROR_OPERATION_ABORTED 返回，循环随即退出。
+        try:
+            dll.CancelIoEx(handle, None)
+        except Exception:
+            pass
+        try:
+            dll.DisconnectNamedPipe(handle)
+        except Exception:
+            pass
+        try:
+            dll.CloseHandle(handle)
+        except Exception:
+            pass
+
+    def stop(self):
+        self._running = False
+        with self._server_lock:
+            server = list(self._server_handles)
+            clients = list(self._client_handles)
+        # Unblock the accept loop: it is parked in ConnectNamedPipe, which only
+        # returns once somebody connects. Connect to our own pipe once.
+        if server:
+            try:
+                dll = self._dll()
+                handle = dll.CreateFileW(self.path, GENERIC_READ | GENERIC_WRITE,
+                                         0, None, OPEN_EXISTING, 0, None)
+                if handle != INVALID_HANDLE_VALUE:
+                    dll.CloseHandle(handle)
+            except Exception:
+                pass
+        for handle in server:
+            self._close_server_handle(handle)
+        for handle in clients:
+            try:
+                self._dll().CloseHandle(handle)
+            except Exception:
+                pass
+        with self._server_lock:
+            self._client_handles = []
+        self._client_local = threading.local()
+        self._io_local = threading.local()
+        super(NamedPipeTransport, self).stop()

--- a/src/bigqmt_signal_trader/transports/pipe_transport.py
+++ b/src/bigqmt_signal_trader/transports/pipe_transport.py
@@ -77,6 +77,8 @@ def _kernel32():
     dll = ctypes.WinDLL("kernel32", use_last_error=True)
     dll.CreateNamedPipeW.restype = wintypes.HANDLE
     dll.CreateFileW.restype = wintypes.HANDLE
+    # drain 模式要用它做非阻塞探测：有数据才 ReadFile，绝不在 adjust 线程上阻塞
+    dll.PeekNamedPipe.restype = wintypes.BOOL
     return dll, wintypes
 
 
@@ -111,6 +113,9 @@ class NamedPipeTransport(RpcTransport):
         self._wintypes = None
         self._listener = None
         self._server_handles = []
+        # drain 模式下由 adjust 线程轮询的已连接句柄
+        self._background_threads = True
+        self._drain_handles = []
         self._server_lock = threading.RLock()
         # Per-thread client handle. A single shared handle would serialise every
         # caller behind one round trip -- exactly the bug #186 fixed for the ZMQ
@@ -284,7 +289,21 @@ class NamedPipeTransport(RpcTransport):
 
     # -- server side -------------------------------------------------------
     def start_receiving(self, on_request, **kwargs):
+        """两种模式，和 zmq / redis 一致（#183）。
+
+        background_threads=True  每连接一个工作线程收发（原有行为）
+        background_threads=False adjust 线程在 drain_request_queue 里非阻塞轮询
+
+        实测 background_threads=True 时请求要 ~200ms 才到达 handler，而
+        handler 本身 0.0ms —— 和 #183 记录的 zmq 404ms 是同一个形状。drain
+        模式把读、处理、写全放回 adjust 线程，去掉跨线程交接。
+
+        两种模式下 accept 都留一个线程：它只阻塞在 ConnectNamedPipe 上，不碰
+        请求数据，代价是一个常驻线程而不是每连接一个。
+        """
         super(NamedPipeTransport, self).start_receiving(on_request)
+        background = kwargs.get("background_threads")
+        self._background_threads = True if background is None else bool(background)
         self._listener = threading.Thread(
             target=self._accept_loop, name="bigqmt-pipe-accept")
         self._listener.daemon = True
@@ -311,6 +330,10 @@ class NamedPipeTransport(RpcTransport):
             if not self._running:
                 self._close_server_handle(handle)
                 return
+            if not self._background_threads:
+                # drain 模式：不起工作线程，交给 adjust 线程轮询这个句柄。
+                self._drain_handles.append(handle)
+                continue
             worker = threading.Thread(
                 target=self._serve_connection, args=(handle,),
                 name="bigqmt-pipe-conn")
@@ -364,17 +387,72 @@ class NamedPipeTransport(RpcTransport):
                 pass
             self._close_server_handle(handle)
 
-    def drain_request_queue(self, max_items=20):
-        """没有队列要排空 —— 请求由每连接的工作线程直接投递。
+    def _peek_available(self, handle):
+        """这个句柄上有没有待读数据。PeekNamedPipe 不阻塞，可用于同步句柄。"""
+        dll = self._dll()
+        avail = self._wintypes.DWORD(0)
+        ok = dll.PeekNamedPipe(handle, None, 0, None,
+                               ctypes.byref(avail), None)
+        if not ok:
+            raise TransportError("PeekNamedPipe failed (err=%s)" % self._last_error())
+        return avail.value
 
-        **必须存在，哪怕是空实现。** 服务端 drain_request_queue 的兜底分支是
-        Redis 的 ``listen_redis.lpop``，而 pipe 部署上 listen_redis 是 None：
-        传输少了这个方法，adjust 每个 tick 都会撞
-        ``AttributeError: 'NoneType' object has no attribute 'lpop'``。
-        实盘上就是这么炸的 —— 单测抓不到，只有端到端能暴露。zmq 的
-        drain_request_queue 在 router 线程存在时同样是 no-op。
+    def drain_request_queue(self, max_items=20):
+        """drain 模式：adjust 线程自己把请求读出来、处理掉、把响应写回去。
+
+        读、handler、写全在同一条线程上，所以没有跨线程交接，也不需要
+        outbox + CancelIoEx 那套唤醒机制 —— 那套是 background_threads=True
+        时才需要的。
+
+        非阻塞：先 PeekNamedPipe 看有没有数据，有才 ReadFile。没有就跳过，
+        绝不能在 adjust 线程上阻塞等下一个请求。
         """
-        return 0
+        if self._background_threads:
+            return 0                 # 工作线程在收，这里不插手
+        processed = 0
+        for handle in list(self._drain_handles):
+            while processed < int(max_items):
+                try:
+                    if not self._peek_available(handle):
+                        break
+                    raw = self._read(handle)
+                except TransportError:
+                    self._forget_drain_handle(handle)
+                    break
+                if not raw:
+                    break
+                try:
+                    request = json.loads(decode_text(raw))
+                except Exception:
+                    self._forget_drain_handle(handle)
+                    break
+                request["_pipe_handle"] = handle
+                response = None
+                try:
+                    response = self.deliver(request)
+                except Exception as exc:
+                    response = {"schema_version": 1,
+                                "request_id": request.get("request_id"),
+                                "method": request.get("method"),
+                                "ok": False,
+                                "error": "%s: %s" % (exc.__class__.__name__, exc)}
+                if response is not None:
+                    try:
+                        self._write(handle, json.dumps(
+                            response, ensure_ascii=False, default=str).encode("utf-8"))
+                    except Exception:
+                        self._forget_drain_handle(handle)
+                        break
+                processed += 1
+        return processed
+
+    def _forget_drain_handle(self, handle):
+        try:
+            self._drain_handles.remove(handle)
+        except ValueError:
+            pass
+        self._close_server_handle(handle)
+
 
     def send_response(self, request, response):
         """Queue the answer onto the connection's outbox and wake its worker.
@@ -386,10 +464,16 @@ class NamedPipeTransport(RpcTransport):
         aborted read returns.
         """
         handle = (request or {}).get("_pipe_handle")
-        outbox = (request or {}).get("_pipe_outbox")
-        if handle is None or outbox is None:
+        if handle is None:
             raise TransportError("no pipe handle on the request to reply to")
         payload = json.dumps(response, ensure_ascii=False, default=str).encode("utf-8")
+        outbox = (request or {}).get("_pipe_outbox")
+        if outbox is None:
+            # drain 模式：没有工作线程，adjust 线程是唯一的读者也是唯一的写者，
+            # 没有并发读写的问题，直接写。（漏了这一支时服务端自己发响应会抛
+            # 「no pipe handle」，客户端表现为超时，实盘上就是这么卡住的。）
+            self._write(handle, payload)
+            return
         outbox.put(payload)
         self._cancel_read(handle)
 

--- a/src/bigqmt_signal_trader/version.py
+++ b/src/bigqmt_signal_trader/version.py
@@ -21,7 +21,7 @@ copy never happened" and "the copy landed but was not picked up" look identical
 from the outside.
 """
 
-__version__ = "0.3.26"
+__version__ = "0.3.27"
 
 
 def deployment_report(package_dir=None):

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -955,6 +955,9 @@ class BigQmtRpcClient:
             factory_config = {
                 "zmq": zmq_config,
                 "mysql": dict(config_redis.get("mysql") or {}, **self.mysql_config),
+                # 管道名两侧必须一致，否则客户端连的是另一条线 —— 表现为
+                # 「连不上」而不是「配错了」，最难查的那种。
+                "pipe": dict(config_redis.get("pipe") or {}),
             }
             self._transport_instance = build_transport(
                 self.transport_name,

--- a/src/bigqmt_signal_trader_strategy.py
+++ b/src/bigqmt_signal_trader_strategy.py
@@ -585,18 +585,38 @@ def _resolve_background_threads(transport_name, configured):
     each time a background thread acquires the GIL costs ~1 adjust tick
     (~100ms), which is where the round trip actually goes (#104).
 
-    Only zmq/mysql implement drain_request_queue, so only they honor the
+    Only transports that implement a *real* drain_request_queue may honor the
     override; anything else keeps the receiver thread it needs to be polled by.
     Redis honors either value (blocking brpop path AND an adjust lpop drain).
+
+    The list used to be a hardcoded ("zmq", "mysql") and a new transport had to
+    remember to add itself -- pipe did not, so an explicit False was silently
+    forced back to True and the drain never ran (the log said
+    ``background_threads=True`` while the config said False). Ask the transport
+    class instead: it is the thing that knows.
     """
     normalized = str(transport_name or "redis").lower()
     if _is_redis_transport(normalized):
         return bool(configured)
     if configured is None:
         return True
-    if normalized in ("zmq", "mysql"):
+    if _transport_can_drain(normalized):
         return bool(configured)
     return True
+
+
+def _transport_can_drain(transport_name):
+    """这个传输自己实现了 drain_request_queue 吗。
+
+    问传输类本身，而不是维护一张名单 —— 名单会漏，pipe 就漏过一次。
+    基类的实现返回 0（占位），所以只认子类自己覆盖过的。
+    """
+    try:
+        from bigqmt_signal_trader.transports.factory import transport_supports_drain
+    except Exception:
+        # 导入不到就退回历史名单，别让一个 import 失败改变行为
+        return str(transport_name or "").lower() in ("zmq", "mysql")
+    return transport_supports_drain(transport_name)
 
 
 def _build_quote_subscription_service(context_info, config, transport_name, account_id, redis_client):

--- a/tests/bigqmt_signal_trader/test_pipe_transport.py
+++ b/tests/bigqmt_signal_trader/test_pipe_transport.py
@@ -107,6 +107,127 @@ class ServiceContractTest(unittest.TestCase):
                 "%s 传输没有 drain_request_queue，adjust 会掉进 redis 兜底" % name)
 
 
+@WINDOWS_ONLY
+class DrainModeTest(unittest.TestCase):
+    """drain 模式：adjust 线程自己非阻塞轮询，不起工作线程。
+
+    background_threads=True 时实测请求要 ~200ms 才到达 handler，而 handler
+    本身 0.0ms —— 和 #183 记录的 zmq 404ms 同一个形状。#183 的解法是让
+    adjust 线程自己拉，去掉跨线程交接；这里给 pipe 补上同一条路。
+    """
+
+    def _pair(self, name):
+        srv = NamedPipeTransport(account_id="d", pipe_name=name)
+        srv.start_receiving(_echo, background_threads=False)
+        time.sleep(0.3)
+        cli = NamedPipeTransport(account_id="d", pipe_name=name)
+        self.addCleanup(srv.stop)
+        self.addCleanup(cli.stop)
+        return srv, cli
+
+    def test_nothing_is_answered_until_the_adjust_thread_drains(self):
+        """没人调 drain 就没人回答 —— 这正是 drain 模式的定义。"""
+        srv, cli = self._pair("bigqmt_test_drain_wait")
+        answers = []
+        t = threading.Thread(target=lambda: answers.append(
+            cli.send_request({"request_id": "d1", "method": "p", "params": {}}, 10)))
+        t.daemon = True
+        t.start()
+        time.sleep(0.6)
+        self.assertEqual(answers, [], "没 drain 就被回答了，说明还在走工作线程")
+        self.assertGreater(srv.drain_request_queue(max_items=20), 0)
+        t.join(timeout=5)
+        self.assertEqual(answers[0]["request_id"], "d1")
+
+    def test_the_service_can_answer_through_send_response(self):
+        """服务端不走 deliver 的返回值，它自己调 send_response 发响应。
+
+        drain 模式下没有工作线程，也就没有 outbox —— 第一版 send_response
+        强制要求 outbox，于是抛「no pipe handle」，客户端只看到超时。实盘上
+        就是这么卡住的：background_threads=False 一生效，一条都答不出来。
+        """
+        answers = []
+        holder = {}
+
+        def capture(req):
+            holder["req"] = req
+            return None                      # 模拟服务端：自己发，不靠返回值
+
+        srv = NamedPipeTransport(account_id="d", pipe_name="bigqmt_test_drain_sr")
+        srv.start_receiving(capture, background_threads=False)
+        self.addCleanup(srv.stop)
+        time.sleep(0.3)
+        cli = NamedPipeTransport(account_id="d", pipe_name="bigqmt_test_drain_sr")
+        self.addCleanup(cli.stop)
+
+        t = threading.Thread(target=lambda: answers.append(
+            cli.send_request({"request_id": "s1", "method": "p", "params": {}}, 10)))
+        t.daemon = True
+        t.start()
+        time.sleep(0.5)
+        srv.drain_request_queue(max_items=5)
+        srv.send_response(holder["req"], {"request_id": "s1", "ok": True, "data": {"v": 1}})
+        t.join(timeout=5)
+        self.assertEqual(answers[0]["data"]["v"], 1)
+
+    def test_drain_is_non_blocking_when_idle(self):
+        """空闲时 drain 必须立刻返回 —— 它跑在 adjust 主线程上。"""
+        srv, _cli = self._pair("bigqmt_test_drain_idle")
+        started = time.time()
+        for _ in range(5):
+            self.assertEqual(srv.drain_request_queue(max_items=20), 0)
+        self.assertLess(time.time() - started, 0.5, "drain 在空闲时阻塞了")
+
+    def test_drain_respects_max_items(self):
+        srv, cli = self._pair("bigqmt_test_drain_cap")
+        for i in range(6):
+            t = threading.Thread(target=lambda i=i: cli.send_request(
+                {"request_id": "c%d" % i, "method": "p", "params": {}}, 10))
+            t.daemon = True
+            t.start()
+        time.sleep(0.6)
+        self.assertLessEqual(srv.drain_request_queue(max_items=2), 2)
+
+    def test_background_mode_leaves_drain_a_no_op(self):
+        """开着工作线程时 drain 不能插手，否则两边抢同一个句柄。"""
+        srv = NamedPipeTransport(account_id="d", pipe_name="bigqmt_test_drain_bg")
+        srv.start_receiving(_echo, background_threads=True)
+        self.addCleanup(srv.stop)
+        time.sleep(0.3)
+        self.assertEqual(srv.drain_request_queue(max_items=20), 0)
+
+
+class BackgroundThreadResolutionTest(unittest.TestCase):
+    """新增传输时，「谁能走 drain」不能靠一张手写名单。
+
+    这张名单原来硬编码成 ("zmq", "mysql")，pipe 加进来时没人记得改它 ——
+    于是配置里写了 rpc_background_threads=False，日志里却是 True，drain 从
+    没跑起来，而我还拿那组数字下了「drain 没用」的结论。和入口文件手抄
+    QMT 全局函数名单（#202）是同一类错误。
+    """
+
+    def test_pipe_may_opt_into_drain(self):
+        from bigqmt_signal_trader_strategy import _resolve_background_threads
+        self.assertFalse(_resolve_background_threads("pipe", False))
+        self.assertTrue(_resolve_background_threads("pipe", True))
+
+    def test_a_transport_without_a_real_drain_keeps_its_thread(self):
+        """没实现 drain 的传输必须保留接收线程，否则一条请求都收不到。"""
+        from bigqmt_signal_trader_strategy import _resolve_background_threads
+        self.assertTrue(_resolve_background_threads("shm", False))
+
+    def test_the_decision_asks_the_transport_not_a_list(self):
+        from bigqmt_signal_trader_strategy import _transport_can_drain
+        for name in ("zmq", "mysql", "pipe"):
+            self.assertTrue(_transport_can_drain(name), name)
+        self.assertFalse(_transport_can_drain("shm"))
+        self.assertFalse(_transport_can_drain("nonesuch"))
+
+    def test_unset_keeps_the_historical_default(self):
+        from bigqmt_signal_trader_strategy import _resolve_background_threads
+        self.assertTrue(_resolve_background_threads("pipe", None))
+
+
 class FactoryTest(unittest.TestCase):
 
     def test_pipe_is_a_known_transport(self):

--- a/tests/bigqmt_signal_trader/test_pipe_transport.py
+++ b/tests/bigqmt_signal_trader/test_pipe_transport.py
@@ -1,0 +1,277 @@
+# coding: utf-8
+"""Windows 命名管道传输。
+
+存在的理由是依赖，不是速度：有些券商 QMT 的导入白名单拒 ``socket``（还包括
+``logging.handlers`` 间接引入的那次），且不许往自带 Python 里 pip install ——
+那种终端上 redis 客户端和 pyzmq 都装不进去，桥根本没有线可用。命名管道走
+``ctypes.WinDLL("kernel32")``，是标准库、也不是套接字。
+
+**QMT 沙箱内实测放行**：``import ctypes`` / ``from ctypes import wintypes`` /
+``WinDLL("kernel32")`` / 六个 kernel32 函数解析 / ``CreateNamedPipeW`` 真建出
+管道内核对象，全部通过（probe_capabilities 的 ctypes_probe 一项）。
+
+速度实测（同机、108 字节载荷）::
+
+    裸 IPC 往返        命名管道 0.012ms   zmq 0.109ms   redis 0.798ms
+    完整传输层         命名管道 0.031ms                 redis ~0.81ms
+    端到端 RPC（活桥）  3~12ms
+
+传输层快 26 倍，但端到端只省 0.8ms —— 瓶颈在桥内处理，不在线缆。这一点要写在
+这里，免得有人拿裸 IPC 的 66 倍去做架构决策。
+"""
+import os
+import sys
+import threading
+import time
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.transports.base import TransportError
+from bigqmt_signal_trader.transports.factory import KNOWN_TRANSPORTS, build_transport
+from bigqmt_signal_trader.transports.pipe_transport import (
+    NamedPipeTransport, pipe_path,
+)
+
+
+WINDOWS_ONLY = unittest.skipUnless(os.name == "nt", "命名管道是 Windows 专有")
+
+
+def _echo(request):
+    return {
+        "schema_version": 1,
+        "request_id": request.get("request_id"),
+        "method": request.get("method"),
+        "ok": True,
+        "data": {"echo": request.get("params")},
+    }
+
+
+class _Pair(object):
+    """一对已连上的服务端/客户端，测完保证拆干净。"""
+
+    def __init__(self, name, on_request=_echo):
+        self.server = NamedPipeTransport(account_id="t", pipe_name=name)
+        self.server.start_receiving(on_request)
+        time.sleep(0.3)
+        self.client = NamedPipeTransport(account_id="t", pipe_name=name)
+
+    def close(self):
+        self.server.stop()
+        self.client.stop()
+
+
+class PipePathTest(unittest.TestCase):
+
+    def test_the_account_id_is_part_of_the_pipe_name(self):
+        """两个桥 —— 一个实盘一个模拟 —— 绝不能共用一条线。
+
+        同一个错误让两个部署共用过一个日志文件（#144），那次的代价是
+        TimedRotatingFileHandler 永远轮转不了、日志无限增长。
+        """
+        live = pipe_path("bigqmt_rpc", "8886800503")
+        sim = pipe_path("bigqmt_rpc", "5500000001")
+        self.assertNotEqual(live, sim)
+        self.assertIn("8886800503", live)
+
+    def test_no_account_id_still_yields_a_usable_path(self):
+        self.assertTrue(pipe_path("bigqmt_rpc", "").endswith("bigqmt_rpc"))
+
+
+class FactoryTest(unittest.TestCase):
+
+    def test_pipe_is_a_known_transport(self):
+        self.assertIn("pipe", KNOWN_TRANSPORTS)
+
+    def test_the_factory_builds_it(self):
+        transport = build_transport("pipe", {}, account_id="acct")
+        self.assertEqual(transport.name, "pipe")
+        self.assertIn("acct", transport.path)
+
+    def test_config_can_override_the_pipe_name(self):
+        transport = build_transport(
+            "pipe", {"pipe": {"pipe_name": "custom_wire"}}, account_id="acct")
+        self.assertIn("custom_wire", transport.path)
+
+
+@WINDOWS_ONLY
+class RoundTripTest(unittest.TestCase):
+
+    def setUp(self):
+        self.pair = _Pair("bigqmt_test_roundtrip")
+        self.addCleanup(self.pair.close)
+
+    def test_a_request_comes_back_with_its_own_request_id(self):
+        out = self.pair.client.send_request(
+            {"request_id": "r1", "method": "ping", "params": {"a": 1}}, 5)
+        self.assertEqual(out["request_id"], "r1")
+        self.assertTrue(out["ok"])
+        self.assertEqual(out["data"]["echo"], {"a": 1})
+
+    def test_utf8_survives_both_directions(self):
+        out = self.pair.client.send_request(
+            {"request_id": "r2", "method": "x",
+             "params": {"名称": "维持担保比例", "值": 3.35}}, 5)
+        self.assertEqual(out["data"]["echo"]["名称"], "维持担保比例")
+        self.assertEqual(out["data"]["echo"]["值"], 3.35)
+
+    def test_a_whole_market_payload_survives(self):
+        """全推订阅一帧是 26800 个代码 —— 消息模式下不能被截断。"""
+        codes = ["%06d.SH" % i for i in range(26800)]
+        out = self.pair.client.send_request(
+            {"request_id": "r3", "method": "big", "params": {"codes": codes}}, 30)
+        self.assertEqual(len(out["data"]["echo"]["codes"]), 26800)
+        self.assertEqual(out["data"]["echo"]["codes"][-1], codes[-1])
+
+    def test_floats_keep_their_precision(self):
+        out = self.pair.client.send_request(
+            {"request_id": "r4", "method": "x",
+             "params": {"price": 13.981600016666668}}, 5)
+        self.assertEqual(out["data"]["echo"]["price"], 13.981600016666668)
+
+
+@WINDOWS_ONLY
+class HandlerFailureTest(unittest.TestCase):
+    """handler 抛异常不能把连接搞死 —— 后面的请求还得能走。"""
+
+    def setUp(self):
+        def boom(request):
+            if request.get("method") == "boom":
+                raise RuntimeError("handler exploded")
+            return _echo(request)
+
+        self.pair = _Pair("bigqmt_test_boom", on_request=boom)
+        self.addCleanup(self.pair.close)
+
+    def test_the_error_comes_back_as_a_response_not_a_dropped_connection(self):
+        out = self.pair.client.send_request(
+            {"request_id": "e1", "method": "boom", "params": {}}, 5)
+        self.assertFalse(out["ok"])
+        self.assertIn("handler exploded", out["error"])
+
+    def test_the_connection_still_works_afterwards(self):
+        self.pair.client.send_request(
+            {"request_id": "e1", "method": "boom", "params": {}}, 5)
+        out = self.pair.client.send_request(
+            {"request_id": "e2", "method": "fine", "params": {"ok": 1}}, 5)
+        self.assertTrue(out["ok"])
+
+
+@WINDOWS_ONLY
+class ConcurrencyTest(unittest.TestCase):
+    """每个线程一条自己的管道句柄。
+
+    共用一个句柄会把所有调用方串行化 —— 正是 #186 给 ZMQ DEALER 修掉的那个
+    bug，不能在新传输上重犯。串包（拿到别人的 request_id）比慢更严重。
+    """
+
+    def setUp(self):
+        self.pair = _Pair("bigqmt_test_concurrent")
+        self.addCleanup(self.pair.close)
+
+    def test_twenty_threads_never_cross_responses(self):
+        errors = []
+
+        def worker(wid):
+            for i in range(25):
+                rid = "w%d-%d" % (wid, i)
+                try:
+                    out = self.pair.client.send_request(
+                        {"request_id": rid, "method": "p",
+                         "params": {"w": wid, "i": i}}, 15)
+                except Exception as exc:
+                    errors.append((rid, repr(exc)))
+                    continue
+                if out["request_id"] != rid:
+                    errors.append(("串包", rid, out["request_id"]))
+                elif out["data"]["echo"]["w"] != wid:
+                    errors.append(("载荷串了", rid))
+
+        threads = [threading.Thread(target=worker, args=(w,)) for w in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+        self.assertEqual(errors[:5], [], "500 次并发里出了 %d 个错" % len(errors))
+
+    def test_each_thread_gets_its_own_handle(self):
+        seen = []
+        lock = threading.Lock()
+
+        def grab():
+            self.pair.client.send_request(
+                {"request_id": "h", "method": "p", "params": {}}, 5)
+            with lock:
+                seen.append(self.pair.client._client_local.handle)
+
+        threads = [threading.Thread(target=grab) for _ in range(6)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+        self.assertEqual(len(seen), 6)
+        self.assertEqual(len(set(seen)), 6, "线程之间共用了句柄")
+
+
+@WINDOWS_ONLY
+class ShutdownTest(unittest.TestCase):
+    """stop() 曾经死锁，而且是必然死锁，不是偶发。
+
+    工作线程阻塞在 ReadFile 等下一个请求，主线程调 DisconnectNamedPipe ——
+    而 DisconnectNamedPipe 会等同一句柄上挂起的同步 ReadFile 完成。两边互等。
+    线程栈实锤，修法是先 CancelIoEx 取消挂起的 I/O。
+    """
+
+    def test_stop_returns_even_with_idle_connections_parked_in_readfile(self):
+        pair = _Pair("bigqmt_test_shutdown")
+        for w in range(8):
+            threading.Thread(
+                target=lambda: pair.client.send_request(
+                    {"request_id": "s%d" % w, "method": "p", "params": {}}, 10)
+            ).start()
+        time.sleep(1.0)
+
+        done = threading.Event()
+
+        def stopper():
+            pair.close()
+            done.set()
+
+        threading.Thread(target=stopper, daemon=True).start()
+        self.assertTrue(done.wait(timeout=20),
+                        "stop() 又卡住了 —— 检查 CancelIoEx 还在不在")
+
+    def test_stop_is_safe_to_call_twice(self):
+        pair = _Pair("bigqmt_test_double_stop")
+        pair.close()
+        pair.close()
+
+
+@WINDOWS_ONLY
+class ClientWithoutServerTest(unittest.TestCase):
+
+    def test_connecting_to_a_dead_pipe_says_what_to_check(self):
+        client = NamedPipeTransport(
+            account_id="nobody", pipe_name="bigqmt_test_absent",
+            connect_timeout_seconds=0.3)
+        self.addCleanup(client.stop)
+        with self.assertRaises(TransportError) as caught:
+            client.send_request({"request_id": "x", "method": "ping"}, 2)
+        # 「连不上」要指向该查的地方，不能只报一个 errno
+        self.assertIn("transport=pipe", str(caught.exception))
+
+
+class NonWindowsTest(unittest.TestCase):
+
+    @unittest.skipIf(os.name == "nt", "这条测的是非 Windows 上的报错")
+    def test_it_fails_fast_with_a_clear_message(self):
+        client = NamedPipeTransport(account_id="x")
+        with self.assertRaises(TransportError) as caught:
+            client.send_request({"request_id": "x", "method": "ping"}, 1)
+        self.assertIn("Windows-only", str(caught.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_pipe_transport.py
+++ b/tests/bigqmt_signal_trader/test_pipe_transport.py
@@ -80,6 +80,33 @@ class PipePathTest(unittest.TestCase):
         self.assertTrue(pipe_path("bigqmt_rpc", "").endswith("bigqmt_rpc"))
 
 
+class ServiceContractTest(unittest.TestCase):
+    """传输要能被服务端那套 drain/inline 机制驱动，不只是自己能收发。"""
+
+    def test_it_has_drain_request_queue(self):
+        """少了这个方法，adjust 每个 tick 都会撞 Redis 兜底分支。
+
+        服务端 drain_request_queue 的兜底是 listen_redis.lpop，而 pipe 部署上
+        listen_redis 是 None —— 实盘上每 100ms 抛一次
+        AttributeError: 'NoneType' object has no attribute 'lpop'。
+        单测抓不到，只有端到端能暴露，所以这条要钉住。
+        """
+        transport = build_transport("pipe", {}, account_id="acct")
+        self.assertTrue(callable(getattr(transport, "drain_request_queue", None)))
+        self.assertEqual(transport.drain_request_queue(max_items=20), 0)
+
+    def test_every_transport_the_factory_builds_can_be_drained(self):
+        """同一个坑不要在下一个传输上重犯。"""
+        for name in ("redis", "zmq", "pipe"):
+            try:
+                transport = build_transport(name, {}, account_id="acct")
+            except Exception:
+                continue          # 缺依赖的传输跳过，不是本条要测的
+            self.assertTrue(
+                callable(getattr(transport, "drain_request_queue", None)),
+                "%s 传输没有 drain_request_queue，adjust 会掉进 redis 兜底" % name)
+
+
 class FactoryTest(unittest.TestCase):
 
     def test_pipe_is_a_known_transport(self):

--- a/tests/bigqmt_signal_trader/test_pipe_transport_e2e.py
+++ b/tests/bigqmt_signal_trader/test_pipe_transport_e2e.py
@@ -1,0 +1,181 @@
+# coding: utf-8
+"""#236 follow-up: the four live defects and their fixes, end to end on a
+real named pipe (Windows only).
+
+  1. deferred methods never answered -- inline answers and adjust-thread
+     answers now serialize per connection; frames no longer interleave.
+  2. the client had no real timeout (a blocking ReadFile checks the deadline
+     only AFTER it returns) -- now a pump thread + inbox queue, so
+     queue.get(timeout=...) is the timeout (cfquant's shape, for the same
+     reason).
+  3. stop() must not hang on a pump's pending ReadFile.
+  4. a restarted server on the same pipe name takes new clients again.
+"""
+import json
+import os
+import sys
+import threading
+import time
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.transports.base import TransportTimeout
+from bigqmt_signal_trader.transports.pipe_transport import NamedPipeTransport
+
+WINDOWS = os.name == "nt"
+
+
+def _transport_pair(pipe_name):
+    server = NamedPipeTransport(pipe_name=pipe_name, print_prefix="[test-srv]")
+    client = NamedPipeTransport(pipe_name=pipe_name, print_prefix="[test-cli]")
+    return server, client
+
+
+@unittest.skipUnless(WINDOWS, "named pipes are Windows-only")
+class RoundTripTest(unittest.TestCase):
+    def setUp(self):
+        self.pipe = "bigqmt-test-%d-%d" % (os.getpid(), int(time.time() * 1000) % 100000)
+        self.server, self.client = _transport_pair(self.pipe)
+
+    def tearDown(self):
+        try:
+            self.client.stop()
+        except Exception:
+            pass
+        try:
+            self.server.stop()
+        except Exception:
+            pass
+
+    def test_inline_round_trip(self):
+        self.server.start_receiving(lambda req: {
+            "request_id": req.get("request_id"), "ok": True, "echo": req.get("method")})
+
+        answer = self.client.send_request(
+            {"request_id": "r1", "method": "ping"}, timeout_seconds=5.0)
+
+        self.assertEqual(answer, {"request_id": "r1", "ok": True, "echo": "ping"})
+
+    def test_an_answer_written_on_another_thread_arrives(self):
+        """The deferred shape: the request is received on the connection
+        worker, parked, and answered from a DIFFERENT thread (the adjust
+        thread in production). Before the per-connection write lock, this
+        raced with inline answers and corrupted frames."""
+        parked = threading.Event()
+        released = threading.Event()
+
+        def deferred_handler(req):
+            parked.set()
+            released.wait(5.0)
+            return {"request_id": req.get("request_id"), "ok": True,
+                    "echo": req.get("method"), "thread": threading.current_thread().name}
+
+        self.server.start_receiving(deferred_handler)
+        releaser = threading.Timer(0.2, released.set)
+        releaser.start()
+
+        answer = self.client.send_request(
+            {"request_id": "r-deferred", "method": "get_asset"}, timeout_seconds=5.0)
+
+        self.assertTrue(parked.is_set())
+        self.assertEqual(answer["request_id"], "r-deferred")
+        self.assertEqual(answer["echo"], "get_asset")
+        releaser.cancel()
+
+    def test_the_timeout_is_real(self):
+        """Defect 3: a silent server must not hang the client forever."""
+        self.server.start_receiving(lambda req: time.sleep(60))
+
+        started = time.time()
+        with self.assertRaises(TransportTimeout):
+            self.client.send_request({"request_id": "r-hang", "method": "ping"},
+                                     timeout_seconds=1.0)
+        elapsed = time.time() - started
+
+        self.assertLess(elapsed, 5.0, "the client waited %.1fs -- the timeout is decorative" % elapsed)
+
+    def test_concurrent_writes_from_two_threads_keep_frames_intact(self):
+        """Many responses racing on ONE connection from two threads (inline
+        worker + adjust): every frame must arrive as one parseable message."""
+        requests = []
+        done_setup = threading.Event()
+
+        def handler(req):
+            requests.append(req.get("request_id"))
+            done_setup.wait(1.0)
+            return {"request_id": req.get("request_id"), "ok": True, "n": req.get("n")}
+
+        self.server.start_receiving(handler)
+        done_setup.set()
+
+        errors = []
+        def call(n):
+            try:
+                answer = self.client.send_request(
+                    {"request_id": "req-%d" % n, "method": "work", "n": n},
+                    timeout_seconds=10.0)
+                if answer.get("n") != n:
+                    errors.append("mismatched answer %r for %d" % (answer, n))
+            except Exception as exc:
+                errors.append(str(exc))
+
+        threads = [threading.Thread(target=call, args=(n,)) for n in range(12)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=15.0)
+
+        self.assertEqual(errors, [])
+
+    def test_stop_does_not_hang(self):
+        """stop() with an idle pump blocked in ReadFile must return promptly."""
+        self.server.start_receiving(lambda req: time.sleep(60))
+        # Arm a client pump blocked in a read.
+        hanging = threading.Thread(
+            target=lambda: self._silence(lambda: self.client.send_request(
+                {"request_id": "x", "method": "ping"}, timeout_seconds=60.0),
+                timeout=10.0), daemon=True)
+        hanging.start()
+        time.sleep(0.5)
+
+        started = time.time()
+        self.client.stop()
+        self.server.stop()
+        elapsed = time.time() - started
+
+        self.assertLess(elapsed, 6.0, "stop() took %.1fs" % elapsed)
+
+    @staticmethod
+    def _silence(fn, timeout):
+        thread = threading.Thread(target=fn, daemon=True)
+        thread.start()
+        thread.join(timeout=timeout)
+
+    def test_a_restarted_server_takes_clients_again(self):
+        """After a server restart the client recovers within the SAME call:
+        a write-side failure is provably unsent, so one reconnect-and-resend
+        is safe. (A read-side failure stays a loud error -- unknown outcome,
+        the #195 class; the caller decides there.)"""
+        self.server.start_receiving(lambda req: {"request_id": req.get("request_id"), "ok": True})
+        self.client.send_request({"request_id": "a", "method": "ping"}, timeout_seconds=5.0)
+        self.server.stop()
+
+        replacement, _client2 = _transport_pair(self.pipe)
+        try:
+            replacement.start_receiving(lambda req: {
+                "request_id": req.get("request_id"), "ok": True, "echo": req.get("method")})
+            answer = self.client.send_request(
+                {"request_id": "b1", "method": "ping"}, timeout_seconds=5.0)
+            self.assertEqual(answer["echo"], "ping")
+            answer = self.client.send_request(
+                {"request_id": "b2", "method": "ping"}, timeout_seconds=5.0)
+            self.assertEqual(answer["echo"], "ping")
+        finally:
+            replacement.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
第五种传输：Windows 命名管道，走 `ctypes.WinDLL("kernel32")`，不需要任何第三方包。

## 为什么要它 —— 是依赖，不是速度

有些券商 QMT 的导入白名单拒 `socket`，且不许往自带 Python 里 `pip install`。**那种终端上 redis 客户端和 pyzmq 都装不进去，桥根本没有线可用。** 命名管道是标准库、也不是套接字。

**它不是为了快** —— 实测它比 redis 和 zmq 都慢（见下表）。它的价值只有一个：在没有别的线可用时，它能用。

## QMT 沙箱内实测放行

`probe_capabilities` 新增只读的 `ctypes_probe`，在真实 QMT 进程里逐级探测：

```
import ctypes / from ctypes import wintypes / WinDLL("kernel32")   全 True
六个 kernel32 函数解析                                              全 True
CreateNamedPipeW 真建出管道内核对象                                 True
```

没有停在「import 过了」——DLL 载入成功和内核允许创建管道对象是两回事。

⚠️ 这台是国金终端，**它本来就不限制**。真正需要命名管道的是限制严格的终端，那种我手上没有。

## 实盘验证（QMT 里真跑 transport=pipe）

### 功能：100 个只读方法，零回归

| | redis+后台线程 | pipe+drain |
|---|---|---|
| 有数据 / 空 / None / 错误 | 27 / 23 / 1 / 49 | 27 / 23 / 1 / 49 |
| **逐方法状态差异** | — | **0** |
| **结构指纹差异**（字段名+嵌套形状 sha256）| — | **0** |
| **返回行数差异** | — | **0** |

（49 个「错误」是探测脚本给错参数，两种模式下完全相同；其中 5 个是终端本身不提供 L2 行情的既有限制。）

### 延迟：六渠道横向

| 渠道 | 中位 | p90 |
|---|---|---|
| redis + 后台线程 | **3.4ms** | 25.2ms |
| zmq + drain | 15.8ms | 94.7ms |
| redis + drain | 30.7ms | 93.4ms |
| **pipe + drain** | **94.4ms** | 95.6ms |
| pipe + 后台线程 | 189.0ms | 296.8ms |
| zmq + 后台线程 | 592.9ms | 697.5ms |

**pipe 排第四。** 单看它自己：`ping` 从 403.2ms 降到 **0.5ms**（快 800 倍），交易查询 201.6ms → 94.6ms。

所有渠道的「最快」都是 0.2~0.3ms —— 线本身都不是瓶颈，差距全在唤醒机制。

## 这一版修了什么

**1. `drain_request_queue` 换成真实现。** adjust 线程用 `PeekNamedPipe` 非阻塞探测、有数据才 `ReadFile`，读/处理/写全在同一条线程上，去掉跨线程交接。空闲时立刻返回 —— 它跑在 adjust 主线程上，绝不能阻塞。

**2. `send_response` 支持无 outbox 的路径。** drain 模式下没有工作线程，也就没有 outbox，而服务端不看 `deliver` 的返回值、自己调 `send_response` —— 第一版强制要求 outbox，于是抛「no pipe handle」，客户端只看到超时。**实盘上就是这么全部卡住的。**

**3. `_resolve_background_threads` 不再用硬编码名单。** 原来写死 `("zmq","mysql")`，新传输得记得把自己加进去 —— pipe 没加，于是配置里写 `False`、日志里却是 `True`，**drain 从没跑起来，而我还拿那组数字下了「drain 没用」的结论**。改成问工厂 `transport_supports_drain()`。探测只比类属性、不构造实例 —— 构造 redis 传输会建连接起线程，用它做探测污染过测试环境一次。

顺带修了一个自己写出来的静默失败：探测里把 `MysqlTransport` 写成 `MySqlTransport`，而 `except Exception` 把 ImportError 吞了，mysql 被判成「不支持 drain」。改成只吞 `ImportError`。

## 早期几个自己写出的 bug（已修）

- `stop()` 必然死锁：`DisconnectNamedPipe` 等挂起的 `ReadFile`（线程栈实锤）→ `CancelIoEx`
- 每次 `_read` 分配清零 1MB；`buf.raw[:n]` 复制整个 1MB 再切片 —— 两处合计占往返 96%，改后 0.765ms → 0.031ms
- 缺 `drain_request_queue` 导致 adjust 每 tick 撞 `listen_redis.lpop` 的 `AttributeError`（日志里 294 次）

## 用例

27 条（非 Windows 跳过 1 条）：并发 20 线程串包检查、handler 异常后连接可用、26800 代码载荷、`stop()` 不死锁（移除 `CancelIoEx` 后必红）、drain 模式四条（不 drain 就不答、空闲不阻塞、`max_items` 生效、后台模式下 drain 不插手）、`send_response` 走 drain 路径、以及「工厂能造出的每种传输都得有 drain_request_queue」。

**测试状态**：我的 27 条全绿；全量 1777 passed（排除了另一处会话在途未提交的 `test_kline_worker.py` / `test_redis_rpc.py`，那两个文件不在我的分支 HEAD 上）。

## 已知限制

- **`reload_deployment` 在 pipe 上会拆掉自己的回复线路** —— reload 清掉传输模块，而 reload 自己的响应正要从那条管道发回来。CLAUDE.md 记过 zmq 的同类问题。改传输代码要靠重启，不能靠 reload。
- **数值级比对只做了 zmq vs redis**（14 个方法 sha256 逐字节相同），pipe 只验到结构层面。
- **受限终端未验证** —— 这条传输存在的理由是那种终端，而我手上没有。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
