### PR TITLE
zmq ROUTER 线程出错后自动重建 (#240)

### DIFF
--- a/src/bigqmt_signal_trader/transports/zmq_transport.py
+++ b/src/bigqmt_signal_trader/transports/zmq_transport.py
@@ -22,6 +22,7 @@ using DEALER + ``poll`` (synchronous request/response fits the RPC model).
 import json
 import queue
 import threading
+import traceback
 import time
 import uuid
 
@@ -344,6 +345,42 @@ class ZmqTransport(RpcTransport):
         )
 
     def _router_loop(self):
+        """接收循环，出错自动重建 ROUTER 并继续（#240）。
+
+        原来这里是一层 try/finally：任何逃出内层 while 的异常都会走到 finally
+        关掉 socket、线程结束，**桥从此不再接收任何请求，也没有任何提示** ——
+        从客户端看和「服务端死了」一模一样，而 QMT 里的策略还好好地跑着，
+        adjust 照常打点。
+
+        redis 那两条循环早就是「异常 -> 退避 -> 重建连接」的形状；zmq 缺这一层。
+        现在补上：内层跑接收，外层负责重建。退避从 1 秒起、翻倍到 30 秒封顶 ——
+        端口被别的进程占着时不至于每秒刷屏。
+        """
+        backoff = 1.0
+        while self._running:
+            try:
+                self._router_session()
+                backoff = 1.0          # 正常退出（stop），不重连
+            except Exception:
+                if not self._running:
+                    break
+                print("%s zmq router failed, rebuilding in %.0fs:\n%s"
+                      % (self.print_prefix, backoff, traceback.format_exc()))
+                time.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+                if not self._running:
+                    break
+                try:
+                    self._bind_configured_address()
+                except Exception:
+                    # 重建失败（端口还被占着）——下一轮继续退避重试，
+                    # 不能在这里放弃：放弃就回到了「线程静悄悄死掉」。
+                    print("%s zmq rebind failed, will retry" % self.print_prefix)
+                    continue
+                print("%s zmq router rebuilt bound=%s"
+                      % (self.print_prefix, self._actual_bind_address or self.bind_address))
+
+    def _router_session(self):
         poller = None
         if self._wake_recv is not None:
             try:
@@ -382,11 +419,15 @@ class ZmqTransport(RpcTransport):
             # closing a ZMQ socket from a different thread trips a signaler
             # assertion (abort); closing it here is safe because this thread
             # created and exclusively used it.
-            try:
-                self._router.close(linger=0)
-            except Exception:
-                pass
-            self._router = None
+            #
+            # 只在真正停机时关。重连路径上 _bind_configured_address 会建一个新的，
+            # 这里再关就把新 socket 关掉了 —— 那会让「重连成功」变成静默失效。
+            if not self._running:
+                try:
+                    self._router.close(linger=0)
+                except Exception:
+                    pass
+                self._router = None
 
     def _receive_request(self, flags=0):
         try:

--- a/tests/bigqmt_signal_trader/test_zmq_router_self_heal.py
+++ b/tests/bigqmt_signal_trader/test_zmq_router_self_heal.py
@@ -1,0 +1,185 @@
+# coding: utf-8
+"""ROUTER 线程出错要自己重建，不能静悄悄死掉（#240）。
+
+原来 `_router_loop` 是一层 try/finally：任何逃出内层 while 的异常都走到
+finally 关掉 socket、线程结束。**桥从此不再接收任何请求，而且没有任何提示**
+—— 从客户端看和「服务端死了」一模一样，可 QMT 里的策略还好好地跑着，adjust
+照常打点、日志照常滚。这正是本仓反复吃亏的那种形态：失败看起来像没发生。
+
+redis 那两条循环早就是「异常 -> 退避 -> 重建连接」的形状（`_listen_loop` /
+`_queue_loop`），zmq 缺这一层。
+"""
+import os
+import sys
+import threading
+import time
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.transports.zmq_transport import ZmqTransport  # noqa: E402
+
+
+class _Boom(RuntimeError):
+    pass
+
+
+class RouterSelfHealTest(unittest.TestCase):
+    """用打桩的 _router_session / _bind_configured_address 驱动重建逻辑。
+
+    不起真 socket：这条要测的是**循环的控制流**，不是 zmq 本身。真 socket
+    会把「重建了几次」变成时序问题，而时序问题的测试是不稳定的。
+    """
+
+    def _transport(self):
+        transport = ZmqTransport.__new__(ZmqTransport)
+        transport.print_prefix = "[test]"
+        transport._running = True
+        transport._actual_bind_address = "tcp://127.0.0.1:15560"
+        transport.bind_address = "tcp://127.0.0.1:15560"
+        return transport
+
+    def test_a_crashed_session_is_rebuilt_not_abandoned(self):
+        transport = self._transport()
+        sessions = []
+        rebinds = []
+
+        def session():
+            sessions.append(1)
+            if len(sessions) < 3:
+                raise _Boom("router died")
+            transport._running = False      # 第三次正常收工
+
+        transport._router_session = session
+        transport._bind_configured_address = lambda: rebinds.append(1)
+
+        started = time.time()
+        transport._router_loop()
+
+        self.assertEqual(len(sessions), 3, "崩了以后没有重建，线程直接结束了")
+        self.assertEqual(len(rebinds), 2, "重建时没有重新 bind")
+        self.assertLess(time.time() - started, 10, "退避太久")
+
+    def test_backoff_grows_so_a_held_port_does_not_spam(self):
+        """端口被别的进程占着时不能每秒刷屏。"""
+        transport = self._transport()
+        slept = []
+        rounds = []
+
+        def session():
+            rounds.append(1)
+            if len(rounds) >= 4:
+                transport._running = False
+            raise _Boom("still dead")
+
+        transport._router_session = session
+        transport._bind_configured_address = lambda: None
+        real_sleep = time.sleep
+        try:
+            time.sleep = lambda s: slept.append(s)
+            transport._router_loop()
+        finally:
+            time.sleep = real_sleep
+
+        self.assertGreaterEqual(len(slept), 3)
+        self.assertEqual(slept[:3], [1.0, 2.0, 4.0], "退避没有翻倍：%s" % slept[:3])
+
+    def test_backoff_is_capped(self):
+        transport = self._transport()
+        slept = []
+        rounds = []
+
+        def session():
+            rounds.append(1)
+            if len(rounds) >= 12:
+                transport._running = False
+            raise _Boom("still dead")
+
+        transport._router_session = session
+        transport._bind_configured_address = lambda: None
+        real_sleep = time.sleep
+        try:
+            time.sleep = lambda s: slept.append(s)
+            transport._router_loop()
+        finally:
+            time.sleep = real_sleep
+
+        self.assertLessEqual(max(slept), 30.0, "退避没有封顶：%s" % max(slept))
+
+    def test_a_failed_rebind_keeps_retrying(self):
+        """重建失败不能放弃 —— 放弃就回到了「线程静悄悄死掉」。"""
+        transport = self._transport()
+        attempts = []
+
+        def session():
+            raise _Boom("router died")
+
+        def rebind():
+            attempts.append(1)
+            if len(attempts) >= 3:
+                transport._running = False
+            raise _Boom("port still held")
+
+        transport._router_session = session
+        transport._bind_configured_address = rebind
+        real_sleep = time.sleep
+        try:
+            time.sleep = lambda s: None
+            transport._router_loop()
+        finally:
+            time.sleep = real_sleep
+
+        self.assertGreaterEqual(len(attempts), 3, "rebind 失败一次就不再重试了")
+
+    def test_stop_does_not_trigger_a_rebuild(self):
+        """正常停机不该被当成故障重连。"""
+        transport = self._transport()
+        rebinds = []
+
+        def session():
+            transport._running = False      # stop() 的效果
+
+        transport._router_session = session
+        transport._bind_configured_address = lambda: rebinds.append(1)
+        transport._router_loop()
+
+        self.assertEqual(rebinds, [], "正常停机也去重连了")
+
+    def test_an_exception_after_stop_is_not_reported_as_failure(self):
+        """stop() 让阻塞的 recv 抛异常 —— 那是停机路径，不是故障。
+
+        redis 那边为这件事专门修过一次（#189）：正常停机打完整堆栈，
+        会让每次重启都看着像故障，读的人于是学会跳过它 —— 包括真的那次。
+        """
+        transport = self._transport()
+        rebinds = []
+
+        def session():
+            transport._running = False
+            raise _Boom("socket closed under us by stop()")
+
+        transport._router_session = session
+        transport._bind_configured_address = lambda: rebinds.append(1)
+        transport._router_loop()
+
+        self.assertEqual(rebinds, [], "停机时的异常被当成故障去重连了")
+
+
+class RouterSessionOwnershipTest(unittest.TestCase):
+    """重连时不能把新建的 socket 关掉。"""
+
+    def test_the_session_only_closes_its_socket_when_stopping(self):
+        source = open(os.path.join(
+            ROOT, "src", "bigqmt_signal_trader", "transports", "zmq_transport.py"),
+            encoding="utf-8").read()
+        session = source.split("def _router_session", 1)[1]
+        session = session.split("\n    def ", 1)[0]
+        self.assertIn("if not self._running:", session,
+                      "_router_session 的 finally 无条件关 socket —— 重连路径上会把"
+                      "刚建好的新 socket 关掉，让『重连成功』变成静默失效")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #240.

## 问题

zmq 的 ROUTER 接收线程**一旦出错就永久死掉，而且没有任何提示**：

```python
try:
    while self._running:
        ...接收、分发...
finally:
    self._router.close(linger=0)   # 任何逃出内层 while 的异常都走到这里
    self._router = None            # 线程结束，从此不再接收任何请求
```

从客户端看和「服务端进程死了」一模一样，可 QMT 里的策略还好好地跑着，adjust 照常打点、日志照常滚。**本仓反复吃亏的那种形态：失败看起来像没发生。**

redis 的 `_listen_loop` / `_queue_loop` 早就是「异常 → 退避 → 重建连接」的形状，zmq 缺这一层。而 zmq 恰好是「没有 redis 时的首选」——0.3.28 实测 drain 模式 **15.8ms**，六渠道里第二快。

## 改法

拆成外层 `_router_loop`（负责重建）+ 内层 `_router_session`（负责接收）：

- 异常 → 打日志 → 退避 → `_bind_configured_address()` 重建 ROUTER → 继续
- 退避 **1s 起、翻倍、30s 封顶** —— 端口被别的进程占着时不至于每秒刷屏
- **重建失败继续重试，不放弃** —— 放弃就回到了「线程静悄悄死掉」
- `_running` 已是 False 时**不重连、不打堆栈**：那是 `stop()` 让阻塞 recv 抛的异常，是停机路径。#189 为 redis 修过同一件事——正常停机打完整堆栈会让每次重启都像故障，读的人于是学会跳过它，**包括真的那次**

**还有一处必须一起改**：原来的 `finally` 无条件关 socket。重连路径上 `_bind_configured_address` 会建一个新的，这里再关就把**新** socket 关掉了 —— 那会让「重连成功」变成静默失效。改成只在 `not self._running` 时关，并用一条读源码的用例钉住。

## 顺带纠正一个容易误解的地方

`_stall_watchdog_loop` 看着像断链检测，**其实是慢 handler 检测**（那次 `get_financial_data` 346 秒就是靠它发现的）。它对 socket 死掉一无所知 —— 所以 zmq 此前**连断链告警都没有**，更谈不上自愈。

## 用例

7 条，**对修复前的代码 5 条红**（`git show origin/main:...` 换回旧文件验证过）：

- 崩溃后重建而不是放弃
- 退避翻倍 `[1.0, 2.0, 4.0]`
- 退避 30s 封顶
- rebind 失败继续重试
- 正常停机不触发重连
- 停机时的异常不当故障
- `_router_session` 的 finally 只在停机时关 socket

**不起真 socket**：这几条测的是**循环的控制流**，不是 zmq 本身。真 socket 会把「重建了几次」变成时序问题，而时序测试是不稳定的。

## 验证

全量 **1842 passed, 1 skipped**，收集数 141 == 文件数 141。

**实盘未验证** —— 要真验证得让运行中的 ROUTER socket 崩掉，我没有可靠的办法在不损坏实盘桥的前提下制造那个故障。控制流由单测覆盖，真实故障下的行为仍是推断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
