### PR TITLE
fix: identify QMT login windows independently of screen resolution

### DIFF
--- a/src/bigqmt_signal_trader/qmt_launcher.py
+++ b/src/bigqmt_signal_trader/qmt_launcher.py
@@ -358,44 +358,45 @@ def open_qmt(install_dir, mode="auto", bat_path=None, exe_name=None,
     return wait_until_ready(ready_port, timeout_seconds=ready_timeout_seconds)
 
 
-def _looks_like_login_window(rect, screen_width, screen_height):
-    """Return whether a QMT top-level window has login-dialog proportions.
+def classify_qmt_window(style):
+    """Classify a selected QMT Qt window as ``login``, ``main`` or ``unknown``.
 
-    Absolute pixel cut-offs are not stable on Windows: the exact same 国金
-    login window is reported as 832x591 to a DPI-virtualised process and
-    1248x886 after a library makes the process DPI-aware (150% scaling).  The
-    full terminal is normally maximised or close to the work-area size, while
-    the login shell occupies roughly half the screen in both coordinate
-    systems.  Ratios therefore survive DPI scaling and broker UI revisions.
+    国金 QMT uses 0x96000000 for login and 0x960b0000 for its main window
+    (issue #232). Both lack WS_THICKFRAME; the distinguishing bits are
+    WS_SYSMENU, WS_MINIMIZEBOX and WS_MAXIMIZEBOX. Require the observed Qt
+    popup/clipping structure, and reject unsupported frame/button patterns.
+    Geometry and DPI are deliberately irrelevant. Callers must first select
+    the intended terminal's visible Qt window by title; this is not a generic
+    Windows dialog classifier.
     """
-    try:
-        width = max(int(rect[2]) - int(rect[0]), 0)
-        height = max(int(rect[3]) - int(rect[1]), 0)
-        screen_width = max(int(screen_width), 1)
-        screen_height = max(int(screen_height), 1)
-    except (TypeError, ValueError, IndexError):
-        return False
-    return width < screen_width * 0.65 and height < screen_height * 0.65
+    if not isinstance(style, int):
+        return "unknown"
+    style &= 0xffffffff  # GetWindowLong can return a signed 32-bit value.
+    if style & 0x96000000 != 0x96000000 or style & 0x40000000:  # WS_CHILD
+        return "unknown"
+    frame = style & 0x00cf0000  # caption, thick frame, system menu and buttons
+    if frame == 0:
+        return "login"
+    if frame == 0x000b0000:
+        return "main"
+    return "unknown"
 
 
 def _wait_for_main_window(
-        find_window, get_rect, screen_width, screen_height,
+        find_window, window_kind,
         timeout_seconds=90.0, poll_interval=1.0):
     """Wait until the QMT login shell is replaced by the main terminal.
 
     FormulaServer port 58600 already listens while the login dialog is still
     open, so a port-only readiness check can report success after the broker
     has rejected or timed out the login.  Require the visible QMT window to
-    transition to main-window proportions before declaring login complete.
+    become a positively identified main window before declaring login complete.
     """
     deadline = time.monotonic() + max(float(timeout_seconds), 0.0)
     while True:
         handle = find_window()
-        if handle:
-            rect = get_rect(handle)
-            if not _looks_like_login_window(
-                    rect, screen_width, screen_height):
-                return handle
+        if handle and window_kind(handle) == "main":
+            return handle
         if time.monotonic() >= deadline:
             return None
         time.sleep(max(float(poll_interval), 0.0))
@@ -462,19 +463,24 @@ def _login_via_window(credentials, window_title_prefix=None, appear_timeout_seco
         win32gui.EnumWindows(_collect, matches)
         return matches[0] if matches else None
 
+    def _kind(hwnd):
+        try:
+            return classify_qmt_window(win32gui.GetWindowLong(hwnd, win32con.GWL_STYLE))
+        except Exception:
+            return "unknown"  # A disappearing/unreadable window is not logged in.
+
     deadline = time.time() + appear_timeout_seconds
     handle = None
     while time.time() < deadline:
         candidate = _find()
         if candidate:
-            r = win32gui.GetWindowRect(candidate)
-            if _looks_like_login_window(
-                    r, user32.GetSystemMetrics(0), user32.GetSystemMetrics(1)):
+            kind = _kind(candidate)
+            if kind == "login":
                 handle = candidate
                 break
-            # 大窗 = 主界面已出现：终端自动登录了，无需输入凭据，直接跳过。
-            log.info("main window already up (auto-login); skipping credentials")
-            return
+            if kind == "main":
+                log.info("main window already up (auto-login); skipping credentials")
+                return
         time.sleep(2.0)
     if not handle:
         raise QmtLauncherError(
@@ -498,17 +504,12 @@ def _login_via_window(credentials, window_title_prefix=None, appear_timeout_seco
             "could not foreground the login dialog (another window may hold focus); "
             "proceeding with topmost + verified clicks anyway")
 
-    def _looks_like_login_dialog():
-        # 登录框约占屏幕一半；主界面是大窗/最大化。不要用固定像素阈值：
-        # 150% DPI 下同一登录框可分别报告成 832x591 或 1248x886。
-        # 自动登录完成时找到的会是主界面——打字会落进主窗口控件，必须跳过。
-        r = win32gui.GetWindowRect(handle)
-        return _looks_like_login_window(
-            r, user32.GetSystemMetrics(0), user32.GetSystemMetrics(1))
-
-    if not _looks_like_login_dialog():
+    kind = _kind(handle)
+    if kind == "main":
         log.info("window is already the main interface (auto-login); skipping credentials")
         return
+    if kind != "login":
+        raise QmtLauncherError("unsupported or unavailable QMT window; refusing credential input")
 
     # 国金 2.1.19 登录框（624x443）控件的相对位置，按比例适配尺寸变化。
     # 账号框 x 必须避开右侧下拉按钮（~0.66w，点它会展开账号列表——实盘事故），
@@ -617,17 +618,17 @@ def _login_via_window(credentials, window_title_prefix=None, appear_timeout_seco
             "aborted without submitting."
         )
 
-    if not _looks_like_login_dialog():
-        # 自动登录在打字过程中已完成——对话框已关闭，别再点"登录"坐标。
+    kind = _kind(handle)
+    if kind == "main":
         log.info("login dialog gone mid-entry (auto-login completed); skipping submit click")
         return
+    if kind != "login":
+        raise QmtLauncherError("QMT window changed or disappeared; refusing login submission")
     # 用 Enter 提交而不是点坐标——布局无关（issue #128）。
     _key(win32con.VK_RETURN)
     if not _wait_for_main_window(
             _find,
-            win32gui.GetWindowRect,
-            user32.GetSystemMetrics(0),
-            user32.GetSystemMetrics(1),
+            _kind,
             timeout_seconds=appear_timeout_seconds):
         raise QmtLauncherError(
             "QMT login did not reach the main window within %.0fs; the login "

--- a/src/bigqmt_signal_trader/qmt_launcher.py
+++ b/src/bigqmt_signal_trader/qmt_launcher.py
@@ -57,6 +57,7 @@ DEFAULT_READY_PORT = 58600
 
 __all__ = [
     "QmtLauncherError",
+    "classify_qmt_window",
     "close_qmt",
     "find_qmt_processes",
     "is_qmt_running",

--- a/tests/bigqmt_signal_trader/test_qmt_launcher.py
+++ b/tests/bigqmt_signal_trader/test_qmt_launcher.py
@@ -70,7 +70,7 @@ class ProcessStub(object):
 
 class ResolveInstallDirTest(unittest.TestCase):
     def test_accepts_root_bin_and_exe_paths(self):
-        expected = os.path.normpath("D:/qmt_lemo/bin.x64")
+        expected = os.path.abspath("D:/qmt_lemo/bin.x64")
         orig = os.path.isdir
         os.path.isdir = lambda p: os.path.basename(os.path.normpath(p)).lower() == "bin.x64"
         try:
@@ -228,43 +228,35 @@ class OpenQmtTest(unittest.TestCase):
 
 
 class LoginWindowDetectionTest(unittest.TestCase):
-    def test_login_detection_is_dpi_scale_independent(self):
-        # Same QMT login shell before/after 150% DPI scaling.
-        self.assertTrue(qmt_launcher._looks_like_login_window(
-            (544, 280, 1376, 871), 1920, 1200))
-        self.assertTrue(qmt_launcher._looks_like_login_window(
-            (816, 420, 2064, 1306), 2880, 1800))
+    def test_known_styles_do_not_depend_on_dpi_or_window_size(self):
+        self.assertEqual(qmt_launcher.classify_qmt_window(0x96000000), "login")
+        self.assertEqual(qmt_launcher.classify_qmt_window(0x960b0000), "main")
+        self.assertEqual(qmt_launcher.classify_qmt_window(0x970b0000), "main")
+        self.assertEqual(qmt_launcher.classify_qmt_window(0xb60b0000), "main")
+        self.assertEqual(qmt_launcher.classify_qmt_window(0x96000000 - 2**32), "login")
 
-    def test_main_window_is_not_treated_as_login(self):
-        self.assertFalse(qmt_launcher._looks_like_login_window(
-            (0, 0, 1920, 1160), 1920, 1200))
-        self.assertFalse(qmt_launcher._looks_like_login_window(
-            (250, 120, 1650, 1020), 1920, 1200))
+    def test_unknown_styles_cannot_be_treated_as_login_or_main(self):
+        for style in (None, "bad", 0, 0x90000000, 0x96080000, 0x960f0000, 0xd6000000):
+            self.assertEqual(qmt_launcher.classify_qmt_window(style), "unknown", style)
 
-    def test_login_completion_waits_for_the_main_window(self):
-        login = (816, 420, 2064, 1306)
-        main = (0, 0, 2880, 1740)
-        handles = iter((10, 20))
-        rects = {10: login, 20: main}
-
+    def test_completion_waits_through_login_unknown_and_missing_windows(self):
+        handles = iter((10, 0, 30, 20))
+        styles = {10: 0x96000000, 30: 0, 20: 0x960b0000}
         result = qmt_launcher._wait_for_main_window(
-            lambda: next(handles), rects.get, 2880, 1800,
+            lambda: next(handles),
+            lambda h: qmt_launcher.classify_qmt_window(styles[h]),
             timeout_seconds=1.0, poll_interval=0.0,
         )
-
         self.assertEqual(result, 20)
 
-    def test_login_completion_rejects_a_persistent_login_dialog(self):
-        result = qmt_launcher._wait_for_main_window(
-            lambda: 10,
-            lambda _handle: (816, 420, 2064, 1306),
-            2880,
-            1800,
-            timeout_seconds=0.0,
-            poll_interval=0.0,
-        )
-
-        self.assertIsNone(result)
+    def test_completion_rejects_persistent_login_and_unknown_window(self):
+        for style in (0x96000000, 0):
+            result = qmt_launcher._wait_for_main_window(
+                lambda: 10,
+                lambda h: qmt_launcher.classify_qmt_window(style),
+                timeout_seconds=0.0, poll_interval=0.0,
+            )
+            self.assertIsNone(result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #232.

The same 1248×886 QMT login shell is currently classified as a main window at 1920×1080, so the launcher can skip credential entry. Replace the screen-ratio heuristic with one public `classify_qmt_window(style)` function shared by the initial probe, pre-input check, pre-submit check and main-window wait. It recognizes the observed 国金 Qt popup styles, normalizes signed Win32 values, ignores maximize/minimize state bits, and returns `unknown` for unsupported styles. Unknown windows do not receive credentials or count as completed login.

This keeps the existing title/Qt selection, physical input and per-field screenshot checks. It does not add a login state machine or a second input implementation. Consumers can use the same public classifier for their readiness probes.

Validation: 22 launcher tests passed on Linux, including signed styles, main-window maximize/minimize bits, persistent login windows and unknown/missing windows. One existing test expectation now uses an absolute path to match the existing resolver on Linux as well as Windows. No upstream full suite was run. Live validation used our fixed simulation installation/account only; no real-funded terminal was involved. Known style evidence is from the issue; unsupported broker window structures intentionally require separate evidence rather than a geometry fallback.

Live simulation validation completed on 2026-09-08 20:10 Asia/Shanghai using exact commit ec6187bb49aaf1bcb44ea9378479bd809ff17d67. The existing Interactive recovery task transferred its own RDP session to the physical console with Windows tscon, then called this unmodified launcher. With RDP disconnected, console session 1 reported 1920×1080, screenshot capture succeeded, QMT logged in and Redis RPC/ACCOUNT passed. Client process changed from the stopped simulation process to a new process in console session 1. The same application probe subsequently reported healthy/ready. Positions/orders/trades remained 8/8/99 with zero pending orders; no validation order was submitted. Our downstream contract/behavior suite passed 400 tests and CI passed. Windows reboot/Autologon and other broker UI styles were not exercised.

A subsequent user-requested test moved the main window to the center of a 3840×2160 RDP desktop. The classifier still returned main; recovery again transferred to a 1920×1080 console and correctly identified the 1248×886 login shell, entered credentials and submitted login. This time the terminal reported network error 2 / End of file and the task correctly returned failure with RPC unavailable. Native logs show the account connection had already failed at 20:15:23, before this second restart. This confirms the tested classification and input path, while the second attempt did not re-establish an account session; a possible nightly brokerage maintenance window is unconfirmed. No further restart was attempted that evening.
