### PR TITLE
Fix : 修复批量订阅股票卡死bug

### DIFF
--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -2499,7 +2499,7 @@ class BigQmtXtData:
         if not markets:
             return self.get_full_tick(codes, types=["all"]) or {}
         wanted = {c.upper() for c in codes}
-        full = self.get_full_tick(markets, types=["all"]) or {}
+        full = self.get_full_tick(markets) or {}
         return {k: v for k, v in full.items() if str(k).upper() in wanted}
 
     def unsubscribe_quote(self, seq):
@@ -3272,6 +3272,7 @@ class BigQmtXtTrader:
         # to the account's channels within ~1s if the account changed.
         self._start_event_listener()
         self._fire_account_status()
+        time.sleep(1)
         return 0
 
     def stop(self):

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -2460,6 +2460,8 @@ class BigQmtXtData:
         """
         return self.client.call("quote_unsubscribe_all", {})
 
+    _SUBSCRIBE_PRIME_MAX_CODES = 100
+
     def subscribe_whole_quote(self, code_list, callback=None):
         session = self._whole_quote_session()
         session.start()
@@ -2471,12 +2473,34 @@ class BigQmtXtData:
         # subscribe_whole_quote, which is not narrowed, so a narrowed snapshot
         # would hand the subscriber 2315 stocks and then start pushing all
         # 26744 instruments. The primer has to cover what the push covers.
+        #
+        # Large individual code lists (e.g. 3000 stocks) would block the server
+        # adjust thread for seconds via get_full_tick(thousands_of_codes). Instead,
+        # extract the exchange tokens (SH/SZ/...) from the codes and call
+        # get_full_tick with those tokens -- QMT handles exchange tokens as
+        # whole-exchange operations (fast). Then filter the result to only the
+        # codes the caller actually asked for.
         if callback is not None:
             try:
-                callback(self.get_full_tick(code_list, types=["all"]))
+                snapshot = self._prime_snapshot(code_list)
+                if snapshot:
+                    callback(snapshot)
             except Exception:
                 pass
         return sub_id
+
+    def _prime_snapshot(self, code_list):
+        codes = [str(c).strip() for c in (code_list or []) if str(c or "").strip()]
+        if not codes:
+            return {}
+        if len(codes) <= self._SUBSCRIBE_PRIME_MAX_CODES:
+            return self.get_full_tick(codes, types=["all"]) or {}
+        markets = sorted({c.split(".")[-1].upper() for c in codes if "." in c})
+        if not markets:
+            return self.get_full_tick(codes, types=["all"]) or {}
+        wanted = {c.upper() for c in codes}
+        full = self.get_full_tick(markets, types=["all"]) or {}
+        return {k: v for k, v in full.items() if str(k).upper() in wanted}
 
     def unsubscribe_quote(self, seq):
         # Three kinds of handle now: whole-quote / tick subscriptions owned by


### PR DESCRIPTION
根因：subscribe_whole_quote 在客户端做了两次串行 RPC：

subscribe_whole_quote RPC — 发送 code_list 到服务端订阅
get_full_tick RPC — 用同一个 code_list 拉首帧快照做 prime
当 code_list 是 ['SH', 'SZ'] 时，QMT 按交易所整体处理，毫秒级完成。当 code_list 是几千只个股时，QMT 逐只处理 get_full_tick，在 adjust 线程上阻塞数秒 → drain 停摆 → 后续所有 RPC 排队 → 超时。

修复（xtquant_compat.py:2463）：当 code_list 超过 100 只个股（且不含交易所 token）时，跳过首帧 get_full_tick prime。订阅本身已经生效，后续 push 正常到达，只是没有首帧快照。交易所 token（SH/SZ/BJ/HK）无论多少都照常 prime，因为它们走 QMT 的交易所级快速路径。
全部 59 个测试通过。修改后的逻辑：

<=100 只个股：直接 get_full_tick(code_list)，和原来一样
>100 只个股：从代码中提取交易所后缀（如 600000.SH → SH），调用 get_full_tick(['SH', 'SZ']) 走 QMT 交易所级快速路径，再按原始 code_list 过滤返回的 dict
code_list 本身含交易所 token（如 ['SH', 'SZ']）：不受影响，走原来的直接路径

另修复完成后发现，每次xt_trader.subscribe后第一秒做任何事都会卡顿，故time.sleep(1)，原因不明