### PR TITLE
fix: rpc_background_threads 按传输选，并堵上让它变危险的那个洞 (#244)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ python -m bigqmt_signal_trader.init_config
 
 几个不问、直接定死的选项：
 
-- **`rpc_background_threads` 恒为 `False`** —— `get_trade_detail_data` 离开主策略线程返回空，这不是可选项
+- **`rpc_background_threads` 按传输选**（redis `True`、zmq/pipe `False`）—— 选反了差 4~37 倍，向导按你选的传输定，不问
 - **`rpc_allow_order_methods` 默认 `False`** —— 打开前会明确提示：任何能连上这条通道的程序都可以下单
 - 选了**无 redis 单文件**会自动把传输改成 zmq，不会留下一份声称用 redis 的配置
 
@@ -1121,16 +1121,20 @@ BIGQMT_REDIS_CONFIG = {
     "rpc_allow_order_methods": False,    # 下单默认关闭
     "rpc_process_in_listener": True,     # 只读请求在收包线程直接处理（低延迟）
     "rpc_listener_methods": ("*",),      # * = 所有只读方法
-    "rpc_background_threads": False,     # redis 用 QMT adjust 线程 drain
+    "rpc_background_threads": True,      # redis 用后台收包线程（最快）
     "schedule_adjust": True,
-    "schedule_adjust_interval": "500nMilliSecond",
+    "schedule_adjust_interval": "100nMilliSecond",
 }
 ```
 
-> **`rpc_background_threads` 保持 `False`**，包括 zmq 和 mysql。0.3.21 起这两种传输
-> 也支持 adjust 线程 drain（#183），实测把 zmq 的 ping 从 405ms 降到 95ms、交易查询从
-> 607ms 降到 95ms。0.3.21 之前它们必须设 `True`，现在设 `True` 等于主动放弃这段提速。
-> 不写这个键则沿用历史默认（开后台线程）。
+> **这个开关按传输选，没有一个值对所有传输都最好**（实测见上面的传输对比表）：
+> redis 用 `True`（3.4ms，`brpop` 唤醒是即时的）；zmq / pipe / mysql 用 `False`
+> 走 adjust drain（zmq 15.8ms），因为它们的后台线程每次都要付跨线程 GIL 交接，
+> 约一个 adjust tick。zmq 配 `True` 是 592.9ms，慢 37 倍。不写这个键则沿用历史
+> 默认（开后台线程）—— 对 redis 正好是对的，对 zmq / pipe 不是。
+>
+> 安全性不依赖这个开关：碰交易上下文的方法（`LISTENER_DEFERRED_METHODS`）在展开
+> listener 名单时被无条件剔除，任何配置都无法把它们排到后台线程上（#244）。
 
 ### 第 3 步：在 QMT 里运行策略
 

--- a/qmt-trader/SKILL.md
+++ b/qmt-trader/SKILL.md
@@ -58,18 +58,26 @@ BIGQMT_REDIS_CONFIG = {
     "rpc_allow_order_methods": False,     # 下单开关，默认关闭；确认风控后改 True
     "rpc_process_in_listener": True,
     "rpc_listener_methods": ("*",),
-    "rpc_background_threads": False,      # 若切 zmq/mysql 传输必须改 True
+    "rpc_background_threads": True,       # redis 用后台收包线程最快；zmq/pipe 要改 False
     "schedule_adjust": True,
-    "schedule_adjust_interval": "500nMilliSecond",
+    "schedule_adjust_interval": "100nMilliSecond",
 }
 ```
 
-> 切 zmq：配置里加 `"transport": "zmq"` 并把 `rpc_background_threads` 改 `True`（QMT 端需装 pyzmq 19.0.2，Python 3.6 最后支持的版本）。
+> **这个开关按传输选，选反了差几十倍**（实测见 README 的传输对比表）：
+> redis 用 `True`（3.4ms），zmq / pipe 用 `False` 走 adjust drain（zmq 15.8ms）。
+> zmq 配 `True` 是 592.9ms —— 慢 37 倍。原因是 zmq / pipe 的后台线程每次都要付
+> 跨线程 GIL 交接（约一个 adjust tick），redis 的 `brpop` 唤醒没有这一步。
+>
+> 切 zmq：配置里加 `"transport": "zmq"` 并把 `rpc_background_threads` 改 `False`
+> （QMT 端需装 pyzmq 19.0.2，Python 3.6 最后支持的版本）。
 
 ### 第 4 步：在 QMT 策略编辑器运行入口
 
 QMT 策略编辑器里**只加载运行 `BIGQMT_REDIS_DRYRUN.py` 一个文件**（它自动 import 其余模块）。
-若 QMT 装在非默认路径且用 exec 方式加载，需改文件里 `_known_qmt_python_dir()` 的 fallback 路径。
+装在非默认路径不用改任何代码：入口先用自己 `__file__` 所在目录，取不到才回落
+到扫 `sys.path`。（旧版文档教人改 `_known_qmt_python_dir()` 的写死路径，
+那会让你多背一个源码补丁，现在不需要了。）
 
 启动成功标志（QMT 输出面板）：
 
@@ -90,7 +98,7 @@ $env:BIGQMT_REDIS_HOST="Redis地址"; $env:BIGQMT_REDIS_PORT="6379"
 $env:BIGQMT_REDIS_DB="5"; $env:BIGQMT_REDIS_PASSWORD="Redis密码"
 ```
 
-然后验证（redis ~13ms / zmq ~0.7ms 为正常）：
+然后验证（redis ~3ms / zmq+drain ~16ms 为正常，实测口径见 README 传输对比表）：
 
 ```bash
 python scripts/qmt.py ping
@@ -114,7 +122,7 @@ python scripts/qmt.py ping
 python scripts/qmt.py ping
 ```
 
-返回 `ok: true` 且 `latency_ms` 合理（redis ~13ms / zmq ~0.7ms）即表示服务端就绪。
+返回 `ok: true` 且 `latency_ms` 合理（redis ~3ms / zmq+drain ~16ms）即表示服务端就绪。
 
 ### 第 1 步：一键快照（资产+持仓+委托+成交）
 

--- a/src/bigqmt_signal_trader/init_config.py
+++ b/src/bigqmt_signal_trader/init_config.py
@@ -95,6 +95,25 @@ def _zmq_server_bind_host(client_host):
     return "0.0.0.0"
 
 
+def _background_threads_for(transport):
+    """Which rpc_background_threads value this transport wants.
+
+    Not a safety choice -- trade-context methods are excluded from listener
+    processing no matter what this says (#244) -- purely latency. Measured on
+    the live terminal over 100 read methods (docs/LATENCY_REPORT.md):
+
+        redis  True 3.4ms   / False 30.7ms
+        zmq    True 592.9ms / False 15.8ms
+        pipe   True 189.0ms / False 94.4ms
+
+    redis is the only one that wants True: its brpop wake is immediate, while
+    zmq/pipe background threads pay a cross-thread GIL handoff (~1 adjust
+    tick) on every round trip. One blanket value here is what shipped zmq
+    configs 37x slower than they needed to be.
+    """
+    return str(transport or "redis").lower() in ("redis", "", "default")
+
+
 def render_server_config(answers):
     """bigqmt_signal_trader_local_config.py -- read by the QMT-side strategy."""
     lines = [
@@ -131,12 +150,14 @@ def render_server_config(answers):
         lines.append("    # Remote order/cancel stays off until you explicitly want it.")
     lines.extend([
         '    "rpc_allow_order_methods": %r,' % bool(answers["allow_order_methods"]),
-        "    # Requests drain through QMT's run_time(\"adjust\", ...) callback, on the",
-        "    # main strategy thread. get_trade_detail_data returns EMPTY off that",
-        "    # thread, so order/query methods must not move to a background thread.",
+        "    # get_trade_detail_data returns EMPTY off the main strategy thread, so",
+        "    # order/query methods always run on QMT's adjust callback -- enforced",
+        "    # in code, not by the flag below (#244). rpc_background_threads is a",
+        "    # latency choice and it differs per transport: redis wants True,",
+        "    # zmq/pipe want False (adjust drain).",
         '    "rpc_process_in_listener": True,',
         '    "rpc_listener_methods": ("*",),',
-        '    "rpc_background_threads": False,',
+        '    "rpc_background_threads": %r,' % _background_threads_for(answers["transport"]),
         '    "schedule_adjust": True,',
         '    "schedule_adjust_interval": "100nMilliSecond",',
         '    "full_tick_cache_enabled": False,',
@@ -262,7 +283,7 @@ def render_single_file_config_block(answers):
         '    "rpc_allow_order_methods": %r,' % bool(answers["allow_order_methods"]),
         '    "rpc_process_in_listener": True,',
         '    "rpc_listener_methods": ("*",),',
-        '    "rpc_background_threads": False,',
+        '    "rpc_background_threads": %r,' % _background_threads_for(answers["transport"]),
         '    "schedule_adjust": True,',
         '    "schedule_adjust_interval": "100nMilliSecond",',
         '    "full_tick_cache_enabled": False,',

--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -3276,16 +3276,33 @@ class RedisPubSubRpcService:
         return canonical in self.listener_methods
 
     def _expand_listener_methods(self, listener_methods):
+        """Which methods may run inline on the receive thread.
+
+        The deferred set is subtracted **last**, over the whole result, not
+        only inside the ``"*"`` branch. Naming a method explicitly used to
+        bypass the subtraction entirely, so
+        ``rpc_listener_methods=("get_asset",)`` put a trade-context method
+        back on the receive thread. That is harmless while the receive thread
+        IS the adjust thread (rpc_background_threads False), and silently
+        wrong the moment it is not: off the main strategy thread these answer
+        with the right row count and every field None -- which reads as "this
+        account has no money", not as a failed call.
+
+        Making it depend on two unrelated keys agreeing is what kept
+        ``rpc_background_threads`` pinned to False as a blanket rule. Enforce
+        it here instead: no configuration can route a trade-context method to
+        a background thread, so the flag is free to be chosen on latency.
+        """
         methods = set()
         for method in listener_methods or ():
             method = str(method)
             if method in ("*", "all", "read", "readonly"):
-                methods.update(READ_METHODS - LISTENER_DEFERRED_METHODS)
+                methods.update(READ_METHODS)
             else:
                 methods.add(method)
                 canonical = getattr(self.handlers, "_canonical_method", lambda value: value)(method)
                 methods.add(canonical)
-        return methods
+        return methods - LISTENER_DEFERRED_METHODS
 
     def _loads(self, raw_payload):
         if isinstance(raw_payload, dict):

--- a/src/bigqmt_signal_trader_local_config.example.py
+++ b/src/bigqmt_signal_trader_local_config.example.py
@@ -42,11 +42,22 @@ BIGQMT_REDIS_CONFIG = {
     # （issue #154），任何看那个界面的人都能看到。设成自己的名字，或者设成
     # "" 让该列留空 —— 和手动下单一样。单次调用传 strategy_name= 始终优先。
     # "rpc_default_strategy_name": "",
-    # Redis and ZMQ can both drain requests through QMT's official
-    # run_time("adjust", ...) callback. This avoids GIL stalls in QMT's process.
+    # Trade-context methods (LISTENER_DEFERRED_METHODS) always run on QMT's
+    # run_time("adjust", ...) callback -- get_trade_detail_data returns EMPTY
+    # off the main strategy thread. That is enforced when the listener list is
+    # expanded, so no value below can move them (#244).
+    #
+    # rpc_background_threads is therefore a pure latency choice, and it differs
+    # per transport (100 read methods, live terminal -- docs/LATENCY_REPORT.md):
+    #     redis  True 3.4ms   / False 30.7ms   <- this file ships redis
+    #     zmq    True 592.9ms / False 15.8ms
+    #     pipe   True 189.0ms / False 94.4ms
+    # Only redis wants True: its brpop wake is immediate, while zmq/pipe
+    # background threads pay a cross-thread GIL handoff (~1 adjust tick) per
+    # round trip. Switching transport? Switch this too.
     "rpc_process_in_listener": True,
     "rpc_listener_methods": ("*",),
-    "rpc_background_threads": False,
+    "rpc_background_threads": True,
     "schedule_adjust": True,
     "schedule_adjust_interval": "100nMilliSecond",
     # The default mode calls get_full_tick through RPC. Enable this cache only

--- a/tests/bigqmt_signal_trader/test_init_config.py
+++ b/tests/bigqmt_signal_trader/test_init_config.py
@@ -107,14 +107,31 @@ class RenderedConfigTest(unittest.TestCase):
             _answers(allow_order_methods=True)), "s.py")
         self.assertIs(on["BIGQMT_REDIS_CONFIG"]["rpc_allow_order_methods"], True)
 
-    def test_background_threads_stay_off_whatever_was_answered(self):
-        """get_trade_detail_data returns empty off the main strategy thread, so
-        this is not a user-facing choice."""
-        for answers in (_answers(), _answers(allow_order_methods=True),
-                        _answers(transport="zmq")):
-            loaded = _load(init_config.render_server_config(answers), "s.py")
-            self.assertIs(loaded["BIGQMT_REDIS_CONFIG"]["rpc_background_threads"], False)
+    def test_background_threads_follow_the_transport(self):
+        """Not a safety choice, a latency one -- and it differs per transport.
+
+        This test used to pin False for everything, matching a blanket rule
+        that was protecting the wrong thing: safety comes from
+        LISTENER_DEFERRED_METHODS being excluded when the listener list is
+        expanded (test_listener_methods_never_leak_deferred), not from this
+        flag. Pinning one value shipped zmq 37x slower than it needed to be
+        (592.9ms vs 15.8ms) and redis 9x (30.7ms vs 3.4ms) -- see #244 and
+        docs/LATENCY_REPORT.md.
+        """
+        wants_background = {"redis": True, "zmq": False,
+                            "pipe": False, "mysql": False}
+        for transport, expected in sorted(wants_background.items()):
+            loaded = _load(init_config.render_server_config(
+                _answers(transport=transport)), "s.py")
+            self.assertIs(
+                loaded["BIGQMT_REDIS_CONFIG"]["rpc_background_threads"], expected,
+                "transport=%s 应该是 %s" % (transport, expected))
             self.assertIs(loaded["BIGQMT_REDIS_CONFIG"]["rpc_process_in_listener"], True)
+
+    def test_the_order_switch_does_not_change_the_threading_mode(self):
+        for answers in (_answers(), _answers(allow_order_methods=True)):
+            loaded = _load(init_config.render_server_config(answers), "s.py")
+            self.assertIs(loaded["BIGQMT_REDIS_CONFIG"]["rpc_background_threads"], True)
 
     def test_zmq_client_gets_a_concrete_connect_address(self):
         loaded = _load(init_config.render_client_config(

--- a/tests/bigqmt_signal_trader/test_listener_methods_never_leak_deferred.py
+++ b/tests/bigqmt_signal_trader/test_listener_methods_never_leak_deferred.py
@@ -1,0 +1,67 @@
+# coding: utf-8
+"""没有任何配置能把 trade-context 方法排到后台线程上（#244）。
+
+`LISTENER_DEFERRED_METHODS` 是「必须在 adjust 主线程执行」的名单，因为
+`get_trade_detail_data` 离开主策略线程返回空。`_expand_listener_methods`
+以前只在 `"*"` 分支里减掉这个名单，**显式点名的方法直接 add**，所以
+`rpc_listener_methods=("get_asset",)` 会把它放回收包线程。
+
+这在 `rpc_background_threads=False` 时无害（收包线程就是 adjust 线程），
+在 True 时静默出错。而且错得很阴：离开主线程后 `get_asset` 返回的不是空，
+是**行数对、字段全是 None** 的对象 —— 客户端读成「这账户没钱」，不是
+「调用失败」。
+
+安全性依赖两个不相干的键碰巧一致，正是 `rpc_background_threads` 被一刀切
+钉死为 False 的原因。在展开处强制执行之后，这个开关才可以纯按延迟来选。
+"""
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.redis_rpc import (  # noqa: E402
+    LISTENER_DEFERRED_METHODS,
+    READ_METHODS,
+    RedisPubSubRpcService,
+)
+
+
+class ListenerExpansionTest(unittest.TestCase):
+    def _service(self):
+        service = RedisPubSubRpcService.__new__(RedisPubSubRpcService)
+        service.handlers = None
+        return service
+
+    def _leaked(self, listener_methods):
+        expanded = self._service()._expand_listener_methods(listener_methods)
+        return expanded & LISTENER_DEFERRED_METHODS
+
+    def test_wildcard_excludes_deferred(self):
+        self.assertEqual(self._leaked(("*",)), set())
+
+    def test_naming_a_deferred_method_explicitly_does_not_smuggle_it_in(self):
+        """这条在修复前是红的。"""
+        for method in sorted(LISTENER_DEFERRED_METHODS):
+            self.assertEqual(
+                self._leaked((method,)), set(),
+                "显式点名 %s 把它排到了收包线程；background_threads=True 时它会"
+                "返回「行数对、字段全 None」，客户端读成账户没钱" % method)
+
+    def test_a_mixed_list_keeps_the_safe_ones(self):
+        safe = sorted(READ_METHODS - LISTENER_DEFERRED_METHODS)[:3]
+        deferred = sorted(LISTENER_DEFERRED_METHODS)[:2]
+        expanded = self._service()._expand_listener_methods(tuple(safe) + tuple(deferred))
+        self.assertEqual(expanded & LISTENER_DEFERRED_METHODS, set())
+        for method in safe:
+            self.assertIn(method, expanded, "把安全的只读方法也一起丢了")
+
+    def test_wildcard_still_covers_the_read_surface(self):
+        expanded = self._service()._expand_listener_methods(("*",))
+        self.assertEqual(expanded, READ_METHODS - LISTENER_DEFERRED_METHODS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #244

`qmt-trader/SKILL.md` 的部署示例与 v0.3.28 实测相反。感谢 @shengyy 指出——四条全部属实，而且顺着查下去发现了一个真正的安全洞。

## 报告的四条

| 报告 | 核实 |
|---|---|
| 第3步 redis 写 `False`、切 zmq 要求改 `True` | ✅ **正好反了**。实测 zmq+后台线程 592.9ms、zmq+drain 15.8ms，照着装慢 37 倍 |
| 第5步/快速开始仍称 redis ~13ms / zmq ~0.7ms | ✅ 那张反表的第三份拷贝（README 和 LATENCY_REPORT 已改，漏了这份）|
| 第4步教人改 `_known_qmt_python_dir()` fallback | ✅ 入口早就优先用 `__file__` 所在目录，这个源码补丁不需要了 |
| 应引用 README 唯一实测表，别手抄 | ✅ 已改成引用 |

## 顺带查出的洞：这条建议为什么一直不敢改

CLAUDE.md 有一条铁律「never let `rpc_background_threads` default to True」。查下来，**它保护的东西根本不在这个开关上**：

`_expand_listener_methods` 只在 `"*"` 分支里减掉 `LISTENER_DEFERRED_METHODS`，**显式点名的方法直接 `add`，绕过了减法**：

```python
rpc_listener_methods = ("get_asset",)   # -> get_asset 被排到收包线程
```

`background_threads=False` 时无害（收包线程就是 adjust 线程），`True` 时静默出错。而且错得阴——离开主线程后 `get_asset` 返回的不是空，是**行数对、字段全 None** 的对象，客户端读成「这账户没钱」，不是「调用失败」。

也就是说安全性依赖两个不相干的配置键碰巧一致。一刀切钉死 `False` 是绕开它，代价是 redis 慢 9 倍（3.4ms → 30.7ms）；而且那条规则本来也没真的成立——不写这个键时代码默认就是 `True`。

## 改法

把减法移到展开结果的末尾，**任何配置都无法把 trade-context 方法排到后台线程**。

`"*"` 的展开结果一字未变（106 个，等于 `READ_METHODS - DEFERRED`），**现有默认配置零影响**；只有显式点名那条路被堵上。

这之后开关才可以纯按延迟选：

- `init_config` 新增 `_background_threads_for(transport)`，向导按所选传输生成（redis `True` / 其余 `False`），不再两处写死
- 示例配置、README、SKILL.md 同步到实测口径
- README 第 65 行原写「恒为 `False`……这不是可选项」，与同文件第 555 行「redis 是唯一后台线程更快的」直接打架，一并修掉

## 验证

- 新增 `test_listener_methods_never_leak_deferred.py`（4 条），**修复前 2 条红**
- `test_init_config` 里钉旧规则的那条改成按传输断言
- 全量 **1847 通过**，142/142 模块收集
- 用终端自带 `xtquant`（91 名）预检导入服务端全模块通过

未做实盘验证：线上部署是 0.3.27，这段代码不在被测范围内。但 `"*"` 展开结果不变这一点，意味着对现有部署是 no-op。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
