### PR TITLE
fix: 账户查询失败不再伪装成成功 (#243)

### DIFF
--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -3143,6 +3143,82 @@ class BigQmtXtTrader:
         # ping reports, fall back to what the caller declared.
         self._server_account_type = ""
         self._declared_account_type = ""
+        # Account-query cache fallback (#243). OFF by default: a failed
+        # POSITION/ASSET query must reach the caller, the way it already does
+        # on every non-redis transport. Serving the last redis snapshot
+        # instead turns "the query failed" into "here is what you own",
+        # which is the one answer a strategy must never be given wrongly.
+        #
+        # Deliberately NOT tied to local_cache_enabled: that key is the
+        # client-side *market data* cache. Two different caches, two
+        # switches -- conflating them is what made local_cache_enabled=False
+        # look like it should have disabled this and it did not.
+        # Read the config as handed to us: BigQmtRpcClient normalises its own
+        # copy and drops keys it does not know, so self.client.redis_config
+        # cannot be the source here.
+        cache_config = dict((load_client_config() or {}).get("redis_config") or {})
+        cache_config.update(dict(redis_config or {}))
+        self.account_cache_fallback = _bool_value(
+            cache_config.get("account_cache_fallback"),
+            _env_bool("BIGQMT_ACCOUNT_CACHE_FALLBACK", False),
+        )
+        try:
+            self.account_cache_max_age_seconds = float(
+                cache_config.get("account_cache_max_age_seconds")
+                or os.environ.get("BIGQMT_ACCOUNT_CACHE_MAX_AGE") or 30.0)
+        except (TypeError, ValueError):
+            self.account_cache_max_age_seconds = 30.0
+
+    def _snapshot_age_seconds(self, snapshot):
+        """How old the cached snapshot is, or None when it does not say.
+
+        A snapshot that carries no ``updated_at`` is treated as unusable
+        rather than fresh: the whole point of the bound is refusing to answer
+        with facts we cannot date.
+        """
+        stamp = (snapshot or {}).get("updated_at")
+        if not stamp:
+            return None
+        text = str(stamp).strip()
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S.%f"):
+            try:
+                parsed = _dt.datetime.strptime(text.split("+")[0].strip(), fmt)
+            except ValueError:
+                continue
+            return max(0.0, (_dt.datetime.now() - parsed).total_seconds())
+        try:  # epoch seconds
+            return max(0.0, time.time() - float(text))
+        except (TypeError, ValueError):
+            return None
+
+    def _account_cache_usable(self, account_id, what):
+        """May we answer `what` from the cached snapshot at all?
+
+        Returns the snapshot when the fallback is switched on AND the data is
+        dated AND it is inside the age bound. Anything else -> None, and the
+        caller re-raises the original error.
+        """
+        if not self.account_cache_fallback:
+            return None
+        if not self._redis_cache_enabled():
+            return None
+        snapshot = self._cached_position_snapshot(account_id)
+        if not snapshot:
+            return None
+        age = self._snapshot_age_seconds(snapshot)
+        if age is None:
+            log.warning(
+                "%s: 拒绝用缓存回答 —— 快照没有 updated_at，无法判断新旧", what)
+            return None
+        if age > self.account_cache_max_age_seconds:
+            log.warning(
+                "%s: 拒绝用缓存回答 —— 快照已 %.1fs 前（上限 %.1fs）",
+                what, age, self.account_cache_max_age_seconds)
+            return None
+        log.warning(
+            "%s: 原生查询失败，改用 %.1fs 前的 redis 缓存作答（"
+            "account_cache_fallback=True 打开的行为）", what, age)
+        return snapshot
 
     def _cached_position_snapshot(self, account_id):
         key = "bigqmt:positions:%s" % str(account_id or self.client.account_id or "")
@@ -3533,15 +3609,18 @@ class BigQmtXtTrader:
         try:
             data = self.client.call("query_stock_asset", {"account_id": account_id}, account_id=account_id) or {}
         except Exception:
-            if not self._redis_cache_enabled():
+            # #243: default is to let the failure through. Only an explicit
+            # account_cache_fallback, with a dated and fresh snapshot, answers
+            # from cache -- and it says so in the log when it does.
+            if self._account_cache_usable(account_id, "query_stock_asset") is None:
                 raise
             data = self._cached_asset(account_id)
             if not data:
                 raise
         if (
-            self._redis_cache_enabled()
-            and data.get("cash") is None
+            data.get("cash") is None
             and data.get("total_asset") is None
+            and self._account_cache_usable(account_id, "query_stock_asset(empty)") is not None
         ):
             data = self._cached_asset(account_id) or data
         cash = data.get("cash")
@@ -3633,7 +3712,7 @@ class BigQmtXtTrader:
         try:
             data = self.client.call("query_stock_positions", {"account_id": account_id}, account_id=account_id) or {}
         except Exception:
-            if not self._redis_cache_enabled():
+            if self._account_cache_usable(account_id, "query_stock_positions") is None:
                 raise
             data = self._cached_positions(account_id)
             if not data:
@@ -3762,7 +3841,7 @@ class BigQmtXtTrader:
                 account_id=account_id,
             )
         except Exception:
-            if not self._redis_cache_enabled():
+            if self._account_cache_usable(account_id, "query_stock_position") is None:
                 raise
             normalized = str(stock_code or "").strip().upper()
             data = None

--- a/src/bigqmt_signal_trader_client_config.example.py
+++ b/src/bigqmt_signal_trader_client_config.example.py
@@ -14,6 +14,13 @@ BIGQMT_DOWNLOAD_WAIT_SECONDS = 1800
 BIGQMT_DOWNLOAD_POLL_INTERVAL_SECONDS = 0.5
 
 BIGQMT_REDIS_CONFIG = {
+    # 账户查询（持仓/资产）失败时，是否用 redis 里的上一份快照作答。
+    # 默认 False —— 查询失败就抛给调用方，和 zmq/pipe 一致。打开它等于接受
+    # 「拿旧持仓当当前持仓」，策略据此算仓位是会出事的（#243）。
+    # 打开后仍要求快照带 updated_at 且在时限内，否则照样抛。
+    # "account_cache_fallback": False,
+    # "account_cache_max_age_seconds": 30,
+
     "host": "YOUR_REDIS_HOST",
     "port": 6379,
     "db": 5,

--- a/tests/bigqmt_signal_trader/test_account_cache_fallback.py
+++ b/tests/bigqmt_signal_trader/test_account_cache_fallback.py
@@ -1,0 +1,155 @@
+# coding: utf-8
+"""账户查询失败不能伪装成成功（#243）。
+
+`query_stock_positions` / `query_stock_asset` / `query_stock_position` 在 RPC
+抛异常后会去读 `bigqmt:positions:<account>`，只要那里有非空旧数据就当成
+查询结果返回。后果是 #229/#230 好不容易让原生 POSITION 查询异常上抛，在
+redis 客户端这条路上又被吞回去 —— **同一个输入，zmq 抛错、redis 返回旧持仓**。
+
+对交易系统来说这是最坏的一种错：策略拿它去算仓位，而它看起来完全正常。
+缓存还不校 `updated_at`，2000 年的快照和一秒前的一样会被采信。
+
+判定「开没开」以前只看 transport，`local_cache_enabled=False` 关不掉它 ——
+那个键本来也是**客户端行情缓存**的开关，两回事。所以这里给账户缓存一个
+自己的开关，默认关（失败就是失败），打开也要求快照有日期且在时限内。
+"""
+import datetime
+import json
+import os
+import sys
+import unittest
+
+from unittest.mock import Mock
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+os.environ.setdefault("BIGQMT_LOG_NAME", "bigqmt-test-account-cache")
+
+from bigqmt_signal_trader.xtquant_compat import BigQmtXtTrader  # noqa: E402
+
+
+POSITIONS = {"600000.SH": {"stock_code": "600000.SH", "volume": 1000,
+                           "available": 1000, "cost": 10.0}}
+ASSET = {"cash": 1234.0, "total_asset": 5678.0}
+
+
+def _snapshot(updated_at):
+    snap = {"positions": POSITIONS, "asset": ASSET}
+    if updated_at is not None:
+        snap["updated_at"] = updated_at
+    return snap
+
+
+def _now():
+    return datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _trader(snapshot, **extra):
+    config = {"transport": "redis", "local_cache_enabled": False}
+    config.update(extra)
+    trader = BigQmtXtTrader(account_id="test-only", redis_config=config)
+    trader.client.call = Mock(side_effect=RuntimeError("native query failed"))
+    trader.client._redis = Mock(return_value=Mock(
+        get=Mock(return_value=json.dumps(snapshot).encode())))
+    return trader
+
+
+class DefaultPropagatesTest(unittest.TestCase):
+    """默认行为：失败就是失败，和 zmq 一致。"""
+
+    def test_positions_failure_reaches_the_caller(self):
+        trader = _trader(_snapshot("2000-01-01 00:00:00"))
+        with self.assertRaises(RuntimeError):
+            trader.query_stock_positions("test-only")
+
+    def test_a_fresh_snapshot_does_not_change_that(self):
+        """不是「太旧才不用」，是默认根本不用。"""
+        trader = _trader(_snapshot(_now()))
+        with self.assertRaises(RuntimeError):
+            trader.query_stock_positions("test-only")
+
+    def test_asset_failure_reaches_the_caller(self):
+        trader = _trader(_snapshot(_now()))
+        with self.assertRaises(RuntimeError):
+            trader.query_stock_asset("test-only")
+
+    def test_single_position_failure_reaches_the_caller(self):
+        trader = _trader(_snapshot(_now()))
+        with self.assertRaises(RuntimeError):
+            trader.query_stock_position("test-only", "600000.SH")
+
+    def test_redis_now_matches_zmq(self):
+        """#243 的核心症状：同一输入两种传输答案相反。"""
+        for transport in ("redis", "zmq"):
+            trader = _trader(_snapshot(_now()))
+            trader.client.transport_name = transport
+            with self.assertRaises(RuntimeError, msg="transport=%s 吞掉了异常" % transport):
+                trader.query_stock_positions("test-only")
+
+
+class OptInFallbackTest(unittest.TestCase):
+    """显式打开后：要有日期，且在时限内。"""
+
+    def test_fresh_snapshot_answers(self):
+        trader = _trader(_snapshot(_now()), account_cache_fallback=True)
+        positions = trader.query_stock_positions("test-only")
+        self.assertEqual(positions[0].volume, 1000)
+
+    def test_stale_snapshot_still_raises(self):
+        trader = _trader(_snapshot("2000-01-01 00:00:00"), account_cache_fallback=True)
+        with self.assertRaises(RuntimeError):
+            trader.query_stock_positions("test-only")
+
+    def test_an_undated_snapshot_is_refused(self):
+        """没有 updated_at 就无法判断新旧，不能采信。"""
+        trader = _trader(_snapshot(None), account_cache_fallback=True)
+        with self.assertRaises(RuntimeError):
+            trader.query_stock_positions("test-only")
+
+    def test_the_age_bound_is_configurable(self):
+        old = (datetime.datetime.now() - datetime.timedelta(seconds=120)
+               ).strftime("%Y-%m-%d %H:%M:%S")
+        tight = _trader(_snapshot(old), account_cache_fallback=True)
+        with self.assertRaises(RuntimeError):
+            tight.query_stock_positions("test-only")
+
+        loose = _trader(_snapshot(old), account_cache_fallback=True,
+                        account_cache_max_age_seconds=600)
+        self.assertEqual(loose.query_stock_positions("test-only")[0].volume, 1000)
+
+    def test_asset_and_single_position_honour_the_same_switch(self):
+        asset = _trader(_snapshot(_now()), account_cache_fallback=True)
+        self.assertEqual(asset.query_stock_asset("test-only").cash, 1234.0)
+
+        single = _trader(_snapshot(_now()), account_cache_fallback=True)
+        self.assertEqual(single.query_stock_position("test-only", "600000.SH").volume, 1000)
+
+
+class SwitchIndependenceTest(unittest.TestCase):
+    def test_local_cache_enabled_is_a_different_cache(self):
+        """local_cache_enabled 管客户端行情缓存，不该顺手管账户缓存。
+
+        它开着也不该把账户回退打开 —— 账户回退有自己的键。
+        """
+        trader = _trader(_snapshot(_now()), local_cache_enabled=True)
+        with self.assertRaises(RuntimeError):
+            trader.query_stock_positions("test-only")
+
+
+class SnapshotAgeTest(unittest.TestCase):
+    def test_parses_the_formats_the_publisher_writes(self):
+        trader = _trader(_snapshot(_now()))
+        for stamp in ("2026-09-08 10:00:00", "2026-09-08T10:00:00",
+                      "2026-09-08 10:00:00.500"):
+            self.assertIsNotNone(trader._snapshot_age_seconds({"updated_at": stamp}), stamp)
+
+    def test_unparseable_is_none_not_zero(self):
+        """认不出来要当「不知道多旧」，不能当「刚刚」。"""
+        trader = _trader(_snapshot(_now()))
+        for stamp in ("", None, "not-a-date"):
+            self.assertIsNone(trader._snapshot_age_seconds({"updated_at": stamp}), repr(stamp))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_xtquant_compat.py
+++ b/tests/bigqmt_signal_trader/test_xtquant_compat.py
@@ -25,6 +25,12 @@ from bigqmt_signal_trader.xtquant_compat import (
 from bigqmt_signal_trader.full_tick_cache import full_tick_demand_key, full_tick_request_id, write_full_tick_cache
 
 
+
+def _now_stamp():
+    import datetime as _d
+    return _d.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+
 class FakeRpcClient:
     def __init__(self):
         self.account_id = "acct"
@@ -588,7 +594,7 @@ class XtquantCompatTest(unittest.TestCase):
         self.assertEqual(client.redis_config["password"], "")
         self.assertEqual(client.timeout_seconds, 3)
 
-    def test_trader_falls_back_to_cached_positions_when_rpc_fails(self):
+    def _failing_client_with_cache(self, updated_at):
         class FailingRpcClient(FakeRpcClient):
             def call(self, method, params=None, account_id=None, timeout_seconds=None):
                 if method in ("query_stock_asset", "query_stock_positions", "query_stock_position"):
@@ -596,7 +602,7 @@ class XtquantCompatTest(unittest.TestCase):
                 return super().call(method, params, account_id, timeout_seconds)
 
         client = FailingRpcClient()
-        client.redis.hashes["bigqmt:positions:acct"] = {
+        snapshot = {
             "account_id": "acct",
             "asset": {"cash": 123.0, "total_asset": 456.0},
             "positions": {
@@ -609,8 +615,33 @@ class XtquantCompatTest(unittest.TestCase):
                 }
             },
         }
+        if updated_at is not None:
+            snapshot["updated_at"] = updated_at
+        client.redis.hashes["bigqmt:positions:acct"] = snapshot
+        return client
+
+    def test_a_failed_account_query_is_not_answered_from_cache_by_default(self):
+        """#243：以前只要缓存非空就当查询成功，把原生异常吞掉了。
+
+        对交易系统来说这是最坏的一种错——策略拿旧持仓去算仓位，而调用看起来
+        完全正常。默认改为传播，要回退得显式打开 account_cache_fallback。
+        """
         trader = BigQmtXtTrader(account_id="acct")
-        trader.client = client
+        trader.client = self._failing_client_with_cache(_now_stamp())
+        acc = StockAccount("acct")
+
+        for call in (lambda: trader.query_stock_asset(acc),
+                     lambda: trader.query_stock_positions(acc),
+                     lambda: trader.query_stock_position(acc, "600000")):
+            with self.assertRaises(RuntimeError):
+                call()
+
+    def test_opting_in_serves_a_fresh_snapshot(self):
+        trader = BigQmtXtTrader(
+            account_id="acct",
+            redis_config={"transport": "redis", "account_cache_fallback": True},
+        )
+        trader.client = self._failing_client_with_cache(_now_stamp())
         acc = StockAccount("acct")
 
         asset = trader.query_stock_asset(acc)
@@ -622,6 +653,15 @@ class XtquantCompatTest(unittest.TestCase):
         self.assertEqual(positions[0].stock_code, "600000.SH")
         self.assertEqual(positions[0].can_use_volume, 80)
         self.assertEqual(single.stock_name, "cached")
+
+    def test_opting_in_still_refuses_a_stale_snapshot(self):
+        trader = BigQmtXtTrader(
+            account_id="acct",
+            redis_config={"transport": "redis", "account_cache_fallback": True},
+        )
+        trader.client = self._failing_client_with_cache("2000-01-01 00:00:00")
+        with self.assertRaises(RuntimeError):
+            trader.query_stock_positions(StockAccount("acct"))
 
     def test_zmq_query_failure_never_falls_back_to_redis_cache(self):
         class FailingZmqClient(FakeRpcClient):


### PR DESCRIPTION
Fixes #243

感谢 @shengyy 的隔离复现——**照着跑一次就重现了**，而且它指出的正是本仓最怕的那种错误形态：失败看起来像成功。

## 复现确认

同一个输入，两种传输答案相反：

```
redis -> volume=1000 yesterday_volume=1000 price=10.0   (updated_at 是 2000 年的)
zmq   -> 正确抛出 RuntimeError: native POSITION query failed
```

`_redis_cache_enabled()` 只看 transport，`local_cache_enabled=False` 确实关不掉。

## 为什么这个默认值必须改

#229 / #230 花了力气让原生 POSITION 查询异常上抛，在 redis 客户端这条路上又被吞回去。对交易系统来说这是最坏的一种错：**策略拿旧持仓去算仓位，而调用看起来完全正常**。缓存还不校 `updated_at`，2000 年的快照和一秒前的一样被采信。

## 关于「行情缓存与账户缓存要分开」

报告人这条说得对，而且比表面更彻底：`local_cache_enabled` 在代码里明确是**客户端行情缓存**的开关（`"Client-side local market-data cache"`）。所以它关不掉账户缓存不是 bug——**缺的是账户缓存自己的开关**。没有给它加进 `local_cache_enabled` 的语义里，而是给了它独立的键。

## 改法

- 新增 `account_cache_fallback`，**默认 `False`**：失败就是失败，和 zmq/pipe 一致
- 打开后仍要求快照带 `updated_at` 且在 `account_cache_max_age_seconds`（默认 30s）以内；日期认不出来当「不知道多旧」，拒绝采信（不能当成「刚刚」）
- 真的用缓存作答时打 WARNING，写明用了几秒前的数据
- `query_stock_asset` 里第二条静默路径（查询成功但 `cash`/`total_asset` 都是 None 时拿缓存顶上）走同一个闸

行为矩阵：

| | 默认 | `account_cache_fallback=True` |
|---|---|---|
| 新鲜快照 | 抛错 | 作答（带 WARNING）|
| 陈旧快照 | 抛错 | 抛错 |
| 无 `updated_at` | 抛错 | 抛错 |

## 验证

- 新增 `test_account_cache_fallback.py`（13 条），**修复前 11 条红**
- `test_xtquant_compat` 里钉旧行为的那条拆成三条
- 全量 **1857 通过**，142/142 模块收集
- **实盘验证**：对着运行中的桥跑真实查询，资产 `cash=2163.13`、5 条持仓正常返回——新默认值下正常路径不受影响，改动只作用于失败路径

这是行为变更：升级后原本被静默掩盖的查询故障会开始抛错。这正是意图，需要旧行为的显式打开开关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
