### PR TITLE
fix: 同一个 request_id 的下单请求只派发一次 (#245)

### DIFF
--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -3086,6 +3086,10 @@ class RedisPubSubRpcService:
         self.debug_log_limit = int(debug_log_limit)
         self._received_count = 0
         self._processed_count = 0
+        # (account_id, request_id) -> {"at", "response"} for write methods,
+        # so a transparently retried RPUSH cannot dispatch a second order (#245).
+        self._order_requests = collections.OrderedDict()
+        self._duplicate_order_requests = 0
         self._published_count = 0
         self._deferred_count = 0
         self.print_prefix = print_prefix
@@ -3382,11 +3386,79 @@ class RedisPubSubRpcService:
             processed += 1
         return processed
 
+    ORDER_DEDUP_MAX = 512
+    ORDER_DEDUP_TTL_SECONDS = 600
+
+    def _canonical(self, method):
+        resolve = getattr(self.handlers, "_canonical_method", None)
+        return resolve(method) if callable(resolve) else method
+
+    def _claim_order_request(self, key):
+        """Claim (account_id, request_id) for a write. None == first time.
+
+        Returns the existing entry when this id has already been seen, so the
+        caller can answer without dispatching a second native order.
+        """
+        store = getattr(self, "_order_requests", None)
+        if store is None:
+            store = self._order_requests = collections.OrderedDict()
+        now = time.time()
+        # Prune by age, then by size. Both are bounded on purpose: this runs
+        # on the adjust thread and must not grow with uptime.
+        for stale in [k for k, v in store.items()
+                      if now - v.get("at", now) > self.ORDER_DEDUP_TTL_SECONDS]:
+            store.pop(stale, None)
+        while len(store) > self.ORDER_DEDUP_MAX:
+            store.popitem(last=False)
+        existing = store.get(key)
+        if existing is not None:
+            return existing
+        store[key] = {"at": now, "response": None}
+        return None
+
+    def _remember_order_response(self, key, response):
+        store = getattr(self, "_order_requests", None)
+        if store is not None and key in store:
+            store[key]["response"] = response
+
     def process_request(self, request):
         request = dict(request or {})
         request_id = str(request.get("request_id") or request.get("id") or uuid.uuid4().hex)
         account_id = str(request.get("account_id") or self.account_id or "")
         method = str(request.get("method") or "")
+
+        # At-most-once for writes (#245). The client's redis-py connection
+        # retries transparently on ConnectionError/TimeoutError, and the retry
+        # re-sends the whole command -- conn.retry wraps send AND parse, so an
+        # RPUSH the server already accepted is sent again when the reply is
+        # lost. Nothing downstream deduped: order_stock / order_stock_async
+        # both alias to submit_order, and _handle_submit_order has no
+        # idempotency check (only submit_orders_batch does). So one
+        # client.call could dispatch two native passorders.
+        #
+        # The retry re-sends the identical payload, request_id included, which
+        # is what makes this fixable here: the second copy is recognisable.
+        # Answer it with the first one's response instead of dispatching --
+        # both copies name the same reply key, so it lands where the client is
+        # already waiting.
+        order_key = None
+        if request_id and self._canonical(method) in ORDER_METHODS:
+            order_key = (account_id, request_id)
+            seen = self._claim_order_request(order_key)
+            if seen is not None:
+                self._duplicate_order_requests += 1
+                remembered = seen.get("response")
+                print("%s duplicate order request suppressed method=%s request_id=%s"
+                      % (self.print_prefix, method, request_id))
+                if remembered is None:
+                    # Still in flight: the first copy publishes to the same
+                    # reply key when it settles. Nothing to do but not dispatch.
+                    return None
+                try:
+                    self._publish_response(request, remembered)
+                except Exception:
+                    pass
+                return remembered
         response = {
             "schema_version": 1,
             "request_id": request_id,
@@ -3430,10 +3502,14 @@ class RedisPubSubRpcService:
                 settlement.response = response
                 self._pending_settlements.put(settlement)
                 self._deferred_count += 1
+                if order_key is not None:
+                    self._remember_order_response(order_key, response)
                 return response
         except Exception as exc:
             response["error"] = "%s: %s" % (exc.__class__.__name__, exc)
         response["_t_reply"] = time.time()
+        if order_key is not None:
+            self._remember_order_response(order_key, response)
         _t_pub0 = time.perf_counter() if method == "ping" else 0.0
         try:
             self._publish_response(request, response)

--- a/tests/bigqmt_signal_trader/test_order_request_dedup.py
+++ b/tests/bigqmt_signal_trader/test_order_request_dedup.py
@@ -1,0 +1,151 @@
+# coding: utf-8
+"""同一个 request_id 的下单请求只派发一次（#245）。
+
+客户端的 redis-py 连接默认带透明重试（ConnectionError / TimeoutError），而
+`Redis._execute_command` 里 `conn.retry.call_with_retry(...)` 包的是
+**send + parse**：服务端已经接受的 RPUSH，如果应答阶段出错，整条命令会被
+重发。RPUSH 不是幂等的，于是同一次 `client.call('passorder', ...)` 可能派发
+两次原生下单。
+
+下游没有任何一层兜住：`order_stock` / `order_stock_async` 都是 `submit_order`
+的别名，而 `_handle_submit_order` 没有去重（幂等日志只在
+`submit_orders_batch` 里）。`request_id` 此前只用于路由应答。
+
+能在服务端修干净，靠的是重试**重发的是同一份 payload**，request_id 一样 ——
+第二份认得出来。而且两份都指向同一个应答键，所以把第一份的答案重发一次，
+正好落在客户端等待的位置。
+"""
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+os.environ.setdefault("BIGQMT_LOG_NAME", "bigqmt-test-dedup")
+
+from bigqmt_signal_trader.redis_rpc import (  # noqa: E402
+    ORDER_METHODS,
+    RedisPubSubRpcService,
+)
+
+
+class _Handlers(object):
+    """只记参数，不碰 QMT、不碰柜台。"""
+
+    def __init__(self):
+        self.dispatched = []
+        self._last_server_error = ""
+
+    def _canonical_method(self, method):
+        return {"order_stock": "submit_order",
+                "order_stock_async": "submit_order"}.get(method, method)
+
+    def handle(self, method, params=None):
+        self.dispatched.append((self._canonical_method(method), dict(params or {})))
+        return {"order_sys_id": "1001", "user_order_id": (params or {}).get("user_order_id")}
+
+    def take_pending_settlement(self):
+        return None
+
+
+def _service():
+    service = RedisPubSubRpcService.__new__(RedisPubSubRpcService)
+    service.handlers = _Handlers()
+    service.account_id = "acct"
+    service.print_prefix = "[test]"
+    service.debug_log_limit = 0
+    service._processed_count = 0
+    service._deferred_count = 0
+    import collections
+    service._order_requests = collections.OrderedDict()
+    service._duplicate_order_requests = 0
+    service.published = []
+    service._publish_response = lambda request, response: service.published.append(response)
+    return service
+
+
+def _request(method, request_id, **params):
+    return {"schema_version": 1, "request_id": request_id, "account_id": "acct",
+            "method": method, "params": params}
+
+
+class OrderDedupTest(unittest.TestCase):
+    def test_a_resent_passorder_dispatches_once(self):
+        """报告里的场景：RPUSH 被透明重试重发。"""
+        service = _service()
+        request = _request("passorder", "abc123", user_order_id="u-1")
+
+        service.process_request(dict(request))
+        service.process_request(dict(request))      # 重试重发的那一份
+
+        dispatched = [m for m, _ in service.handlers.dispatched]
+        self.assertEqual(dispatched, ["passorder"], "派发了两次：%s" % dispatched)
+        self.assertEqual(service._duplicate_order_requests, 1)
+
+    def test_the_duplicate_still_gets_an_answer(self):
+        """不能只是丢掉——客户端还在同一个应答键上等。"""
+        service = _service()
+        request = _request("passorder", "abc123", user_order_id="u-1")
+
+        first = service.process_request(dict(request))
+        second = service.process_request(dict(request))
+
+        self.assertIsNotNone(second)
+        self.assertEqual(second["request_id"], first["request_id"])
+        self.assertEqual(second["data"], first["data"])
+        self.assertEqual(len(service.published), 2, "重复请求没有重发答案")
+
+    def test_alias_paths_are_covered_too(self):
+        """order_stock / order_stock_async 都别名到 submit_order。"""
+        for method in ("order_stock", "order_stock_async", "submit_order"):
+            service = _service()
+            request = _request(method, "same-id", stock_code="600000.SH")
+            service.process_request(dict(request))
+            service.process_request(dict(request))
+            self.assertEqual(len(service.handlers.dispatched), 1,
+                             "%s 派发了两次" % method)
+
+    def test_every_order_method_is_deduped(self):
+        for method in sorted(ORDER_METHODS):
+            service = _service()
+            request = _request(method, "id-%s" % method)
+            service.process_request(dict(request))
+            service.process_request(dict(request))
+            self.assertEqual(len(service.handlers.dispatched), 1,
+                             "%s 没有去重" % method)
+
+    def test_distinct_request_ids_both_run(self):
+        """去重的是重发，不是两笔真实下单。"""
+        service = _service()
+        service.process_request(_request("passorder", "id-1", user_order_id="u-1"))
+        service.process_request(_request("passorder", "id-2", user_order_id="u-2"))
+        self.assertEqual(len(service.handlers.dispatched), 2,
+                         "把两笔不同的下单也去掉了")
+
+    def test_reads_are_not_deduped(self):
+        """只读请求重发是无害的，去重反而会返回陈旧数据。"""
+        service = _service()
+        request = _request("query_stock_positions", "same-id")
+        service.process_request(dict(request))
+        service.process_request(dict(request))
+        self.assertEqual(len(service.handlers.dispatched), 2)
+
+    def test_the_table_does_not_grow_without_bound(self):
+        service = _service()
+        for index in range(service.ORDER_DEDUP_MAX + 50):
+            service.process_request(_request("passorder", "id-%d" % index))
+        self.assertLessEqual(len(service._order_requests), service.ORDER_DEDUP_MAX + 1)
+
+    def test_an_in_flight_duplicate_is_not_dispatched(self):
+        """第一份还没出答案时来的重发，也不能派发第二次。"""
+        service = _service()
+        key = ("acct", "abc123")
+        service._claim_order_request(key)           # 模拟「已认领、尚无答案」
+        result = service.process_request(_request("passorder", "abc123"))
+        self.assertIsNone(result)
+        self.assertEqual(service.handlers.dispatched, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #245

感谢 @shengyy —— 机制我逐层核实过，**成立**，而且暴露面比报告里写的更大。

## 核实

- `pyproject.toml` 是 `redis>=5.0.0`，无上界 → 实际装到 6/8
- 连接默认 `Retry`，`_supported_errors` 含 `TimeoutError` / `ConnectionError`
- `Redis._execute_command` 里 `conn.retry.call_with_retry(lambda: self._send_command_parse_response(...))` —— 包的是 **send + parse**，所以应答阶段出错会重发整条 RPUSH
- `_redis()` 和 `build_redis_client()` 两处建连接都没设 `retry`
- `request_id` 此前只用于路由应答，不做去重

## 比报告里更严重的一点

报告说风险在裸 `passorder`。实际上：

```python
METHOD_ALIASES = {
    "order_stock": "submit_order",
    "order_stock_async": "submit_order",
    ...
}
```

而 `_handle_submit_order` **没有任何去重** —— 幂等机制（`order_tag` + `_submit_journal`）只存在于 `submit_orders_batch`。所以主流下单口 `order_stock` / `order_stock_async` 也全都没有保护，只有 `order_stock_batch` 是安全的。

## 修法：服务端兜底

重试重发的是**同一份 payload**，`request_id` 在 payload 里而不是每次重生成 —— 这是能在服务端修干净的关键：第二份认得出来。而且两份指向同一个应答键，所以**重发第一份的答案**正好落在客户端正在等的位置，客户端拿到的是成功而不是错误。

- `ORDER_METHODS`（按 canonical 名判定，覆盖别名）按 `(account_id, request_id)` 记账
- 重复到达 → 不派发，重发已有答案
- 第一份还在处理中时到达的重发 → 不派发，由第一份 publish
- 表按条数（512）和时间（600s）双重封顶：这段跑在 adjust 线程上，不能随运行时长增长
- **只读方法不去重**：重发只读无害，去重反而会返回陈旧数据

按讨论的结论，本 PR **不改客户端重试行为**（只读请求继续受益于重试），只做服务端兜底。你在下游注入 `Retry(NoBackoff(), 0)` 的做法依然有效，两者不冲突。

## 验证

**真实 Redis 端到端**（db 15 隔离，handler 只记参数，不碰 QMT、不碰柜台），照你的注入法在 RPUSH 应答阶段抛 `TimeoutError`：

| | 修复前 | 修复后 |
|---|---|---|
| 无注入（基线）| 派发 1 次 | 派发 1 次 |
| 注入丢失 RPUSH 应答 | **派发 2 次** | **派发 1 次**（抑制 1）|

两种情况下客户端都拿到成功应答。

- 新增 `test_order_request_dedup.py`（8 条），**修复前 5 条红**
- 全量 **1850 通过**，142/142 模块收集
- 用终端自带 `xtquant`（91 名）预检导入服务端全模块通过

没有在真实柜台制造重复下单来验证，也不打算——上面的注入是在 RPC 层做的，handler 只记参数。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
