### PR TITLE
fix: recover Redis quote reception and finish partial subscription replays

### DIFF
--- a/src/bigqmt_signal_trader/quote_push_channel.py
+++ b/src/bigqmt_signal_trader/quote_push_channel.py
@@ -202,6 +202,7 @@ class RedisQuotePushChannel(QuotePushChannel):
         self._running = False
         self._pubsub = None
         self._thread = None
+        self._subscriber_stop = threading.Event()
 
     def _channel(self, topic):
         return self.channel_template.format(account_id=self.account_id, topic=topic)
@@ -220,51 +221,57 @@ class RedisQuotePushChannel(QuotePushChannel):
 
     # -- client side ---------------------------------------------------------
     def start_subscriber(self, topics, on_msg):
+        self.stop()
         self._running = True
+        self._subscriber_stop = threading.Event()
         self._thread = threading.Thread(
-            target=self._sub_loop, args=(list(topics or []), on_msg), name="bigqmt-quote-push-sub", daemon=True
+            target=self._sub_loop, args=(list(topics or []), on_msg, self._subscriber_stop),
+            name="bigqmt-quote-push-sub", daemon=True
         )
         self._thread.start()
 
-    def _sub_loop(self, topics, on_msg):
-        # The pubsub connection is owned by THIS thread and closed HERE so a
-        # concurrent stop() can't close it out from under us.
-        pubsub = self.redis.pubsub(ignore_subscribe_messages=True)
-        self._pubsub = pubsub
+    def _sub_loop(self, topics, on_msg, stopped):
+        # This receiver owns reconnect and closes its own connections. Capture
+        # its stop event so a later start cannot revive an old blocked receiver.
         channels = [self._channel(topic) for topic in topics]
-        try:
-            pubsub.subscribe(*channels)
-        except Exception as exc:
-            print("%s redis subscribe failed: %s" % (self.print_prefix, exc))
-            return
-        try:
-            while self._running:
-                try:
-                    message = pubsub.get_message(timeout=0.2)
-                except Exception:
-                    break
-                if not message or message.get("type") != "message":
-                    continue
-                channel = message.get("channel")
-                if isinstance(channel, bytes):
-                    channel = channel.decode("utf-8", errors="ignore")
-                topic = str(channel).rsplit(":", 1)[-1]
-                data = decode_push_payload(message.get("data"))
-                payload_data = data.get("data") if isinstance(data, dict) else data
-                try:
-                    on_msg(topic, payload_data)
-                except Exception as exc:
-                    print("%s subscriber callback failed: %s" % (self.print_prefix, exc))
-        finally:
+        while not stopped.is_set():
+            pubsub = None
             try:
-                pubsub.close()
-            except Exception:
-                pass
+                pubsub = self.redis.pubsub(ignore_subscribe_messages=True)
+                self._pubsub = pubsub
+                pubsub.subscribe(*channels)
+                while not stopped.is_set():
+                    message = pubsub.get_message(timeout=0.2)
+                    if stopped.is_set():
+                        break
+                    if not message or message.get("type") != "message":
+                        continue
+                    channel = message.get("channel")
+                    if isinstance(channel, bytes):
+                        channel = channel.decode("utf-8", errors="ignore")
+                    topic = str(channel).rsplit(":", 1)[-1]
+                    data = decode_push_payload(message.get("data"))
+                    payload_data = data.get("data") if isinstance(data, dict) else data
+                    try:
+                        on_msg(topic, payload_data)
+                    except Exception as exc:
+                        print("%s subscriber callback failed: %s" % (self.print_prefix, exc))
+            except Exception as exc:
+                if not stopped.is_set():
+                    print("%s redis subscriber reconnecting: %s" % (self.print_prefix, exc))
+            finally:
+                if pubsub is not None:
+                    try:
+                        pubsub.close()
+                    except Exception:
+                        pass
+            stopped.wait(1.0)
 
     def stop(self):
         self._running = False
+        self._subscriber_stop.set()
         thread = self._thread
-        if thread is not None and thread.is_alive():
+        if thread is not None and thread is not threading.current_thread() and thread.is_alive():
             thread.join(1.0)
         self._thread = None
         self._pubsub = None

--- a/src/bigqmt_signal_trader/whole_quote_session.py
+++ b/src/bigqmt_signal_trader/whole_quote_session.py
@@ -83,11 +83,18 @@ class WholeQuoteClientSession(object):
         with self._lock:
             items = [(sid, dict(entry)) for sid, entry in self._subscriptions.items()]
             self._replay_pending = True
+        error = None
         for sub_id, entry in items:
-            self._rpc(
-                "subscribe_whole_quote",
-                {"client_id": self.client_id, "sub_id": sub_id, "codes": entry["codes"]},
-            )
+            try:
+                self._rpc(
+                    "subscribe_whole_quote",
+                    {"client_id": self.client_id, "sub_id": sub_id, "codes": entry["codes"]},
+                )
+            except Exception as exc:
+                if error is None:
+                    error = exc
+        if error is not None:
+            raise error
         with self._lock:
             self._replay_pending = False
 

--- a/src/bigqmt_signal_trader/whole_quote_session.py
+++ b/src/bigqmt_signal_trader/whole_quote_session.py
@@ -42,6 +42,7 @@ class WholeQuoteClientSession(object):
         self._subscribed_topics = frozenset()  # topic set the subscriber covers now
         self._heartbeat_thread = None
         self._last_push_time = None  # monotonic time of last incoming push
+        self._replay_pending = False  # a failed batch must finish despite other subscriptions pushing
 
     # -- subscription lifecycle ---------------------------------------------
     def subscribe_whole_quote(self, code_list, callback=None):
@@ -81,11 +82,14 @@ class WholeQuoteClientSession(object):
         Idempotent on the server (keyed by client_id+combo), so replays are safe."""
         with self._lock:
             items = [(sid, dict(entry)) for sid, entry in self._subscriptions.items()]
+            self._replay_pending = True
         for sub_id, entry in items:
             self._rpc(
                 "subscribe_whole_quote",
                 {"client_id": self.client_id, "sub_id": sub_id, "codes": entry["codes"]},
             )
+        with self._lock:
+            self._replay_pending = False
 
     # -- heartbeat -------------------------------------------------------------
     def start(self):
@@ -131,20 +135,9 @@ class WholeQuoteClientSession(object):
                     self._rpc("quote_keepalive", {"client_id": self.client_id, "sub_id": sub_id})
                 except Exception:
                     failures += 1
+            recovered = not failures and consecutive_failures >= 3
             if failures:
                 consecutive_failures += 1
-            elif consecutive_failures >= 3:
-                # Server is back after a restart window: replay subscriptions so
-                # the restarted server re-creates the big-QMT subscriptions (its
-                # state is gone). Idempotent on the server, so replays are safe.
-                # The replay is itself an RPC and can fail while the window is
-                # still open -- that must never kill this loop (#231): a dead
-                # heartbeat leaves every subscription to age out server-side.
-                try:
-                    self.replay_subscriptions()
-                except Exception:
-                    pass
-                consecutive_failures = 0
             else:
                 consecutive_failures = 0
             # Push-silence detection: a server restart can survive with keepalive
@@ -157,9 +150,11 @@ class WholeQuoteClientSession(object):
             else:
                 silence_rounds += 1
             prev_last_push = last_push
-            if silence_rounds >= self._push_silence_replay_heartbeats:
-                # Same rule as the recovery replay above: a failed replay is a
-                # retry next round, never a dead loop (#231).
+            with self._lock:
+                replay_pending = self._replay_pending
+            if recovered or replay_pending or silence_rounds >= self._push_silence_replay_heartbeats:
+                # Retry the idempotent batch until every subscription succeeds.
+                # A's pushes cannot erase B's unresolved replay (#231).
                 try:
                     self.replay_subscriptions()
                 except Exception:

--- a/tests/bigqmt_signal_trader/test_quote_push_channel.py
+++ b/tests/bigqmt_signal_trader/test_quote_push_channel.py
@@ -4,6 +4,7 @@ import sys
 import threading
 import time
 import unittest
+from unittest import mock
 
 
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
@@ -152,6 +153,52 @@ class ZmqPushChannelTest(unittest.TestCase):
 
 
 class RedisPushChannelTest(unittest.TestCase):
+    def test_connection_failures_reconnect_and_deliver_without_changing_topics(self):
+        for stage in ("pubsub", "subscribe", "get_message"):
+            with self.subTest(stage=stage):
+                redis_client = FakeRedis()
+                failed = FakePubSub(redis_client)
+                replacement = FakePubSub(redis_client)
+                if stage != "pubsub":
+                    setattr(failed, stage, mock.Mock(side_effect=ConnectionError("offline failure")))
+                redis_client.pubsub = mock.Mock(side_effect=[
+                    ConnectionError("offline failure") if stage == "pubsub" else failed, replacement])
+                client = RedisQuotePushChannel(redis_client, account_id="acct")
+                received, done = [], threading.Event()
+
+                def callback(topic, data):
+                    received.append((topic, data))
+                    done.set()
+
+                redis_client.publish(client._channel("SH"), encode_push_payload({"data": {"x": 1}}))
+                client.start_subscriber(["SH"], callback)
+                try:
+                    self.assertTrue(done.wait(3.0), "connection recovered but callbacks did not")
+                    self.assertEqual(redis_client.pubsub.call_count, 2)
+                    self.assertEqual(received, [("SH", {"x": 1})])
+                    if stage != "pubsub":
+                        self.assertTrue(failed._closed)
+                finally:
+                    client.stop()
+                self.assertTrue(replacement._closed)
+
+    def test_stop_during_reconnect_backoff_does_not_open_another_connection(self):
+        redis_client = FakeRedis()
+        failed = FakePubSub(redis_client)
+        failed.get_message = mock.Mock(side_effect=ConnectionError("offline failure"))
+        closed = threading.Event()
+        failed.close = closed.set
+        redis_client.pubsub = mock.Mock(return_value=failed)
+        client = RedisQuotePushChannel(redis_client)
+        client.start_subscriber(["SH"], lambda *_: None)
+        thread = client._thread
+        try:
+            self.assertTrue(closed.wait(2.0))
+        finally:
+            client.stop()
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(redis_client.pubsub.call_count, 1)
+
     def test_pub_sub_roundtrip(self):
         redis_client = FakeRedis()
         server = RedisQuotePushChannel(redis_client, account_id="acct")

--- a/tests/bigqmt_signal_trader/test_quote_session_heartbeat.py
+++ b/tests/bigqmt_signal_trader/test_quote_session_heartbeat.py
@@ -35,6 +35,39 @@ def _session_with_failing_rpc():
 
 
 class ReplayFailureDoesNotKillTheLoopTest(unittest.TestCase):
+    def test_partial_replay_retries_even_while_another_subscription_pushes(self):
+        attempts = {"A": 0, "B": 0}
+        active = set()
+        rounds = [0]
+
+        def rpc(method, params):
+            code = params["sub_id"]
+            if method == "subscribe_whole_quote":
+                attempts[code] += 1
+                if code == "B" and attempts[code] == 1:
+                    raise ConnectionError("B replay temporarily unavailable")
+                active.add(code)
+            if "A" in active:
+                session._on_push("A", {"A": {"lastPrice": 1}})
+            return {}
+
+        session = WholeQuoteClientSession(rpc, None, "offline-test", push_silence_replay_heartbeats=2)
+        session._subscriptions = {code: {"topic": code, "codes": [code], "callback": None} for code in attempts}
+        # A server reset requires replay of both existing subscriptions.
+        with self.assertRaises(ConnectionError):
+            session.replay_subscriptions()
+
+        def fake_sleep(_seconds):
+            rounds[0] += 1
+            if rounds[0] >= 10:
+                session._started = False
+
+        session._started = True
+        with mock.patch("time.sleep", fake_sleep):
+            session._heartbeat_loop()
+        self.assertEqual(active, {"A", "B"})
+        self.assertEqual(attempts, {"A": 2, "B": 2})  # Stop replaying once the batch succeeds.
+
     def test_the_loop_survives_a_failing_replay(self):
         session, calls = _session_with_failing_rpc()
         rounds = [0]

--- a/tests/bigqmt_signal_trader/test_quote_session_heartbeat.py
+++ b/tests/bigqmt_signal_trader/test_quote_session_heartbeat.py
@@ -36,7 +36,7 @@ def _session_with_failing_rpc():
 
 class ReplayFailureDoesNotKillTheLoopTest(unittest.TestCase):
     def test_partial_replay_retries_even_while_another_subscription_pushes(self):
-        attempts = {"A": 0, "B": 0}
+        attempts = {"A": 0, "B": 0, "C": 0}
         active = set()
         rounds = [0]
 
@@ -44,7 +44,7 @@ class ReplayFailureDoesNotKillTheLoopTest(unittest.TestCase):
             code = params["sub_id"]
             if method == "subscribe_whole_quote":
                 attempts[code] += 1
-                if code == "B" and attempts[code] == 1:
+                if code == "B" and rounds[0] < 3:
                     raise ConnectionError("B replay temporarily unavailable")
                 active.add(code)
             if "A" in active:
@@ -53,11 +53,14 @@ class ReplayFailureDoesNotKillTheLoopTest(unittest.TestCase):
 
         session = WholeQuoteClientSession(rpc, None, "offline-test", push_silence_replay_heartbeats=2)
         session._subscriptions = {code: {"topic": code, "codes": [code], "callback": None} for code in attempts}
-        # A server reset requires replay of both existing subscriptions.
+        # A middle subscription stays unavailable; later ones must still recover.
         with self.assertRaises(ConnectionError):
             session.replay_subscriptions()
+        self.assertEqual(active, {"A", "C"})
 
         def fake_sleep(_seconds):
+            if rounds[0] < 3:
+                self.assertEqual(active, {"A", "C"})
             rounds[0] += 1
             if rounds[0] >= 10:
                 session._started = False
@@ -65,8 +68,8 @@ class ReplayFailureDoesNotKillTheLoopTest(unittest.TestCase):
         session._started = True
         with mock.patch("time.sleep", fake_sleep):
             session._heartbeat_loop()
-        self.assertEqual(active, {"A", "B"})
-        self.assertEqual(attempts, {"A": 2, "B": 2})  # Stop replaying once the batch succeeds.
+        self.assertEqual(active, {"A", "B", "C"})
+        self.assertEqual(attempts, {"A": 5, "B": 5, "C": 5})  # Stop replaying once the batch succeeds.
 
     def test_the_loop_survives_a_failing_replay(self):
         session, calls = _session_with_failing_rpc()


### PR DESCRIPTION
## Problem and change

A Redis quote receiver exits permanently after a connection exception while the session heartbeat remains healthy (#256). Separately, a partial subscription replay can leave B silent forever because A resumes pushing and clears the session-wide silence condition (remaining report on #231).

The Redis receiver now owns reconnection: it closes its failed pubsub, waits interruptibly, and recreates the same subscriptions. Each receiver captures its own stop event, so stopping or changing topics cannot revive a blocked old receiver. The heartbeat retains an unfinished replay batch and retries the existing idempotent batch until it succeeds; another subscription's pushes cannot erase that work. Every replay round attempts the entire batch before reporting its first error, so a persistently failing middle subscription cannot starve later healthy subscriptions. No application recovery layer, new transport, configuration option or persistent state is added.

Closes #256. Addresses the remaining partial-replay report at https://github.com/litaolemo/xtquant_big_convert/issues/231#issuecomment-5595613596 (the original heartbeat-exception fix remains intact).

## Validation

- Both injected faults reproduced 10/10 on 0.3.29 and 0.3.30; unchanged probes recover 10/10 each with this change. Receiver replacement is live; B is restored and receives its callback.
- New recovery regressions fail against the original source (pubsub construction, subscribe, get_message and partial replay), then pass after the fix.
- Quote push/session/heartbeat/RPC/client/e2e focused suites after the three-subscription fix: 39 passed, 1 skipped (optional msgpack unavailable), 3 subtests passed (7.98s). Earlier receiver and xtdata contract checks also passed.
- Additional three-subscription regression: A and C are recoverable while middle B fails across multiple rounds; original replay starved C indefinitely. The fix restores A/C on each round, then clears pending and stops replaying when B recovers.
- Independent adversarial checks: blocked old receiver released after topic change does not deliver or revive; stop from callback does not self-join or reconnect; B failing repeatedly under both recovery triggers is retried while A pushes; successful batches stop replaying; removal of failed subscriptions uses the current subscription set.
- Real Redis 7.0.15 / redis-py 8.1.0 isolated Unix-socket check (port=0, persistence disabled): three server shutdown/restart cycles restored actual callbacks on the same receiver thread; normal stop followed by another server restart produced no callbacks or subscribers. All temporary server processes were cleaned up.
- No live QMT or production Redis disruption, broker writes, or live trade-loss claim. These tests establish recovery under the injected schedules, not production failure rates.
