### PR TITLE
fix: 行情重连每秒重试，但不每秒刷日志（#256 跟进）

### DIFF
--- a/src/bigqmt_signal_trader/quote_push_channel.py
+++ b/src/bigqmt_signal_trader/quote_push_channel.py
@@ -18,6 +18,7 @@ channel stays usable without the optional dependency.
 
 import json
 import threading
+import time
 
 try:
     import msgpack
@@ -234,6 +235,8 @@ class RedisQuotePushChannel(QuotePushChannel):
         # This receiver owns reconnect and closes its own connections. Capture
         # its stop event so a later start cannot revive an old blocked receiver.
         channels = [self._channel(topic) for topic in topics]
+        failures = 0          # consecutive reconnect failures, for log throttling
+        last_report = 0.0
         while not stopped.is_set():
             pubsub = None
             try:
@@ -258,7 +261,23 @@ class RedisQuotePushChannel(QuotePushChannel):
                         print("%s subscriber callback failed: %s" % (self.print_prefix, exc))
             except Exception as exc:
                 if not stopped.is_set():
-                    print("%s redis subscriber reconnecting: %s" % (self.print_prefix, exc))
+                    # Retry every second -- quotes should come back fast -- but
+                    # do NOT print every second. Redis down over a weekend is
+                    # 3600 lines/hour, and this repo has been bitten by log
+                    # volume before (#139 wrote one line 16 times; #144 grew a
+                    # log without bound because rotation could never run). The
+                    # zmq ROUTER rebuild backs its reporting off for the same
+                    # reason (#240). Report attempts 1, 2, 4, 8 ... then at most
+                    # once a minute: the first failure stays loud and a long
+                    # outage stays readable.
+                    failures += 1
+                    now = time.time()
+                    if (failures & (failures - 1)) == 0 or now - last_report >= 60.0:
+                        last_report = now
+                        print("%s redis subscriber reconnecting (attempt %d): %s"
+                              % (self.print_prefix, failures, exc))
+            else:
+                failures = 0
             finally:
                 if pubsub is not None:
                     try:

--- a/tests/bigqmt_signal_trader/test_quote_reconnect_log_throttle.py
+++ b/tests/bigqmt_signal_trader/test_quote_reconnect_log_throttle.py
@@ -1,0 +1,91 @@
+# coding: utf-8
+"""Redis 断开时行情接收器每秒重连，但不能每秒刷一行日志（#256 的跟进）。
+
+#257 让接收器自己负责重连，这是对的 —— 在那之前连接一断行情就永久停掉，而
+keepalive 和补订阅还在成功，外部看着一切健康。
+
+但它每次失败都打一行，重试间隔又是固定 1 秒：Redis 掉一个周末就是 17 万行。
+这个仓库为日志量吃过亏 —— #139 把同一行写了 16 次，#144 因为轮转永远失败导致
+日志无上限增长。zmq 的 ROUTER 重建为同样的理由做了退避（#240）。
+
+所以重连速度保持 1 秒（行情要快点回来），只让**报告**退避：第 1、2、4、8…次
+各报一次，之后最多每分钟一次。第一次失败仍然是响的，长时间故障也读得下去。
+"""
+import contextlib
+import io as _io
+import os
+import sys
+import threading
+import time
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.quote_push_channel import RedisQuotePushChannel  # noqa: E402
+
+
+class _DeadPubsub(object):
+    def subscribe(self, *channels):
+        raise ConnectionError("redis unreachable")
+
+    def get_message(self, **kwargs):
+        return None
+
+    def close(self):
+        pass
+
+
+class _DeadRedis(object):
+    def __init__(self):
+        self.connections = 0
+
+    def pubsub(self, **kwargs):
+        self.connections += 1
+        return _DeadPubsub()
+
+
+class ReconnectLogThrottleTest(unittest.TestCase):
+    def _run_outage(self, seconds):
+        redis = _DeadRedis()
+        channel = RedisQuotePushChannel(redis, account_id="t")
+        buffer = _io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            channel.start_subscriber(["x"], lambda topic, data: None)
+            time.sleep(seconds)
+            channel.stop()
+        lines = [l for l in buffer.getvalue().splitlines() if "reconnecting" in l]
+        return redis, lines
+
+    def test_it_keeps_retrying_every_second(self):
+        """退避的是日志，不是重连 —— 行情要尽快回来。"""
+        redis, _ = self._run_outage(4.5)
+        self.assertGreaterEqual(redis.connections, 4,
+                                "重连变慢了：4.5 秒只试了 %d 次" % redis.connections)
+
+    def test_it_does_not_print_once_per_attempt(self):
+        redis, lines = self._run_outage(4.5)
+        self.assertLess(len(lines), redis.connections,
+                        "每次重连都打了一行：%d 次尝试 %d 行" % (redis.connections, len(lines)))
+
+    def test_the_first_failure_is_still_reported(self):
+        """节流不能把第一次失败也吞掉 —— 那就没人知道断了。"""
+        _, lines = self._run_outage(1.5)
+        self.assertTrue(lines, "第一次连接失败一声不吭")
+
+    def test_a_long_outage_stays_readable(self):
+        """按 1、2、4、8… 报告，10 秒内不该超过 5 行。"""
+        _, lines = self._run_outage(10.0)
+        self.assertLessEqual(len(lines), 5,
+                             "10 秒故障打了 %d 行，长时间故障会淹掉日志" % len(lines))
+
+    def test_the_report_says_which_attempt_it_is(self):
+        """跳号报告必须带次数，否则读的人无法判断断了多久。"""
+        _, lines = self._run_outage(3.0)
+        self.assertTrue(any("attempt" in l for l in lines),
+                        "报告里没有尝试次数：%s" % lines[:2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/bigqmt_signal_trader/test_zmq_router_self_heal.py
+++ b/tests/bigqmt_signal_trader/test_zmq_router_self_heal.py
@@ -77,8 +77,12 @@ class RouterSelfHealTest(unittest.TestCase):
         transport._router_session = session
         transport._bind_configured_address = lambda: None
         real_sleep = time.sleep
+        mine = threading.current_thread()
         try:
-            time.sleep = lambda s: slept.append(s)
+            # 只记录本线程的 sleep。这里替换的是**全局** time.sleep，套件里任何
+            # 并发线程在这个窗口调一次，都会挤进 slept 把断言弄红 —— 实际发生过
+            # 一次偶发失败。门禁里的偶发红比没有断言更糟：读的人会学会忽略红。
+            time.sleep = lambda s: slept.append(s) if threading.current_thread() is mine else None
             transport._router_loop()
         finally:
             time.sleep = real_sleep
@@ -100,8 +104,12 @@ class RouterSelfHealTest(unittest.TestCase):
         transport._router_session = session
         transport._bind_configured_address = lambda: None
         real_sleep = time.sleep
+        mine = threading.current_thread()
         try:
-            time.sleep = lambda s: slept.append(s)
+            # 只记录本线程的 sleep。这里替换的是**全局** time.sleep，套件里任何
+            # 并发线程在这个窗口调一次，都会挤进 slept 把断言弄红 —— 实际发生过
+            # 一次偶发失败。门禁里的偶发红比没有断言更糟：读的人会学会忽略红。
+            time.sleep = lambda s: slept.append(s) if threading.current_thread() is mine else None
             transport._router_loop()
         finally:
             time.sleep = real_sleep
@@ -125,8 +133,9 @@ class RouterSelfHealTest(unittest.TestCase):
         transport._router_session = session
         transport._bind_configured_address = rebind
         real_sleep = time.sleep
+        mine = threading.current_thread()
         try:
-            time.sleep = lambda s: None
+            time.sleep = lambda s: None if threading.current_thread() is mine else real_sleep(s)
             transport._router_loop()
         finally:
             time.sleep = real_sleep


### PR DESCRIPTION
#257（@shengyy）的跟进。**它修的问题是真的，而且很严重** —— 我在 main 上跑他的复现脚本 **10/10 复现**:接收线程已死、只建过 1 个 pubsub 连接从不重连、而 `_subscriber_active` 仍报 `True`、keepalive 和补订阅都还在成功。行情永久停掉，外部看着一切健康。和 #240（zmq ROUTER 线程静默死掉）是同一个形状。

合并前我验过：修复后复现 **0/10**、新增 2 条测试改前红、全量 1889 通过、实盘对比 main 无回归。

这个 PR 收一个尾。

## 每秒重试，也每秒打一行

`_sub_loop` 的重连间隔是固定 1 秒，每次失败打一行。实测 Redis 持续不可用：

| | 日志量 |
|---|---|
| 改前 | 60 行/分钟 = **3600 行/小时** |
| 改后 | 10 秒内 ≤ 5 行 |

这个仓库为日志量吃过亏 —— #139 把同一行写了 16 次（还有同一条 `ping breakdown` 373 次），#144 因为两个进程持有同一文件句柄导致轮转永远失败、日志无上限增长。我修 #240 时给 zmq 的 ROUTER 重建加了指数退避，理由正是「端口被占时不能刷屏」，这里漏了。

**重连速度不变**（行情要尽快回来，1 秒是对的），退避的只是**报告**：第 1、2、4、8… 次各报一次，之后最多每分钟一次，并带上尝试次数——跳号报告不带次数的话，读的人无法判断断了多久。

## 顺带修一个我自己留下的偶发

`test_zmq_router_self_heal` 的退避用例替换的是**全局** `time.sleep`，套件里任何并发线程在那个窗口调一次，都会挤进 `slept` 把 `assertEqual(slept[:3], [1.0, 2.0, 4.0])` 弄红。加了这个文件之后全量偶发红了一次（单独跑绿、两文件一起跑绿、两次重跑全量也绿）。改成只记录本线程的 sleep。

门禁里的偶发红比没有断言更糟：读的人会学会忽略红，而这个仓库的规矩是「不过门禁不合、不发版」。

## 验证

- 新增 `test_quote_reconnect_log_throttle.py`（5 条），**改前 3 条红**
- #256 的复现脚本仍是 **0/10**（没有破坏 #257 的修复）
- 全量 **1894 通过**，147/147 模块收集；连续两次全量绿
- 用终端自带 `xtquant`（91 名）预检导入服务端全模块通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
