### PR TITLE
fix: DRYRUN 可指定配置模块，多账号文档补全 (#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,52 @@
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/) 和 [语义化版本](https://semver.org/)。
 
 
+## [未发布]
+
+### 修复
+
+- **README 里的多账号用法并不存在：入口没有办法指定读哪份配置**（#261，@RuralHunter
+  报告）。「多账号使用」一节从写下起就说「在 QMT 策略编辑器里加载两个 DRYRUN 文件
+  （每个指向不同的配置）」，但配置模块名在三处写死 —— `BIGQMT_REDIS_DRYRUN.py` 的
+  `_load_local_config()`、runtime 的 `from bigqmt_signal_trader_local_config import
+  BIGQMT_ACCOUNT_ID, ...`、strategy `_detect_account_id()` 里的那次 reload ——
+  所以第二份入口副本读到的是**第一个账号**的配置：两个实例绑同一个账号，而两边都
+  正常启动、没有任何报错。文档描述的功能不存在。
+
+  入口现在认一个全局 `BIGQMT_LOCAL_CONFIG_MODULE`（和 `BIGQMT_FORCE_TRANSPORT`
+  同一种形状 —— QMT 会 exec 入口文件，所以文件里的全局就是旋钮）：
+
+  ```python
+  # BIGQMT_REDIS_DRYRUN_CREDIT.py 顶部
+  BIGQMT_LOCAL_CONFIG_MODULE = "bigqmt_signal_trader_local_config_credit"
+  ```
+
+  指定的文件**以标准名 `bigqmt_signal_trader_local_config` 装载**，因此上面另外两处
+  写死的 import 一个字都不用改，四条 reload 路径也照常工作：`_local_import` /
+  `importlib.import_module`、`_detect_account_id()` 的 `importlib.reload`、
+  `reload_deployment()` 的清模块（它清的是 `bigqmt_signal_trader[.*]`，不含这个名字）、
+  以及下一次入口运行的 `_clear_local_modules()`（清干净，所以两次运行之间可以换配置）。
+  四条都有单测。不写这一行就是原来的行为，单账号部署一个字不用改。
+
+  指定的模块**找不到时入口直接报错停机**并列出找过的目录，不会退回默认配置 ——
+  那是另一个账号的配置，用错账号下单比起不来严重得多。启动行加了 `module=`
+  （`[bigqmt_shell] local rpc config loaded module=... transport=... keys=...`），
+  这是「那一行没生效」唯一能看出来的地方：没生效时一切照常启动，只是这一路悄悄跑在了
+  另一个账号上。
+
+  `bigqmt_no_redis/DRYRUN_no_redis.py`（手工维护的副本，会静默漂移）同步加了同一个开关。
+
+  **未在双账号实盘环境复跑过**：维护者手上只有一个账号，双实例同时跑需要第二个可用账号。
+
+### 文档
+
+- README「多账号使用（股票+期货 / 普通+信用）」重写成能照着做的步骤：两份配置文件
+  （差异是 `BIGQMT_ACCOUNT_ID` 与 `BIGQMT_ACCOUNT_TYPE`）、两份入口副本各加一行、
+  怎么从启动行确认每个实例读对了配置、zmq 端口末两位撞车怎么办、单文件版为什么不需要
+  这个开关、以及 `sync_deployment()` 不会更新你另存的入口副本。
+  `docs/DEPLOY_QUICKSTART.md` 增加「再加一个账号」小节指过去。
+
+
 ## [0.3.31] - 2026-09-09
 
 行情推送的自愈。由 @shengyy 报告并提交修复（#256 / #257），本仓收尾（#258）。

--- a/README.md
+++ b/README.md
@@ -831,35 +831,70 @@ xtdata.get_local_data(["close"], ["600654.SH"], period="1d",
 
 ### 多账号使用（股票+期货 / 普通+信用）
 
-当前架构是**单账号单实例**——一个 QMT 策略进程绑定一个账号，RPC channel 按 `account_id` 隔离（`bigqmt:rpc:req:{account_id}`）。多账号场景（如股票+期货、普通+信用账户同时交易）的推荐方案是**在 QMT 里跑多个策略实例**，每个实例绑一个账号。
+当前架构是**单账号单实例**——一个 QMT 策略实例绑一个账号，RPC channel 按 `account_id` 隔离（`bigqmt:rpc:req:{account_id}`）。多账号（股票+期货、普通+信用同时交易）的做法是**在 QMT 里加载多个策略实例，每个实例读自己的那份配置**。
 
-#### 方案：多策略实例（推荐，不改代码）
+#### 服务端（QMT 内）：三步
 
-**服务端（QMT 内）**：为每个账号创建一个独立的配置文件和 DRYRUN 入口。
+**第 1 步：每个账号一份配置文件。** 都放在 QMT 的 `python` 目录，都不进 git。两份之间必须不同的是账号和账号类型：
 
 ```python
-# bigqmt_signal_trader_local_config_stock.py  — 股票账号
+# bigqmt_signal_trader_local_config_stock.py  —— 股票（普通）账号
 BIGQMT_ACCOUNT_ID = "你的股票账号"
+BIGQMT_ACCOUNT_TYPE = "STOCK"
 BIGQMT_REDIS_CONFIG = {
     "host": "...", "port": 6379, "db": 5, "password": "...",
     "transport": "redis",          # 或 "zmq"
-    "account_type": "STOCK",       # 股票
-    # ...
-}
-
-# bigqmt_signal_trader_local_config_credit.py  — 信用账号
-BIGQMT_ACCOUNT_ID = "你的信用账号"
-BIGQMT_REDIS_CONFIG = {
-    "host": "...", "port": 6379, "db": 5, "password": "...",
-    "transport": "redis",
-    "account_type": "CREDIT",      # 信用（两融）
-    # ...
+    # 其余键照抄 src/bigqmt_signal_trader_local_config.example.py
 }
 ```
 
-然后在 QMT 策略编辑器里加载两个 DRYRUN 文件（每个指向不同的配置），分别运行。两个实例的 RPC channel 自动隔离（按 account_id）。
+```python
+# bigqmt_signal_trader_local_config_credit.py  —— 信用（两融）账号
+BIGQMT_ACCOUNT_ID = "你的信用账号"
+BIGQMT_ACCOUNT_TYPE = "CREDIT"     # 别漏：信用账户按 STOCK 查不会报错，
+                                   # 只会返回一行全 0 的资产（issue #92）
+BIGQMT_REDIS_CONFIG = {
+    "host": "...", "port": 6379, "db": 5, "password": "...",
+    "transport": "redis",
+    "account_type": "CREDIT",      # 与 BIGQMT_ACCOUNT_TYPE 二选一即可，两处都认
+}
+```
 
-> **zmq 模式注意**：每个实例的 zmq 端口从 account_id 派生（`15560 + account_id mod 100`），不同账号自动不冲突。
+两份都改名之后就不必再留 `bigqmt_signal_trader_local_config.py` 了 —— 但那样**每个入口副本都必须带下面第 2 步那一行**：没带的入口会去读默认配置，读不到时面板打 `local rpc config load failed`，账号只能靠 QMT 注入的全局兜底（多半是空的）。想省事也可以让其中一个账号继续用默认名，另一个用改名的那份。
+
+**第 2 步：每个账号一份入口副本，各加一行。** 把 `BIGQMT_REDIS_DRYRUN.py`（纯 ZMQ 部署则是 `BIGQMT_ZMQ_DRYRUN.py`）另存一份，在文件顶部加**一行**指明它读哪个配置模块：
+
+```python
+# BIGQMT_REDIS_DRYRUN_CREDIT.py —— 信用账号的入口副本，文件顶部加这一行
+BIGQMT_LOCAL_CONFIG_MODULE = "bigqmt_signal_trader_local_config_credit"
+```
+
+- 写**模块名**，不带 `.py`、不带路径（写成 `..._credit.py` 也认，写路径会直接报错）。
+- 入口会把这个文件**以标准名 `bigqmt_signal_trader_local_config` 装载**——runtime 和 strategy 里那两处写死的 `import` 因此不用改，`_detect_account_id()` 的 `importlib.reload`、`xt_trader.reload_deployment()` 的清模块之后，读到的仍然是这一份。
+- **不加这一行**就是读默认的 `bigqmt_signal_trader_local_config.py`：单账号部署一个字都不用改。
+- 指定的模块**找不到时入口直接报错停机**，并列出找过的目录。它不会退回默认配置——那是另一个账号的配置，用错账号下单比起不来严重得多。
+- 另存的入口文件名随意（`BIGQMT_REDIS_DRYRUN_CREDIT.py` 只是举例），QMT 认的是你加载的那个文件。
+- **升级时记得重拷副本**：`xt_trader.sync_deployment()` 只刷新部署里已有的同名文件，你另存的入口副本它不认识、也就不会更新。升级后从新版 `BIGQMT_REDIS_DRYRUN.py` 重新另存一份，再把那一行加回去。
+
+**第 3 步：两份入口都加进 QMT 的模型交易，分别运行。** 两个实例的 RPC channel 按 `account_id` 自动隔离。
+
+#### 怎么确认每个实例读对了配置
+
+看 QMT 输出面板的启动行，`module=` 就是这个实例真正读到的配置模块：
+
+```
+[bigqmt_shell] local config module=bigqmt_signal_trader_local_config_credit file=D:\...\python\bigqmt_signal_trader_local_config_credit.py
+[bigqmt_shell] local rpc config loaded module=bigqmt_signal_trader_local_config_credit transport=redis keys=[...]
+[bigqmt_rpc] started channel=bigqmt:rpc:req:你的信用账号
+```
+
+`module=` 是唯一能看出「那一行没生效」的地方：没生效时它显示的是标准名 `bigqmt_signal_trader_local_config`，而其余一切照常启动——这一路只是悄悄跑在了另一个账号上。channel 末尾的账号也要和你预期的对上。
+
+> **zmq 模式注意**：每个实例的 zmq 端口从 account_id 派生（`15560 + 账号数字 mod 100`），不同账号一般不冲突；但两个账号的数字末两位相同就会撞端口。显式指定即可：在该账号的 `BIGQMT_REDIS_CONFIG` 里写 `"zmq": {"port": 15571}`。
+
+> **单文件版不用这个开关**：`build_single_file.py` / `build_no_redis_single_file_flat.py` 的产物把配置内嵌在文件顶部的 config block 里，本来就是一份文件一个账号——生成两份、各改各的 config block 即可。
+
+> 机制本身有单测覆盖（`tests/bigqmt_signal_trader/test_multi_account_config_module.py`，含 reload 后仍然生效），但**维护者手上只有一个账号，双实例同时跑没有实盘复跑过**。跑起来了欢迎把上面那三行启动日志贴到 issue 里。
 
 **客户端（外部程序）**：为每个账号创建独立的 client/trader 对象。
 

--- a/bigqmt_no_redis/DRYRUN_no_redis.py
+++ b/bigqmt_no_redis/DRYRUN_no_redis.py
@@ -32,6 +32,18 @@ _LOCAL_ROOTS = (
     "bigqmt_signal_trader_local_config",
     "bigqmt_no_redis",
 )
+# Multi-account (#261): copy this entry per account and add ONE line near the
+# top of the copy --
+#
+#     BIGQMT_LOCAL_CONFIG_MODULE = "bigqmt_signal_trader_local_config_credit"
+#
+# -- and the named file is loaded UNDER the canonical name below, which the
+# runtime imports literally and the strategy importlib.reloads. Never assign
+# that global in this file: an entry that execs this source into its own
+# globals would have its value overwritten.
+_CANONICAL_LOCAL_CONFIG = "bigqmt_signal_trader_local_config"
+# name -> source path, for a module loaded from a file not named after it.
+_LOCAL_MODULE_SOURCE_OVERRIDES = {}
 _ORIGINAL_IMPORT = _builtins.__import__
 _ORIGINAL_IMPORT_MODULE = _importlib.import_module
 _ORIGINAL_RELOAD = _importlib.reload
@@ -71,15 +83,22 @@ def _resolve_name(name, module_globals, level):
     return package + ("." + name if name else "")
 
 
-def _find_local_source(name):
-    relative = name.replace(".", os.sep)
+def _local_source_dirs():
     dirs = []
     if _SOURCE_ROOT:
         dirs.append(_SOURCE_ROOT)
     for p in sys.path:
         if p and os.path.isdir(p) and p not in dirs:
             dirs.append(p)
-    for d in dirs:
+    return dirs
+
+
+def _find_local_source(name):
+    override = _LOCAL_MODULE_SOURCE_OVERRIDES.get(name)
+    if override:
+        return override, False
+    relative = name.replace(".", os.sep)
+    for d in _local_source_dirs():
         package_init = os.path.join(d, relative, "__init__.py")
         if os.path.isfile(package_init):
             return package_init, True
@@ -174,11 +193,56 @@ def _stop_previous_rpc_service():
         print("[bigqmt_shell] previous rpc service stop failed: %s" % exc)
 
 
+def _resolve_local_config_module():
+    """Point the canonical config name at whichever module this entry names.
+
+    Returns the module name that will actually be read. Must run after
+    _clear_local_modules() (so the next load reads the chosen file) and before
+    anything imports the config -- the runtime imports it at module load.
+    """
+    chosen = str(globals().get("BIGQMT_LOCAL_CONFIG_MODULE") or "").strip()
+    if chosen.endswith(".py"):
+        # A module name is what is wanted, but "...config_credit.py" is the
+        # obvious slip and its intent is not ambiguous.
+        chosen = chosen[:-3]
+    _LOCAL_MODULE_SOURCE_OVERRIDES.pop(_CANONICAL_LOCAL_CONFIG, None)
+    if not chosen or chosen == _CANONICAL_LOCAL_CONFIG:
+        return _CANONICAL_LOCAL_CONFIG
+    if os.sep in chosen or "/" in chosen or "." in chosen:
+        raise RuntimeError(
+            "BIGQMT_LOCAL_CONFIG_MODULE must be a module name, not a path: %r. "
+            "Put the config file in the QMT python directory beside this entry "
+            "and name the module, e.g. BIGQMT_LOCAL_CONFIG_MODULE = "
+            "\"bigqmt_signal_trader_local_config_credit\"." % chosen)
+    try:
+        source_path, unused_is_package = _find_local_source(chosen)
+    except ImportError:
+        # Falling back to the default config would start this instance on
+        # ANOTHER account -- the one failure mode worse than not starting.
+        raise RuntimeError(
+            "BIGQMT_LOCAL_CONFIG_MODULE = %r, but %s.py was not found. Looked "
+            "in: %s. Create that file (copy "
+            "bigqmt_signal_trader_local_config.example.py, set its "
+            "BIGQMT_ACCOUNT_ID / BIGQMT_ACCOUNT_TYPE) into the QMT python "
+            "directory. Not falling back to %s.py: that is the other account's "
+            "config, and trading the wrong account is worse than not starting."
+            % (chosen, chosen,
+               ", ".join(_local_source_dirs()) or "(no directories)",
+               _CANONICAL_LOCAL_CONFIG))
+    _LOCAL_MODULE_SOURCE_OVERRIDES[_CANONICAL_LOCAL_CONFIG] = source_path
+    return chosen
+
+
 _stop_previous_rpc_service()
 _clear_local_modules()
 _importlib.import_module = _local_import_module
 _importlib.reload = _local_reload
 print("[bigqmt_shell] importlib entry source_root=%s" % _SOURCE_ROOT)
+_LOCAL_CONFIG_MODULE = _resolve_local_config_module()
+if _LOCAL_CONFIG_MODULE != _CANONICAL_LOCAL_CONFIG:
+    print("[bigqmt_shell] local config module=%s file=%s" % (
+        _LOCAL_CONFIG_MODULE,
+        _LOCAL_MODULE_SOURCE_OVERRIDES.get(_CANONICAL_LOCAL_CONFIG, "")))
 
 
 def _fallback_account_id():
@@ -202,7 +266,9 @@ _runtime = _local_import("bigqmt_signal_trader_redis_rpc_runtime", globals(), fr
 
 
 def _load_local_config():
-    return _local_import("bigqmt_signal_trader_local_config", globals(), fromlist=("*",))
+    # Always the canonical name: _resolve_local_config_module has already
+    # pointed it at whichever file this entry names.
+    return _local_import(_CANONICAL_LOCAL_CONFIG, globals(), fromlist=("*",))
 
 
 try:
@@ -219,8 +285,8 @@ try:
     # file exists because the machine cannot import redis at all, so there is
     # nothing to weigh up here.
     BIGQMT_REDIS_CONFIG["redis_enabled"] = False
-    print("[bigqmt_shell] no-redis mode: transport=zmq background_threads=True "
-          "redis_enabled=False")
+    print("[bigqmt_shell] no-redis mode: module=%s transport=zmq "
+          "background_threads=True redis_enabled=False" % _LOCAL_CONFIG_MODULE)
     _runtime.configure_runtime_redis(BIGQMT_REDIS_CONFIG)
 except Exception as redis_config_error:
     print("[bigqmt_shell] local redis config load failed: %s" % redis_config_error)

--- a/docs/DEPLOY_QUICKSTART.md
+++ b/docs/DEPLOY_QUICKSTART.md
@@ -1,6 +1,6 @@
 # 部署快速开始（单账号）
 
-> 面向第一次部署的最短路径。完整安装、传输层对比、多账号、无 redis 版本等见 [README](../README.md) 的「环境要求与依赖安装」「快速开始」章节；排错见 README「日志与排错」。
+> 面向第一次部署的最短路径。完整安装、传输层对比、无 redis 版本等见 [README](../README.md) 的「环境要求与依赖安装」「快速开始」章节；同一台 QMT 上跑第二个账号见 README「多账号使用（股票+期货 / 普通+信用）」；排错见 README「日志与排错」。
 
 ## 前提
 
@@ -102,5 +102,15 @@ xt_trader.reload_status()            # -> {'ok': True, 'modules_purged': 28,
 约 0.8 秒，期间约 1 秒的查询会超时（服务正在重建）。
 
 **但改这两个文件仍然要重启策略**：`bigqmt_signal_trader_strategy.py`、`BIGQMT_REDIS_DRYRUN.py` —— QMT 自己 exec 它们，模块没法 reload 自己所在的模块。
+
+## 再加一个账号
+
+同一台 QMT 上跑第二个账号（股票+信用、股票+期货）：每个账号一份配置文件，再从 `BIGQMT_REDIS_DRYRUN.py` 另存一份入口副本，副本里加一行说明它读哪份配置：
+
+```python
+BIGQMT_LOCAL_CONFIG_MODULE = "bigqmt_signal_trader_local_config_credit"
+```
+
+两份入口分别加载运行即可。完整步骤和「怎么确认读对了配置」见 README「多账号使用（股票+期货 / 普通+信用）」。
 
 更细的排错（日志位置、日志保留策略、启动诊断字段）见 README「日志与排错」。

--- a/src/BIGQMT_REDIS_DRYRUN.py
+++ b/src/BIGQMT_REDIS_DRYRUN.py
@@ -41,6 +41,30 @@ _LOCAL_ROOTS = (
     "bigqmt_signal_trader_redis_rpc_runtime",
     "bigqmt_signal_trader_local_config",
 )
+# The config module name the runtime and the strategy import literally --
+# bigqmt_signal_trader_redis_rpc_runtime does `from
+# bigqmt_signal_trader_local_config import BIGQMT_ACCOUNT_ID, ...` at import
+# time, and the strategy importlib.reloads that same name in
+# _detect_account_id. Neither takes a parameter, so a second account cannot be
+# expressed by pointing them somewhere else (#261).
+_CANONICAL_LOCAL_CONFIG = "bigqmt_signal_trader_local_config"
+# Multi-account: copy this entry per account and add ONE line near the top of
+# the copy (see the multi-account section of the README):
+#
+#     BIGQMT_LOCAL_CONFIG_MODULE = "bigqmt_signal_trader_local_config_credit"
+#
+# The named file is then loaded UNDER the canonical name, so both import sites
+# above stay untouched and every reload path (importlib.reload in
+# _detect_account_id, reload_deployment's package purge, _clear_local_modules
+# on the next entry run) keeps working exactly as it does with one account.
+#
+# Do NOT assign BIGQMT_LOCAL_CONFIG_MODULE in this file. BIGQMT_ZMQ_DRYRUN.py
+# execs this source into its OWN globals, so a default assignment here would
+# overwrite whatever a copy of that wrapper set -- which is why
+# BIGQMT_FORCE_TRANSPORT is only ever read with globals().get() too.
+#
+# name -> source path, for a module loaded from a file not named after it.
+_LOCAL_MODULE_SOURCE_OVERRIDES = {}
 _ORIGINAL_IMPORT = _builtins.__import__
 _ORIGINAL_IMPORT_MODULE = _importlib.import_module
 _ORIGINAL_RELOAD = _importlib.reload
@@ -81,15 +105,22 @@ def _resolve_name(name, module_globals, level):
     return package + ("." + name if name else "")
 
 
-def _find_local_source(name):
-    relative = name.replace(".", os.sep)
+def _local_source_dirs():
     dirs = []
     if _SOURCE_ROOT:
         dirs.append(_SOURCE_ROOT)
     for p in sys.path:
         if p and os.path.isdir(p) and p not in dirs:
             dirs.append(p)
-    for d in dirs:
+    return dirs
+
+
+def _find_local_source(name):
+    override = _LOCAL_MODULE_SOURCE_OVERRIDES.get(name)
+    if override:
+        return override, False
+    relative = name.replace(".", os.sep)
+    for d in _local_source_dirs():
         package_init = os.path.join(d, relative, "__init__.py")
         if os.path.isfile(package_init):
             return package_init, True
@@ -257,11 +288,56 @@ def _stop_previous_rpc_service():
         print("[bigqmt_shell] previous rpc service stop failed: %s" % exc)
 
 
+def _resolve_local_config_module():
+    """Point the canonical config name at whichever module this entry names.
+
+    Returns the module name that will actually be read. Must run after
+    _clear_local_modules() (so the next load reads the chosen file) and before
+    anything imports the config -- the runtime imports it at module load.
+    """
+    chosen = str(globals().get("BIGQMT_LOCAL_CONFIG_MODULE") or "").strip()
+    if chosen.endswith(".py"):
+        # A module name is what is wanted, but "...config_credit.py" is the
+        # obvious slip and its intent is not ambiguous.
+        chosen = chosen[:-3]
+    _LOCAL_MODULE_SOURCE_OVERRIDES.pop(_CANONICAL_LOCAL_CONFIG, None)
+    if not chosen or chosen == _CANONICAL_LOCAL_CONFIG:
+        return _CANONICAL_LOCAL_CONFIG
+    if os.sep in chosen or "/" in chosen or "." in chosen:
+        raise RuntimeError(
+            "BIGQMT_LOCAL_CONFIG_MODULE must be a module name, not a path: %r. "
+            "Put the config file in the QMT python directory beside this entry "
+            "and name the module, e.g. BIGQMT_LOCAL_CONFIG_MODULE = "
+            "\"bigqmt_signal_trader_local_config_credit\"." % chosen)
+    try:
+        source_path, unused_is_package = _find_local_source(chosen)
+    except ImportError:
+        # Falling back to the default config would start this instance on
+        # ANOTHER account -- the one failure mode worse than not starting.
+        raise RuntimeError(
+            "BIGQMT_LOCAL_CONFIG_MODULE = %r, but %s.py was not found. Looked "
+            "in: %s. Create that file (copy "
+            "bigqmt_signal_trader_local_config.example.py, set its "
+            "BIGQMT_ACCOUNT_ID / BIGQMT_ACCOUNT_TYPE) into the QMT python "
+            "directory. Not falling back to %s.py: that is the other account's "
+            "config, and trading the wrong account is worse than not starting."
+            % (chosen, chosen,
+               ", ".join(_local_source_dirs()) or "(no directories)",
+               _CANONICAL_LOCAL_CONFIG))
+    _LOCAL_MODULE_SOURCE_OVERRIDES[_CANONICAL_LOCAL_CONFIG] = source_path
+    return chosen
+
+
 _stop_previous_rpc_service()
 _clear_local_modules()
 _importlib.import_module = _local_import_module
 _importlib.reload = _local_reload
 print("[bigqmt_shell] importlib entry source_root=%s" % _SOURCE_ROOT)
+_LOCAL_CONFIG_MODULE = _resolve_local_config_module()
+if _LOCAL_CONFIG_MODULE != _CANONICAL_LOCAL_CONFIG:
+    print("[bigqmt_shell] local config module=%s file=%s" % (
+        _LOCAL_CONFIG_MODULE,
+        _LOCAL_MODULE_SOURCE_OVERRIDES.get(_CANONICAL_LOCAL_CONFIG, "")))
 
 
 def _fallback_account_id():
@@ -284,7 +360,10 @@ _runtime = _local_import("bigqmt_signal_trader_redis_rpc_runtime", globals(), fr
 
 
 def _load_local_config():
-    return _local_import("bigqmt_signal_trader_local_config", globals(), fromlist=("*",))
+    # Always the canonical name: _resolve_local_config_module has already
+    # pointed it at whichever file this entry names, so the runtime and the
+    # strategy read the same module object this returns.
+    return _local_import(_CANONICAL_LOCAL_CONFIG, globals(), fromlist=("*",))
 
 
 try:
@@ -310,7 +389,12 @@ try:
             # configured/default switch so MiniQMT-compatible order and trade
             # callbacks keep working without Redis.
             BIGQMT_REDIS_CONFIG["full_tick_cache_enabled"] = False
-    print("[bigqmt_shell] local rpc config loaded transport=%s keys=%s" % (
+    # module= names the file this instance actually read. With two accounts in
+    # two QMT strategies the only way to tell them apart at startup is this
+    # line; a copy whose BIGQMT_LOCAL_CONFIG_MODULE never took effect reads as
+    # the canonical name here instead of failing anywhere.
+    print("[bigqmt_shell] local rpc config loaded module=%s transport=%s keys=%s" % (
+        _LOCAL_CONFIG_MODULE,
         (BIGQMT_REDIS_CONFIG or {}).get("transport", "redis"),
         sorted((BIGQMT_REDIS_CONFIG or {}).keys()),
     ))

--- a/tests/bigqmt_signal_trader/test_multi_account_config_module.py
+++ b/tests/bigqmt_signal_trader/test_multi_account_config_module.py
@@ -1,0 +1,361 @@
+# coding: utf-8
+"""One QMT terminal, two accounts: each entry must be able to name its config
+module (#261).
+
+The README has told people to "load two DRYRUN files, each pointing at a
+different config" since the multi-account section was written. Nothing pointed
+anywhere: the config module name was hardcoded in three places --
+
+    BIGQMT_REDIS_DRYRUN.py            _load_local_config()
+    bigqmt_signal_trader_redis_rpc_runtime.py
+                                      from bigqmt_signal_trader_local_config
+                                      import BIGQMT_ACCOUNT_ID, ...
+    bigqmt_signal_trader_strategy.py  _detect_account_id's importlib.reload
+
+-- so a second copy of the entry read the first account's config and the two
+instances traded the same account. The documented feature did not exist.
+
+The mechanism: the entry resolves BIGQMT_LOCAL_CONFIG_MODULE (a global in the
+entry file, the same shape as BIGQMT_FORCE_TRANSPORT) to a source path and
+loads that file UNDER the canonical name. The other two sites keep importing
+"bigqmt_signal_trader_local_config" literally, which is what makes every
+reload path keep working:
+
+    (a) _local_import / _local_import_module for the canonical name
+    (b) importlib.reload(_local_config) in _detect_account_id
+    (c) reload_deployment's _purge_package_modules
+    (d) _clear_local_modules() at the next entry run
+
+all four are pinned below.
+
+Entry files are exec'd by QMT with its own globals, so the loader half of the
+source is exec'd here on its own -- the same technique test_corrupt_source_
+message.py uses -- and stops short of the QMT-only bottom half.
+"""
+
+import io
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SRC = os.path.join(ROOT, "src")
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)
+
+ENTRY = os.path.join(SRC, "BIGQMT_REDIS_DRYRUN.py")
+NO_REDIS_ENTRY = os.path.join(ROOT, "bigqmt_no_redis", "DRYRUN_no_redis.py")
+CANONICAL = "bigqmt_signal_trader_local_config"
+CREDIT = "bigqmt_signal_trader_local_config_credit"
+RUNTIME = "bigqmt_signal_trader_redis_rpc_runtime"
+
+# The stub stands in for the real runtime module while the loader is under
+# test: same import lines, nothing else. Its point is that the two lines the
+# runtime really uses are exercised through the real _local_import.
+RUNTIME_STUB = (
+    "from bigqmt_signal_trader_local_config import "
+    "BIGQMT_ACCOUNT_ID, BIGQMT_REDIS_CONFIG\n"
+    "from bigqmt_signal_trader_local_config import BIGQMT_ACCOUNT_TYPE\n"
+    "ACCOUNT_ID = BIGQMT_ACCOUNT_ID\n"
+    "ACCOUNT_TYPE = BIGQMT_ACCOUNT_TYPE\n"
+)
+
+CONFIG_TEMPLATE = (
+    "# coding: utf-8\n"
+    "BIGQMT_ACCOUNT_ID = %r\n"
+    "BIGQMT_ACCOUNT_TYPE = %r\n"
+    "BIGQMT_REDIS_CONFIG = {'transport': 'zmq', 'account_type': %r}\n"
+)
+
+
+LOCAL_ROOTS = (
+    "bigqmt_signal_trader",
+    "bigqmt_signal_trader_strategy",
+    RUNTIME,
+    CANONICAL,
+)
+
+
+def _local_module_names():
+    return [name for name in list(sys.modules)
+            if any(name == root or name.startswith(root + ".")
+                   for root in LOCAL_ROOTS)]
+
+
+def _entry_source(path):
+    with io.open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _loader_namespace(path):
+    """Exec the loader half of an entry file, stopping before the QMT half.
+
+    Everything below ``_stop_previous_rpc_service()`` touches the live process
+    (sys.modules, importlib, the RPC service), so the cut is exactly there.
+    """
+    source = _entry_source(path)
+    prefix = source[:source.index("\n_stop_previous_rpc_service()\n")]
+    namespace = {"__file__": path, "__name__": "bigqmt_entry_under_test"}
+    exec(compile(prefix, path, "exec"), namespace)
+    return namespace
+
+
+class _LoaderCase(unittest.TestCase):
+    ENTRY_PATH = ENTRY
+
+    STOCK_ACCOUNT = "1000000011"
+    CREDIT_ACCOUNT = "2000000022"
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="bigqmt261-")
+        self._write(CANONICAL + ".py",
+                    CONFIG_TEMPLATE % (self.STOCK_ACCOUNT, "STOCK", "STOCK"))
+        self._write(CREDIT + ".py",
+                    CONFIG_TEMPLATE % (self.CREDIT_ACCOUNT, "CREDIT", "CREDIT"))
+        self._write(RUNTIME + ".py", RUNTIME_STUB)
+        # Put sys.modules back exactly afterwards. Two of the loader entry
+        # points under test clear the shared import cache -- _clear_local_
+        # modules() drops the whole package, _purge_package_modules() drops
+        # bigqmt_signal_trader.* -- and a test that does that without
+        # restoring breaks whatever runs after it: modules already holding
+        # references get objects the fresh import no longer produces. The same
+        # omission cost 15 failures in test_transports.py /
+        # test_xtquant_compat.py while this file was being written, and is why
+        # test_reload_deployment.py has RestoresImports.
+        self._saved_modules = dict(
+            (name, sys.modules[name]) for name in _local_module_names())
+        # A real runtime already imported by an earlier test would be returned
+        # as-is by the loader, so the stub below would never run.
+        for name in (CANONICAL, CREDIT, RUNTIME):
+            sys.modules.pop(name, None)
+        self.ns = _loader_namespace(self.ENTRY_PATH)
+        # The fixture directory stands in for the QMT python directory.
+        self.ns["_SOURCE_ROOT"] = self.tmpdir
+
+    def tearDown(self):
+        for name in _local_module_names():
+            sys.modules.pop(name, None)
+        sys.modules.update(self._saved_modules)
+        strategy = sys.modules.get("bigqmt_signal_trader_strategy")
+        if strategy is not None:
+            strategy._rebind_module_level_imports()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _write(self, name, text):
+        path = os.path.join(self.tmpdir, name)
+        with io.open(path, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        return path
+
+    def _resolve(self, chosen=None):
+        if chosen is not None:
+            self.ns["BIGQMT_LOCAL_CONFIG_MODULE"] = chosen
+        return self.ns["_resolve_local_config_module"]()
+
+    def _import_config(self):
+        return self.ns["_local_import"](CANONICAL, self.ns, None, ("*",), 0)
+
+
+class ResolutionTest(_LoaderCase):
+    def test_the_default_still_reads_the_canonical_module(self):
+        """No global set: one-account deployments must not change at all."""
+        self.assertEqual(self._resolve(), CANONICAL)
+
+        config = self._import_config()
+
+        self.assertEqual(config.BIGQMT_ACCOUNT_ID, self.STOCK_ACCOUNT)
+        self.assertEqual(config.__file__,
+                         os.path.join(self.tmpdir, CANONICAL + ".py"))
+
+    def test_the_named_module_is_read_instead(self):
+        self.assertEqual(self._resolve(CREDIT), CREDIT)
+
+        config = self._import_config()
+
+        self.assertEqual(config.BIGQMT_ACCOUNT_ID, self.CREDIT_ACCOUNT)
+        self.assertEqual(config.BIGQMT_ACCOUNT_TYPE, "CREDIT")
+
+    def test_it_is_registered_under_the_canonical_name(self):
+        """The whole point: the runtime and the strategy import that name
+        literally, so the alias -- not a second module -- is what they get."""
+        self._resolve(CREDIT)
+
+        config = self._import_config()
+
+        self.assertEqual(config.__name__, CANONICAL)
+        self.assertIs(sys.modules[CANONICAL], config)
+        self.assertEqual(config.__file__,
+                         os.path.join(self.tmpdir, CREDIT + ".py"))
+
+    def test_an_empty_value_means_the_default(self):
+        for value in ("", "   ", None):
+            self.assertEqual(self._resolve(value), CANONICAL, repr(value))
+
+    def test_naming_the_canonical_module_is_not_special_cased_into_a_miss(self):
+        self.assertEqual(self._resolve(CANONICAL), CANONICAL)
+
+        self.assertEqual(self._import_config().BIGQMT_ACCOUNT_ID,
+                         self.STOCK_ACCOUNT)
+
+    def test_a_py_suffix_is_tolerated(self):
+        """"...config_credit.py" is the obvious slip and its intent is not
+        ambiguous -- failing on it would only cost a restart."""
+        self.assertEqual(self._resolve(CREDIT + ".py"), CREDIT)
+
+        self.assertEqual(self._import_config().BIGQMT_ACCOUNT_ID,
+                         self.CREDIT_ACCOUNT)
+
+
+class ImportSitesTest(_LoaderCase):
+    """(a) Both sites that import the name by hand get the chosen file."""
+
+    def test_the_runtime_import_line_sees_the_chosen_account(self):
+        self._resolve(CREDIT)
+
+        runtime = self.ns["_local_import"](RUNTIME, self.ns, None, ("*",), 0)
+
+        self.assertEqual(runtime.ACCOUNT_ID, self.CREDIT_ACCOUNT)
+        self.assertEqual(runtime.ACCOUNT_TYPE, "CREDIT")
+
+    def test_importlib_import_module_sees_it_too(self):
+        """account_type_map.py reaches the config this way."""
+        self._resolve(CREDIT)
+
+        config = self.ns["_local_import_module"](CANONICAL)
+
+        self.assertEqual(config.BIGQMT_ACCOUNT_ID, self.CREDIT_ACCOUNT)
+
+
+class SurvivesReloadTest(_LoaderCase):
+    def test_b_importlib_reload_in_detect_account_id(self):
+        """_detect_account_id reloads the config on every init(); under the
+        sandbox that is _local_reload."""
+        self._resolve(CREDIT)
+        config = self._import_config()
+
+        reloaded = self.ns["_local_reload"](config)
+
+        self.assertIs(reloaded, config)
+        self.assertEqual(reloaded.BIGQMT_ACCOUNT_ID, self.CREDIT_ACCOUNT)
+
+    def test_c_reload_deployment_leaves_the_config_alone(self):
+        """The purge takes bigqmt_signal_trader[.*] -- the config module's name
+        starts with 'bigqmt_signal_trader_', which is not that prefix. Pinned
+        because a purge widened to a plain startswith would silently drop the
+        alias and the next import would read the other account's file.
+
+        setUp/tearDown put sys.modules back: the purge clears a cache the rest
+        of the suite shares.
+        """
+        import bigqmt_signal_trader_strategy as strategy
+
+        self._resolve(CREDIT)
+        config = self._import_config()
+
+        purged = strategy._purge_package_modules()
+
+        self.assertNotIn(CANONICAL, purged)
+        self.assertIs(sys.modules.get(CANONICAL), config)
+        self.assertEqual(sys.modules[CANONICAL].BIGQMT_ACCOUNT_ID,
+                         self.CREDIT_ACCOUNT)
+
+    def test_d_the_next_entry_run_drops_it_cleanly(self):
+        """Switching a running terminal from one config to the other has to
+        work, and _clear_local_modules is what makes the next run re-read."""
+        self._resolve(CREDIT)
+        self._import_config()
+
+        self.ns["_clear_local_modules"]()
+
+        self.assertNotIn(CANONICAL, sys.modules)
+
+        second = _loader_namespace(self.ENTRY_PATH)
+        second["_SOURCE_ROOT"] = self.tmpdir
+        second["_resolve_local_config_module"]()
+
+        config = second["_local_import"](CANONICAL, second, None, ("*",), 0)
+        self.assertEqual(config.BIGQMT_ACCOUNT_ID, self.STOCK_ACCOUNT)
+
+
+class BadValueTest(_LoaderCase):
+    def test_a_missing_file_names_the_file_it_looked_for(self):
+        with self.assertRaises(RuntimeError) as caught:
+            self._resolve(CANONICAL + "_nope")
+
+        message = str(caught.exception)
+        self.assertIn(CANONICAL + "_nope.py", message)
+        self.assertIn(self.tmpdir, message)
+
+    def test_a_missing_file_refuses_rather_than_falling_back(self):
+        """A fallback here starts the instance on the OTHER account."""
+        try:
+            self._resolve(CANONICAL + "_nope")
+        except RuntimeError:
+            pass
+
+        self.assertEqual(self.ns["_LOCAL_MODULE_SOURCE_OVERRIDES"], {})
+        self.assertNotIn(CANONICAL, sys.modules)
+
+    def test_a_path_is_rejected_with_a_message_about_module_names(self):
+        for value in (os.path.join(self.tmpdir, CREDIT + ".py"),
+                      "sub/" + CREDIT,
+                      "package." + CREDIT):
+            with self.assertRaises(RuntimeError) as caught:
+                self._resolve(value)
+            self.assertIn("module name", str(caught.exception))
+
+    def test_resolving_again_clears_a_previous_choice(self):
+        self._resolve(CREDIT)
+
+        self.assertEqual(self._resolve(""), CANONICAL)
+        self.assertEqual(self.ns["_LOCAL_MODULE_SOURCE_OVERRIDES"], {})
+
+
+class NoRedisEntryTest(ResolutionTest):
+    """The no-redis fork is hand-maintained and drifts silently (see
+    CLAUDE.md); it needs the same knob or no-redis deployments -- the ones
+    that cannot use redis channel isolation either -- have no multi-account
+    story at all."""
+
+    ENTRY_PATH = NO_REDIS_ENTRY
+
+
+class SourceTest(unittest.TestCase):
+    def test_neither_entry_assigns_the_global(self):
+        """BIGQMT_ZMQ_DRYRUN.py execs the entry source into its OWN globals, so
+        a default assignment in the entry would overwrite what a copy of that
+        wrapper set -- exactly why BIGQMT_FORCE_TRANSPORT is only ever read
+        with globals().get()."""
+        for path in (ENTRY, NO_REDIS_ENTRY):
+            for line in _entry_source(path).splitlines():
+                self.assertFalse(
+                    line.startswith("BIGQMT_LOCAL_CONFIG_MODULE"),
+                    "%s assigns BIGQMT_LOCAL_CONFIG_MODULE at module level; "
+                    "read it with globals().get() instead"
+                    % os.path.basename(path))
+
+    def test_the_startup_line_names_the_module_that_was_read(self):
+        """Two instances in one terminal: the startup line is the only place a
+        config that did not take effect shows up."""
+        self.assertIn("local rpc config loaded module=%s", _entry_source(ENTRY))
+        self.assertIn("no-redis mode: module=%s", _entry_source(NO_REDIS_ENTRY))
+
+    def test_the_two_hardcoded_import_sites_stay_canonical(self):
+        """They are what the alias exists for. Parameterising them instead
+        would break the reload paths pinned above."""
+        runtime = _entry_source(os.path.join(SRC, RUNTIME + ".py"))
+        self.assertIn(
+            "from bigqmt_signal_trader_local_config import "
+            "BIGQMT_ACCOUNT_ID, BIGQMT_REDIS_CONFIG", runtime)
+        strategy = _entry_source(
+            os.path.join(SRC, "bigqmt_signal_trader_strategy.py"))
+        self.assertIn(
+            "import bigqmt_signal_trader_local_config as _local_config",
+            strategy)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
修 #261（@RuralHunter 报告）。

## 问题

README「多账号使用（股票+期货 / 普通+信用）」写着：

> 然后在 QMT 策略编辑器里加载两个 DRYRUN 文件（每个指向不同的配置），分别运行。

**没有任何办法「指向」不同的配置。** 配置模块名在三处写死：

| 位置 | 代码 |
|---|---|
| `src/BIGQMT_REDIS_DRYRUN.py` `_load_local_config()` | `_local_import("bigqmt_signal_trader_local_config", ...)` |
| `src/bigqmt_signal_trader_redis_rpc_runtime.py:177,182` | `from bigqmt_signal_trader_local_config import BIGQMT_ACCOUNT_ID, ...` |
| `src/bigqmt_signal_trader_strategy.py:444` `_detect_account_id()` | `import bigqmt_signal_trader_local_config as _local_config` |

所以第二份入口副本读到的仍是第一个账号的配置：两个实例绑同一个账号，而两边都正常启动、没有任何报错。文档描述的功能不存在。

## 做法

入口读一个全局 `BIGQMT_LOCAL_CONFIG_MODULE` —— 和 `BIGQMT_FORCE_TRANSPORT` 同一种形状（QMT 会 exec 入口文件，所以文件里的全局就是旋钮；QMT 里用环境变量很别扭）：

```python
# BIGQMT_REDIS_DRYRUN_CREDIT.py 顶部
BIGQMT_LOCAL_CONFIG_MODULE = "bigqmt_signal_trader_local_config_credit"
```

指定的文件**以标准名 `bigqmt_signal_trader_local_config` 装载**（loader 里加了一张 `name -> 源文件路径` 的覆盖表，`_find_local_source` 先查它）。于是上面另外两处写死的 import 一个字都不用改，四条 reload 路径全部照常：

- (a) `_local_import` / `_local_import_module` 取标准名 → 拿到这份别名模块；
- (b) `_detect_account_id()` 的 `importlib.reload(_local_config)` → `_local_reload` → 命中 `sys.modules`，同一个对象；
- (c) `reload_deployment()` 的 `_purge_package_modules()` 清的是 `bigqmt_signal_trader` 和 `bigqmt_signal_trader.`**`.`**`*`，而配置模块名是 `bigqmt_signal_trader_`**`_`**`local_config`，不在其中 → 存活；
- (d) 下一次入口运行的 `_clear_local_modules()` 会清掉它 → 两次运行之间可以换配置。

四条都有单测。

不写这一行 = 原来的行为，单账号部署一个字不用改。

**找不到指定模块时入口直接报错停机**，并列出找过的目录 —— 不退回默认配置：那是另一个账号的配置，用错账号下单比起不来严重得多。

启动行加了 `module=`：

```
[bigqmt_shell] local config module=bigqmt_signal_trader_local_config_credit file=...\bigqmt_signal_trader_local_config_credit.py
[bigqmt_shell] local rpc config loaded module=bigqmt_signal_trader_local_config_credit transport=redis keys=[...]
```

这是「那一行没生效」唯一能看出来的地方：没生效时一切照常启动，只是这一路悄悄跑在了另一个账号上。

`bigqmt_no_redis/DRYRUN_no_redis.py`（手工维护的副本，CLAUDE.md 记着它会静默漂移）同步加了同一个开关。

`BIGQMT_ZMQ_DRYRUN.py` 不用改：它把入口源码 exec 进**自己的** globals，所以它的副本顶部加同一行就生效 —— 也正因为如此，入口文件里**不能**给这个全局赋默认值（会覆盖 wrapper 设的值），单测钉住了这一点。

## 文档

- README「多账号使用」重写成能照着做的步骤：两份配置文件（差异是 `BIGQMT_ACCOUNT_ID` 与 `BIGQMT_ACCOUNT_TYPE`）、两份入口副本各加一行、怎么从启动行确认每个实例读对了配置、zmq 端口末两位撞车怎么办、单文件版为什么不需要这个开关、`sync_deployment()` 不会更新你另存的入口副本。
- `docs/DEPLOY_QUICKSTART.md` 增加「再加一个账号」小节并修正指路。
- CHANGELOG 新增 `## [未发布]` 一节。

报告人还提到 README 太大（1731 行）该拆分。**本 PR 不动 README 结构**，拆分方案单独给维护者决定。

## 验证

- 新测试 `tests/bigqmt_signal_trader/test_multi_account_config_module.py`（24 项）：改动前 22 项失败 / 2 项通过（那 2 项是钉住现状的），改动后全绿。
- 全量 `python -m pytest tests/ -q`：**1923 passed, 1 skipped**（基线 1899 passed）。收集数与文件数一致：**149 / 149**。
- 预检：以终端自带 `xtquant`（`D:\...QMT...\bin.x64\Lib\site-packages`）优先于 `src` 导入 `bigqmt_signal_trader.adapter_factory` 成功，两个入口的 loader 半部也在同一路径下 exec 通过。
- 端到端（独立进程，临时目录当作 QMT python 目录，跑**整个**入口文件）：带 `..._credit` 的副本 → `runtime.ACCOUNT_ID = 2000000022` / `ACCOUNT_TYPE = CREDIT`；不带那一行的副本 → `1000000011` / `STOCK`；名字写错 → `RuntimeError` 指名文件并列出目录。
- 入口文件仍是纯 ASCII、可被 GBK 解码（`#coding:gbk` 那条约束），语法未用 3.7+ 特性。

## 没有验证的部分

**没有在实盘上跑双实例。** 没有部署到终端目录，也没有重启/重载线上策略（终端只跑一个账号，且有另一个 agent 在协调部署）。要真正验证需要：第二个可用资金账号（信用或期货）、两份配置 + 两份入口副本进 QMT 模型交易同时运行，然后核对两边面板的 `module=` 行与 `[bigqmt_rpc] started channel=...` 里的账号、两个客户端各自 `query_stock_asset` 拿到不同的账户。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
