### PR TITLE
fix: parse morning QMT source times without a leading zero

### DIFF
--- a/src/bigqmt_signal_trader/adapters/order_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/order_bigqmt.py
@@ -388,26 +388,7 @@ def _order_time_seconds(row):
         _report_missing_order_time(row)
         return 0
 
-    # 已是数字: 当成时间戳 (>1e11 视为毫秒)。
-    if isinstance(raw_time, (int, float)) and not isinstance(raw_time, bool):
-        value = float(raw_time)
-        if value > 1e11:
-            value /= 1000.0
-        if value > 1e8:      # 像时间戳而不是 093015 这种时分秒
-            return int(value)
-
-    date_text = "".join(ch for ch in str(raw_date or "") if ch.isdigit())
-    time_text = "".join(ch for ch in str(raw_time or "") if ch.isdigit())
-    if not date_text or len(date_text) < 8:
-        return 0
-    time_text = (time_text + "000000")[:6]   # 补齐到 HHMMSS, 丢掉毫秒
-    try:
-        import time as _time
-
-        parsed = _time.strptime(date_text[:8] + time_text, "%Y%m%d%H%M%S")
-        return int(_time.mktime(parsed))
-    except Exception:
-        return 0
+    return date_time_seconds(raw_date, raw_time)
 
 
 def _price_type_value(value, default):

--- a/src/bigqmt_signal_trader/exec_events.py
+++ b/src/bigqmt_signal_trader/exec_events.py
@@ -172,7 +172,7 @@ def date_time_seconds(raw_date, raw_time):
     Official docs (dict.thinktrader.net, data_structure) leave the format of
     m_strTradeDate/m_strTradeTime/m_strInsertDate/m_strInsertTime unspecified,
     so tolerate the shapes seen in practice: date '20260819' or '2026-08-19',
-    time '093015', '09:30:15(.123)', or a full 'YYYY-MM-DD HH:MM:SS' carried
+    time '93015' / '093015', '09:30:15(.123)', or a full 'YYYY-MM-DD HH:MM:SS' carried
     in the time field alone. Numeric timestamps pass through (ms normalized).
     """
     if isinstance(raw_time, (int, float)) and not isinstance(raw_time, bool):
@@ -189,6 +189,8 @@ def date_time_seconds(raw_date, raw_time):
         date_digits, time_digits = time_digits[:8], time_digits[8:14]
     if not date_digits or len(date_digits) < 8:
         return 0
+    if len(time_digits) == 5:  # QMT morning HHMMSS can omit the leading hour zero.
+        time_digits = "0" + time_digits
     time_digits = (time_digits + "000000")[:6]  # pad to HHMMSS, drop ms
     try:
         parsed = time.strptime(date_digits[:8] + time_digits, "%Y%m%d%H%M%S")

--- a/tests/bigqmt_signal_trader/test_order_time_and_chunking.py
+++ b/tests/bigqmt_signal_trader/test_order_time_and_chunking.py
@@ -65,10 +65,11 @@ class OrderTimeParsingTest(unittest.TestCase):
         row = _order_row(m_strInsertDate="20260819", m_strInsertTime="093015")
         self.assertEqual(_order_time_seconds(row), self._expected("20260819093015"))
 
-    def test_morning_time_without_leading_zero(self):
-        for clock in ("93003", "93004", "93015", "93016", "93017"):
+    def test_hhmmss_preserves_seconds_and_afternoon_hours(self):
+        for clock in ("93000", "93003", "93004", "93010", "93015", "93016", "93017",
+                      "94000", "95959", "100000", "113000", "130000", "140000", "145500", "150000"):
             for raw in (clock, int(clock)):
-                expected = self._expected("202609100" + clock)
+                expected = self._expected("20260910" + clock.zfill(6))
                 self.assertEqual(date_time_seconds("20260910", raw), expected)
                 row = _order_row(m_strInsertDate="20260910", m_strInsertTime=raw)
                 self.assertEqual(_order_time_seconds(row), expected)

--- a/tests/bigqmt_signal_trader/test_order_time_and_chunking.py
+++ b/tests/bigqmt_signal_trader/test_order_time_and_chunking.py
@@ -16,6 +16,7 @@ sys.path.insert(0, os.path.join(ROOT, "src"))
 
 from bigqmt_signal_trader.adapters import order_bigqmt
 from bigqmt_signal_trader.adapters.order_bigqmt import BigQmtOrderGateway, _order_time_seconds
+from bigqmt_signal_trader.exec_events import date_time_seconds
 from bigqmt_signal_trader.models import OrderSnapshot
 from bigqmt_signal_trader.xtquant_compat import BigQmtXtData, BigQmtXtTrader, StockAccount
 
@@ -63,6 +64,14 @@ class OrderTimeParsingTest(unittest.TestCase):
     def test_parses_split_date_and_time(self):
         row = _order_row(m_strInsertDate="20260819", m_strInsertTime="093015")
         self.assertEqual(_order_time_seconds(row), self._expected("20260819093015"))
+
+    def test_morning_time_without_leading_zero(self):
+        for clock in ("93003", "93004", "93015", "93016", "93017"):
+            for raw in (clock, int(clock)):
+                expected = self._expected("202609100" + clock)
+                self.assertEqual(date_time_seconds("20260910", raw), expected)
+                row = _order_row(m_strInsertDate="20260910", m_strInsertTime=raw)
+                self.assertEqual(_order_time_seconds(row), expected)
 
     def test_tolerates_separators(self):
         row = _order_row(m_strInsertDate="2026-08-19", m_strInsertTime="09:30:15")


### PR DESCRIPTION
QMT can emit morning source times without the leading hour zero, for example `93003`. The parser right-padded this to `930030`, so valid trades became `traded_time=0` and downstream snapshot consumers could no longer process fills.

Pad five-digit HHMMSS on the left in `date_time_seconds`, and let order queries use the same parser as trade queries and callbacks. Native date extraction and the missing-order-time diagnostic remain in place; no wall-clock substitution is added.

Validation: the five observed morning values, as strings and integers, reproduced the failure before the fix. The relevant order-time, execution-event and order/trade-field test files pass: 102 tests. Based on official commit `276acc1`, whose source tree matches the deployed version, to keep the runtime hotfix focused.

Live test-account validation on 2026-09-10: the same 10 existing fills now report their exact native date and seconds (09:30:03/04/15/16/17). Their identifiers, quantities, prices and other raw fields, both completed orders, and position quantities/costs remained unchanged. The consumer resumed and processed each fill once, without resubmitting orders.

Fixes #266.
