### PR TITLE
fix: strategy_name 显式传空串时不再被替换成 bigqmt_rpc

### DIFF
--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -2313,6 +2313,19 @@ class BigQmtRpcHandlers:
     # 旧名保留：外部调用方和既有测试还在用
     _credit_order_type_from_params = _forwarded_order_type
 
+    def _resolve_strategy_name(self, *candidates):
+        """First supplied candidate wins; "" is a real answer, not "unset".
+
+        ``or`` chains used to swallow an explicit empty string back into
+        ``default_strategy_name``. Blank is exactly how a caller asks for an
+        empty 报单来源 column, the way a hand-placed order looks (#154), so
+        only a missing value (``None``) may fall through to the default.
+        """
+        for candidate in candidates:
+            if candidate is not None:
+                return str(candidate)
+        return str(self.default_strategy_name)
+
     def _handle_submit_order(self, params):
         if self.order_gateway is None:
             raise RuntimeError("order_gateway is not configured")
@@ -2329,8 +2342,8 @@ class BigQmtRpcHandlers:
             volume=int(params.get("volume") or params.get("order_volume") or 0),
             price=float(price if price not in (None, "") else 0),
             price_type=params.get("price_type") or "LIMIT",
-            strategy_name=str(params.get("strategy_name")
-                              or self.default_strategy_name),
+            strategy_name=self._resolve_strategy_name(
+                params.get("strategy_name")),
             remark=order_tag,
             order_type=self._forwarded_order_type(params),
         )
@@ -2508,10 +2521,9 @@ class BigQmtRpcHandlers:
         batch_started = time.time()
         batch_id = str(params.get("batch_id") or uuid.uuid4().hex)
         account_id = self._request_account_id(params)
-        strategy_name = str(
-            params.get("strategy_name")
-            or (orders[0] or {}).get("strategy_name")
-            or self.default_strategy_name
+        strategy_name = self._resolve_strategy_name(
+            params.get("strategy_name"),
+            (orders[0] or {}).get("strategy_name"),
         )
         # order_stock_async routes a queued backlog through here (#181), but it
         # never promised order_stock_batch's idempotency contract, and

--- a/tests/bigqmt_signal_trader/test_empty_strategy_name.py
+++ b/tests/bigqmt_signal_trader/test_empty_strategy_name.py
@@ -1,0 +1,130 @@
+# coding: utf-8
+"""An explicitly empty strategy_name must stay empty on the order path.
+
+#154 handed the caller the string that lands in QMT's 报单来源 column, and the
+empty string is a real answer there: it leaves the column blank, the way a
+hand-placed order looks. The config-level default honoured that from the
+start. The two submit sites did not -- they resolved the per-call value with
+``or``::
+
+    strategy_name=str(params.get("strategy_name") or self.default_strategy_name)
+
+``""`` is falsy, so a caller asking for a blank column got "bigqmt_rpc" on
+every order instead: exactly the string they were trying to remove. Only a
+value the caller never supplied (``None`` or absent) may reach the default.
+
+The batch site resolved the same way, and there the name also selects what the
+idempotency lookup queries with. Under a blank-name deployment that lookup
+searched for orders under "bigqmt_rpc", matched none of its own, and so could
+not recognise a retry.
+"""
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.redis_rpc import (  # noqa: E402
+    DEFAULT_ORDER_STRATEGY_NAME,
+    BigQmtRpcHandlers,
+)
+from bigqmt_signal_trader.adapters.order_dryrun import DryRunOrderGateway  # noqa: E402
+
+from test_redis_rpc import (  # noqa: E402  -- reuse the established fakes
+    FakeMarketData,
+    FakePositionProvider,
+)
+
+
+class _RecordingGateway(DryRunOrderGateway):
+    """Also records the strategy_name each idempotency lookup queries with."""
+
+    def __init__(self):
+        super(_RecordingGateway, self).__init__()
+        self.queried_names = []
+
+    def query_orders(self, account_id, strategy_name):
+        self.queried_names.append(strategy_name)
+        return []
+
+
+def _handlers(gateway, **kwargs):
+    return BigQmtRpcHandlers(
+        account_id="acct",
+        market_data=FakeMarketData(),
+        position_provider=FakePositionProvider(),
+        order_gateway=gateway,
+        allow_order_methods=True,
+        **kwargs
+    )
+
+
+def _order(**overrides):
+    params = {
+        "stock_code": "601398.SH", "action": "BUY", "volume": 100,
+        "price": 8.0, "remark": "tag-1", "wait_settlement": False,
+    }
+    params.update(overrides)
+    return params
+
+
+class SingleOrderTest(unittest.TestCase):
+    def test_an_explicit_empty_name_stays_empty(self):
+        """The reported bug: asking for a blank column produced "bigqmt_rpc"."""
+        gateway = _RecordingGateway()
+        _handlers(gateway)._handle_submit_order(_order(strategy_name=""))
+        self.assertEqual(gateway.submitted[0].strategy_name, "")
+
+    def test_an_absent_name_still_takes_the_default(self):
+        """Existing deployments must not be renamed by this fix."""
+        gateway = _RecordingGateway()
+        _handlers(gateway)._handle_submit_order(_order())
+        self.assertEqual(gateway.submitted[0].strategy_name,
+                         DEFAULT_ORDER_STRATEGY_NAME)
+
+    def test_an_explicit_none_still_takes_the_default(self):
+        """None is "the caller said nothing", which is not the same as ""."""
+        gateway = _RecordingGateway()
+        _handlers(gateway)._handle_submit_order(_order(strategy_name=None))
+        self.assertEqual(gateway.submitted[0].strategy_name,
+                         DEFAULT_ORDER_STRATEGY_NAME)
+
+    def test_a_named_strategy_still_wins(self):
+        gateway = _RecordingGateway()
+        _handlers(gateway)._handle_submit_order(_order(strategy_name="my_book"))
+        self.assertEqual(gateway.submitted[0].strategy_name, "my_book")
+
+    def test_empty_beats_a_non_empty_configured_default(self):
+        """Per-call has always won; "" is a call, not the absence of one."""
+        gateway = _RecordingGateway()
+        handlers = _handlers(gateway, default_strategy_name="my_book")
+        handlers._handle_submit_order(_order(strategy_name=""))
+        self.assertEqual(gateway.submitted[0].strategy_name, "")
+
+
+class BatchTest(unittest.TestCase):
+    def test_a_per_order_empty_name_stays_empty(self):
+        gateway = _RecordingGateway()
+        _handlers(gateway)._handle_submit_orders_batch(
+            {"orders": [_order(strategy_name="")]})
+        self.assertEqual(gateway.submitted[0].strategy_name, "")
+
+    def test_the_idempotency_lookup_uses_the_empty_name(self):
+        """Searching under "bigqmt_rpc" would never match its own orders."""
+        gateway = _RecordingGateway()
+        _handlers(gateway)._handle_submit_orders_batch({
+            "strategy_name": "",
+            "orders": [_order(strategy_name="",
+                              require_idempotency_check=True)],
+        })
+        self.assertEqual(gateway.queried_names, [""])
+
+    def test_an_absent_batch_name_still_looks_up_the_default(self):
+        gateway = _RecordingGateway()
+        _handlers(gateway)._handle_submit_orders_batch({
+            "orders": [_order(require_idempotency_check=True)],
+        })
+        self.assertEqual(gateway.queried_names, [DEFAULT_ORDER_STRATEGY_NAME])


### PR DESCRIPTION
## 问题

调用方显式传 `strategy_name=""` 时，下出去的委托带的是 `bigqmt_rpc`，而不是空。

`#154` 把 QMT 委托列表里「报单来源」那一列的字符串交给了调用方决定，空串在那里是一个**真实取值**：它让这一列留白，跟手工下单的委托看起来一样。配置层的默认值（`rpc_default_strategy_name`）从一开始就正确处理了空串，但两个下单入口不是——它们用 `or` 取值：

```python
strategy_name=str(params.get("strategy_name") or self.default_strategy_name)
```

空串是假值，于是落到 `DEFAULT_ORDER_STRATEGY_NAME`，每一笔委托都打上 `bigqmt_rpc`——正是调用方想去掉的那个字符串。

同一个文件里另外三处取值（`query_orders` 过滤、`get_last_order_id`、passorder 透传的 `pick`）用的都是 `is None` 判断，显式空串能正常保留。所以这是两处写法不一致，不是有意设计。

## 改动

新增 `_resolve_strategy_name()`：按顺序取第一个调用方**确实给了**的候选值，只有缺失（`None`）才回落默认。两个下单入口改走它。

## 批量那处影响的是正确性，不只是显示

批次级的 `strategy_name` 不会下发到每笔委托（每个 item 走自己的值，经 `_handle_submit_order`）。它决定的是**幂等查询用哪个名字去查**。所以在留白部署下：委托以空名字下出去，幂等查询却按 `bigqmt_rpc` 去找，永远匹配不到自己下过的单，重试就识别不出来。

## 测试

新增 `tests/bigqmt_signal_trader/test_empty_strategy_name.py`，8 个用例：单笔和批量的空串保留、显式命名仍然优先、空串压过非空的配置默认值，以及幂等查询用空名字去查。

回归护栏：键缺失和显式 `None` 仍然拿到默认值——现有部署不会被这个改动改名。

红→绿验证过：回退源码后，4 个针对空串的用例全部失败，4 个护栏用例前后都通过。

全量套件 1954 通过。另有 2 项失败是环境缺 `dbutils` / redis 依赖导致，在本分支之前就存在，与本次改动无关。

## 备注

当前线上部署的那份副本带同样的 bug，行号一致（2332-2333、2511-2514）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)