### PR TITLE
fix: 对齐 MiniQMT 契约，补齐账户查询形状与七处缺失字段

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,49 @@
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/) 和 [语义化版本](https://semver.org/)。
 
 
+## [未发布]
+
+### 修复
+
+- **账户查询返回 dict，属性访问一律 AttributeError**（`query_account_status` /
+  `query_account_infos` / `query_credit_detail`）。现场报错是
+  `AttributeError: 'dict' object has no attribute 'm_nStatus'`。
+
+  按终端自带的 `xtquant` 核对过：MiniQMT 的**同步**查询把终端自己的对象原样交出
+  去，`common_op_sync_with_seq` 就是 `return future.result()`，全程不转换；整个
+  `xttrader.py` 里只有四处构造 `xttype.*`，都在异步应答和推送的包装里。账号状态
+  唯一那次转换发生在推送路径 `on_push_AccountStatus`，它读 `m_nStatus` 再包成
+  `XtAccountStatus`。所以同步查询本来就该给带 `m_` 属性的对象。
+
+  桥这边名字一直是对的（服务端原样转发终端的 `m_` 键），错的是容器。行改成
+  `CompatRow`，一个既能属性访问又仍然是 `dict` 的子类 —— 今天在用下标
+  `row["m_nStatus"]` 的调用方不受影响，json 编码和 `isinstance(.., dict)` 也照旧。
+
+- **七处回调/返回对象缺 `xttype` 契约里的字段**。#133 定的规矩是「契约声明的字段
+  必须在，缺就给 MiniQMT 语义的默认值，而不是让调用方撞 AttributeError」，当时补
+  的是委托/成交/持仓。拿终端自带的 `xttype` 逐个对账，剩下这些还短着：
+
+  | 交付点 | 缺失字段 |
+  | --- | --- |
+  | `on_order_error`（推送） | `account_type`、`account_id` |
+  | `on_cancel_error`（推送） | `account_type`、`account_id`、`market` |
+  | `query_stock_asset` | `account_type` |
+  | `on_order_error`（异步） | `account_type`、`account_id`、`strategy_name` |
+  | `on_order_stock_async_response` | `account_type` |
+  | `on_cancel_error`（异步） | `account_type`、`account_id`、`market` |
+  | `on_cancel_order_stock_async_response` | `account_type` |
+
+  `account_id` 尤其冤：推送那两处的 `_deliver_event` 在函数开头就把它算好了，只是
+  没往对象里传。资产对象同时补了 `m_nAccountType`，和 PR #67 给持仓/资产加的那套
+  `m_` 别名保持一致。
+
+  `XtCancelError.market` 按代码后缀推（`SH_MARKET` 0 / `SZ_MARKET` 1）。异步撤单
+  那条路径本来就没有代码，给 -1 表示「未知」，而不是让默认值冒充上海 —— `SH_MARKET`
+  正好是 0。
+
+  委托、成交、持仓、以及推送的账号状态四类对象对账下来没有缺口。
+
+
 ## [0.3.32] - 2026-09-10
 
 客户端方法补齐与合成周期回落（#262 / #237），另修两处取值 bug：上午五位 HHMMSS 成交时间被解析成 0（#266，由 @shengyy 报告并提交 #267），以及显式传空的 `strategy_name` 被替换成 `bigqmt_rpc`（#268）。

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -94,6 +94,50 @@ class CompatObject:
         return "%s(%s)" % (self.__class__.__name__, items)
 
 
+class CompatRow(dict):
+    """A dict that also answers attribute access, keys untouched.
+
+    MiniQMT's *sync* queries hand back the terminal's own objects. Only the
+    push path builds an xttype object -- ``on_push_AccountStatus`` is the one
+    place ``xttrader`` reads ``m_nStatus`` and converts it -- while every
+    ``query_*`` returns ``common_op_sync_with_seq``'s result unchanged, so the
+    account family arrives with m_ prefixed attributes on it.
+
+    The bridge relayed the right names in the wrong container: a dict, where
+    ``.m_nStatus`` raises AttributeError and only ``["m_nStatus"]`` works.
+    Subclassing dict adds the attribute path without taking the subscript one
+    away, so callers written against today's behaviour keep working, and so
+    does anything that json-encodes the row or checks ``isinstance(.., dict)``.
+    """
+
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError:
+            raise AttributeError(name)
+
+
+def _as_compat_row(row):
+    """Wrap a native-field dict for attribute access; pass anything else through."""
+    return CompatRow(row) if isinstance(row, dict) else row
+
+
+def _market_of(stock_code):
+    """``XtCancelError.market`` -- xtconstant SH_MARKET (0) / SZ_MARKET (1).
+
+    The code's suffix is the only source the bridge has, and the cancel paths
+    often carry no code at all. -1 there says "not known" rather than letting
+    an absent value impersonate 上海, which is what defaulting to 0 would do.
+    """
+    suffix = str(stock_code or "").rsplit(".", 1)[-1].upper()
+    if suffix == "SH":
+        return 0
+    if suffix == "SZ":
+        return 1
+    return -1
+
+
+
 
 
 
@@ -3930,6 +3974,10 @@ class BigQmtXtTrader:
                 _sysid = str(event.get("order_sys_id") or "")
                 callback.on_order_error(
                     CompatObject(
+                        # xttype.XtOrderError names both, and account_id
+                        # was already resolved at the top of this method.
+                        account_id=account_id,
+                        account_type=self._account_type_value(event),
                         error_id=event.get("error_id"),
                         error_msg=event.get("error_msg") or "",
                         order_sysid=_sysid,       # MiniQMT 规范名 (issue #65)
@@ -3948,6 +3996,9 @@ class BigQmtXtTrader:
                 _sysid = str(event.get("order_sys_id") or "")
                 callback.on_cancel_error(
                     CompatObject(
+                        account_id=account_id,
+                        account_type=self._account_type_value(event),
+                        market=_market_of(event.get("stock_code")),
                         error_id=event.get("error_id"),
                         error_msg=event.get("error_msg") or "",
                         order_sysid=_sysid,       # MiniQMT 规范名 (issue #65)
@@ -4005,6 +4056,9 @@ class BigQmtXtTrader:
                 market_value -= _safe_float(frozen_cash)
         return CompatObject(
             account_id=account_id,
+            # xttype.XtAsset carries it. #133 added account_type to
+            # order/trade/position; the asset object was missed.
+            account_type=self._account_type_value(),
             cash=_safe_float(cash, 0.0) if cash is not None else None,
             available_cash=_safe_float(cash, 0.0) if cash is not None else None,
             # MiniQMT's XtAsset always exposes frozen_cash, so default to 0.0
@@ -4014,6 +4068,7 @@ class BigQmtXtTrader:
             market_value=_safe_float(market_value, 0.0) if market_value is not None else 0.0,
             # ===== 原生 xtquant 字段名别名（兼容 m_ 前缀访问）=====
             m_strAccountID=account_id,
+            m_nAccountType=self._account_type_value(),
             m_dCash=_safe_float(cash, 0.0) if cash is not None else None,
             m_dAvailableCash=_safe_float(cash, 0.0) if cash is not None else None,
             m_dFrozenCash=_safe_float(frozen_cash, 0.0) if frozen_cash is not None else 0.0,
@@ -5109,6 +5164,9 @@ class BigQmtXtTrader:
                 if callback is not None:
                     callback.on_order_error(
                         CompatObject(
+                            account_id=self.client.account_id,
+                            account_type=self._account_type_value(),
+                            strategy_name=unit.get("strategy_name", ""),
                             error_id=unit["error_id"],
                             error_msg=unit["error_msg"],
                             order_sysid="",          # MiniQMT 规范名 (issue #65)
@@ -5143,6 +5201,7 @@ class BigQmtXtTrader:
                 callback.on_order_stock_async_response(
                     CompatObject(
                         account_id=self.client.account_id,
+                        account_type=self._account_type_value(),
                         seq=seq,
                         order_id=self._order_object_id(order_sys_id or unit["user_order_id"]),
                         order_sysid=order_sys_id,    # MiniQMT 规范名 (issue #65)
@@ -5170,6 +5229,11 @@ class BigQmtXtTrader:
                 if callback is not None:
                     callback.on_cancel_error(
                         CompatObject(
+                            account_id=self.client.account_id,
+                            account_type=self._account_type_value(),
+                            # No code reaches this path (stock_code is ""
+                            # just below), so the market is unknown.
+                            market=-1,
                             error_id=unit["error_id"],
                             error_msg=unit["error_msg"],
                             # seq was missing here while the response path had
@@ -5187,6 +5251,7 @@ class BigQmtXtTrader:
                 callback.on_cancel_order_stock_async_response(
                     CompatObject(
                         account_id=self.client.account_id,
+                        account_type=self._account_type_value(),
                         seq=seq,
                         success=bool(ok),
                         cancel_result=0 if ok else -1,
@@ -5379,9 +5444,15 @@ class BigQmtXtTrader:
     def _query_account_list(self, account, method):
         account_id = _account_id(account, self.client.account_id)
         try:
-            return self.client.call(method, {"account_id": account_id}, account_id=account_id) or []
+            rows = self.client.call(method, {"account_id": account_id}, account_id=account_id) or []
         except Exception:
             return []
+        # MiniQMT answers these by attribute (see CompatRow). The server
+        # already relays the terminal's own m_ names, so only the
+        # container was wrong.
+        if isinstance(rows, list):
+            return [_as_compat_row(row) for row in rows]
+        return _as_compat_row(rows)
 
     def query_account_infos(self, account=None):
         return self._query_account_list(account, "query_account_infos")

--- a/tests/bigqmt_signal_trader/test_miniqmt_contract_gaps.py
+++ b/tests/bigqmt_signal_trader/test_miniqmt_contract_gaps.py
@@ -1,0 +1,230 @@
+# coding: utf-8
+"""Every object the bridge hands a caller must carry its xttype contract.
+
+#133 established the rule: a field the MiniQMT type declares has to be present
+with a sensible default, because the alternative is the caller hitting
+AttributeError on a field the real API answers. It fixed order / trade /
+position. An audit of the remaining delivery sites against the xttype classes
+shipped with the terminal found seven that were still short:
+
+    on_order_error (push)          account_type, account_id
+    on_cancel_error (push)         account_type, account_id, market
+    query_stock_asset              account_type
+    on_order_error (async)         account_type, account_id, strategy_name
+    on_order_stock_async_response  account_type
+    on_cancel_error (async)        account_type, account_id, market
+    on_cancel_order_stock_async..  account_type
+
+Separately, the account family (`query_account_status` / `query_account_infos`
+/ `query_credit_detail`) returned plain dicts. MiniQMT's *sync* queries return
+the terminal's own objects -- ``xttrader`` builds an xttype object only on the
+push path, where ``on_push_AccountStatus`` reads ``m_nStatus`` and converts --
+so `.m_nStatus` answered there and raised AttributeError here. The names the
+bridge relayed were already right; only the container was wrong, which is why
+the rows are now a dict subclass: the subscript access that works today keeps
+working.
+"""
+
+import json
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.xtquant_compat import (  # noqa: E402
+    BigQmtXtTrader,
+    CompatRow,
+    _market_of,
+)
+
+
+class _RecordingCallback(object):
+    def __init__(self):
+        self.order_errors = []
+        self.cancel_errors = []
+        self.order_responses = []
+        self.cancel_responses = []
+
+    def on_order_error(self, err):
+        self.order_errors.append(err)
+
+    def on_cancel_error(self, err):
+        self.cancel_errors.append(err)
+
+    def on_order_stock_async_response(self, resp):
+        self.order_responses.append(resp)
+
+    def on_cancel_order_stock_async_response(self, resp):
+        self.cancel_responses.append(resp)
+
+
+class _FakeClient(object):
+    def __init__(self, payloads=None):
+        self.account_id = "acct"
+        self.payloads = payloads or {}
+
+    def call(self, method, params=None, account_id=None, timeout_seconds=None):
+        return self.payloads.get(method)
+
+
+def _trader(callback=None, payloads=None):
+    trader = BigQmtXtTrader(account_id="acct")
+    trader.client = _FakeClient(payloads)
+    if callback is not None:
+        trader.callback = callback
+    return trader
+
+
+# The account family arrives with the terminal's own native names.
+_STATUS_ROW = {"m_strAccountID": "acct", "m_nAccountType": 2, "m_nStatus": 1}
+
+
+class CompatRowTest(unittest.TestCase):
+    def test_it_answers_attribute_access(self):
+        self.assertEqual(CompatRow(_STATUS_ROW).m_nStatus, 1)
+
+    def test_it_is_still_a_dict(self):
+        """Callers written against today's behaviour must not break."""
+        row = CompatRow(_STATUS_ROW)
+        self.assertIsInstance(row, dict)
+        self.assertEqual(row["m_nStatus"], 1)
+        self.assertEqual(row.get("m_nStatus"), 1)
+        self.assertEqual(sorted(row.keys()), sorted(_STATUS_ROW.keys()))
+
+    def test_it_still_json_encodes(self):
+        self.assertEqual(json.loads(json.dumps(CompatRow(_STATUS_ROW))), _STATUS_ROW)
+
+    def test_an_absent_field_raises_attribute_error_not_key_error(self):
+        with self.assertRaises(AttributeError):
+            CompatRow(_STATUS_ROW).m_nNoSuchField
+
+
+class AccountFamilyShapeTest(unittest.TestCase):
+    """query_account_status / _infos / query_credit_detail return rows, not dicts."""
+
+    def _rows(self, method, call):
+        trader = _trader(payloads={method: [dict(_STATUS_ROW)]})
+        return call(trader)
+
+    def test_account_status_rows_read_by_attribute(self):
+        rows = self._rows("query_account_status", lambda t: t.query_account_status())
+        self.assertEqual(rows[0].m_nStatus, 1)
+
+    def test_account_infos_rows_read_by_attribute(self):
+        rows = self._rows("query_account_infos", lambda t: t.query_account_infos())
+        self.assertEqual(rows[0].m_strAccountID, "acct")
+
+    def test_credit_detail_rows_read_by_attribute(self):
+        rows = self._rows("query_credit_detail", lambda t: t.query_credit_detail("acct"))
+        self.assertEqual(rows[0].m_nAccountType, 2)
+
+    def test_the_subscript_path_still_works(self):
+        rows = self._rows("query_account_status", lambda t: t.query_account_status())
+        self.assertEqual(rows[0]["m_nStatus"], 1)
+
+    def test_an_empty_answer_is_still_an_empty_list(self):
+        trader = _trader(payloads={"query_account_status": []})
+        self.assertEqual(trader.query_account_status(), [])
+
+    def test_a_non_dict_row_passes_through_untouched(self):
+        trader = _trader(payloads={"query_account_status": ["raw", 7]})
+        self.assertEqual(trader.query_account_status(), ["raw", 7])
+
+
+class MarketOfTest(unittest.TestCase):
+    def test_it_reads_the_suffix(self):
+        self.assertEqual(_market_of("600000.SH"), 0)
+        self.assertEqual(_market_of("000001.SZ"), 1)
+
+    def test_an_unknown_code_is_not_reported_as_shanghai(self):
+        """SH_MARKET is 0, so a 0 default would impersonate 上海."""
+        self.assertEqual(_market_of(""), -1)
+        self.assertEqual(_market_of(None), -1)
+        self.assertEqual(_market_of("600000"), -1)
+
+
+class PushCallbackContractTest(unittest.TestCase):
+    def _fire(self, event_type, **extra):
+        cb = _RecordingCallback()
+        event = {"event_type": event_type, "account_id": "acct",
+                 "stock_code": "600000.SH", "error_id": -1, "error_msg": "boom"}
+        event.update(extra)
+        _trader(cb)._deliver_event(event)
+        return cb
+
+    def test_order_error_names_the_account(self):
+        err = self._fire("order_error").order_errors[0]
+        self.assertEqual(err.account_id, "acct")
+        self.assertIsInstance(err.account_type, int)
+
+    def test_cancel_error_names_the_account_and_market(self):
+        err = self._fire("cancel_error").cancel_errors[0]
+        self.assertEqual(err.account_id, "acct")
+        self.assertIsInstance(err.account_type, int)
+        self.assertEqual(err.market, 0)
+
+    def test_cancel_error_market_follows_the_code(self):
+        err = self._fire("cancel_error", stock_code="000001.SZ").cancel_errors[0]
+        self.assertEqual(err.market, 1)
+
+
+class AsyncCallbackContractTest(unittest.TestCase):
+    def _unit(self, kind, **extra):
+        unit = {"kind": kind, "seq": 7, "remark": "r-1", "error_id": -1,
+                "error_msg": "boom", "stock_code": "600000.SH",
+                "order_remark": "tag-1", "user_order_id": "u-1",
+                "order_sys_id": "sys-1", "strategy_name": "my_book"}
+        unit.update(extra)
+        return unit
+
+    def test_async_order_error_names_the_account_and_strategy(self):
+        cb = _RecordingCallback()
+        _trader(cb)._fire_async_outcome(self._unit("error"))
+        err = cb.order_errors[0]
+        self.assertEqual(err.account_id, "acct")
+        self.assertIsInstance(err.account_type, int)
+        self.assertEqual(err.strategy_name, "my_book")
+
+    def test_async_order_response_names_the_account_type(self):
+        cb = _RecordingCallback()
+        _trader(cb)._fire_async_outcome(self._unit("response"))
+        self.assertIsInstance(cb.order_responses[0].account_type, int)
+
+    def test_async_cancel_error_names_the_account_and_market(self):
+        cb = _RecordingCallback()
+        _trader(cb)._fire_async_outcome(self._unit("cancel_error", order_id="o-1"))
+        err = cb.cancel_errors[0]
+        self.assertEqual(err.account_id, "acct")
+        self.assertIsInstance(err.account_type, int)
+        # This path carries no stock_code, so the market is honestly unknown.
+        self.assertEqual(err.market, -1)
+
+    def test_async_cancel_response_names_the_account_type(self):
+        cb = _RecordingCallback()
+        _trader(cb)._fire_async_outcome(
+            self._unit("cancel_response", order_id="o-1", success=True))
+        self.assertIsInstance(cb.cancel_responses[0].account_type, int)
+
+
+class AssetContractTest(unittest.TestCase):
+    def _asset(self):
+        payload = {"cash": 100.0, "total_asset": 300.0,
+                   "frozen_cash": 0.0, "market_value": 200.0}
+        return _trader(payloads={"query_stock_asset": payload}).query_stock_asset("acct")
+
+    def test_it_carries_account_type(self):
+        """xttype.XtAsset declares it; only order/trade/position got it in #133."""
+        self.assertIsInstance(self._asset().account_type, int)
+
+    def test_the_native_alias_agrees_with_it(self):
+        asset = self._asset()
+        self.assertEqual(asset.m_nAccountType, asset.account_type)
+
+    def test_the_existing_fields_are_untouched(self):
+        asset = self._asset()
+        self.assertEqual(asset.cash, 100.0)
+        self.assertEqual(asset.total_asset, 300.0)
+        self.assertEqual(asset.m_dTotalAsset, 300.0)


### PR DESCRIPTION
## 起因

现场两个报错，查下来一个是误用、一个是真缺口：

- `AttributeError: 'CompatObject' object has no attribute 'order_price'` —— **不是桥的问题**。`order_price` 在终端自带的整个 `xtquant` 包里搜不到，`XtOrder` 的价格字段就是 `price`，桥发的也是 `price`。调用方改字段名即可。
- `AttributeError: 'dict' object has no attribute 'm_nStatus'` —— **是真缺口**，本 PR 修这个。

## 为什么 `m_nStatus` 该能取到

按终端自带的 `xtquant` 核对，不是靠记忆：

- MiniQMT 的**同步**查询把终端自己的对象原样交出去。`query_account_status` 直接 `return common_op_sync_with_seq(...)`，而那个函数就是 `return future.result()`，全程不转换。
- 整个 `xttrader.py` 里只有四处构造 `xttype.*` 对象，全在异步应答和推送的包装里。
- 账号状态唯一那次转换发生在推送路径 `on_push_AccountStatus`：它从原生对象读 `m_strAccountID` / `m_nAccountType` / `m_nStatus`，再包成 `XtAccountStatus` 交给 `on_account_status`。

所以同步查询本来就该给带 `m_` 属性的对象，`XtAccountStatus` 那个带 `.status` 的结构只在推送那条路上出现。

桥这边名字一直是对的（服务端原样转发终端的 `m_` 键），错的是容器：给的是 dict。

## 改动

### 1. 账户查询的容器

行改成 `CompatRow`，一个既能属性访问、又仍然是 `dict` 的子类。**今天在用下标 `row["m_nStatus"]` 的调用方不受影响**，json 编码和 `isinstance(.., dict)` 也照旧。影响 `query_account_status` / `query_account_infos` / `query_credit_detail`。

### 2. 七处对象缺 xttype 契约字段

#133 定的规矩是「契约声明的字段必须在，缺就给 MiniQMT 语义的默认值」，当时补的是委托/成交/持仓。拿 `xttype` 逐个对账，剩下这些还短着：

| 交付点 | 缺失字段 |
| --- | --- |
| `on_order_error`（推送） | `account_type`、`account_id` |
| `on_cancel_error`（推送） | `account_type`、`account_id`、`market` |
| `query_stock_asset` | `account_type` |
| `on_order_error`（异步） | `account_type`、`account_id`、`strategy_name` |
| `on_order_stock_async_response` | `account_type` |
| `on_cancel_error`（异步） | `account_type`、`account_id`、`market` |
| `on_cancel_order_stock_async_response` | `account_type` |

`account_id` 尤其冤：推送那两处的 `_deliver_event` 在函数开头就算好了，只是没往对象里传。资产对象同时补了 `m_nAccountType`，和 PR #67 给持仓/资产加的 `m_` 别名保持一致。

`XtCancelError.market` 按代码后缀推（`SH_MARKET` 0 / `SZ_MARKET` 1）。异步撤单那条路径本来就没有代码，给 -1 表示未知，而不是让默认值冒充上海 —— `SH_MARKET` 正好是 0。

**委托、成交、持仓、推送账号状态四类对象对账下来没有缺口。**

## 验证

结构审计：改前 7 个交付点缺字段，改后 0 个。

运行时对拍，改前：

```
row.m_nStatus            AttributeError: 'dict' object has no attribute 'm_nStatus'
row["m_nStatus"]         OK -> 1
asset.account_type       AttributeError
order_error.account_id   AttributeError
cancel_error.market      AttributeError
```

改后：

```
row.m_nStatus            OK -> 1
row["m_nStatus"]         OK -> 1
asset.account_type       OK -> 2
order_error.account_id   OK -> 'acct'
cancel_error.market      OK -> 0
```

新增 22 个用例（`test_miniqmt_contract_gaps.py`），含下标访问不被破坏、json 仍可编码、未知市场不报成上海等。全量套件 1976 通过；另有 2 项失败是环境缺 `dbutils` / redis 依赖，此分支之前就存在。

## 不在本 PR 范围

`query_account_status` 在实盘账户上返回空列表：服务端 `_handle_query_account_status` 用 `TASK`（委托任务状态）这个 detail type 近似，和形状问题独立。已另开 issue。

🤖 Generated with [Claude Code](https://claude.com/claude-code)