### PR TITLE
release: 0.3.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/) 和 [语义化版本](https://semver.org/)。
 
 
-## [未发布]
+## [0.3.33] - 2026-09-10
+
+对齐 MiniQMT 契约：账户查询从 dict 改成可属性访问的行对象（现场报错 `'dict' object has no attribute 'm_nStatus'`），另按终端自带的 `xttype` 逐个对账，补齐七处回调与返回对象缺的字段（#271）。
 
 ### 修复
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xtquant-big-convert"
-version = "0.3.32"
+version = "0.3.33"
 description = "Big QMT RPC bridge and MiniQMT-compatible adapter layer (redis/zmq/mysql transports)"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/bigqmt_signal_trader/version.py
+++ b/src/bigqmt_signal_trader/version.py
@@ -21,7 +21,7 @@ copy never happened" and "the copy landed but was not picked up" look identical
 from the outside.
 """
 
-__version__ = "0.3.32"
+__version__ = "0.3.33"
 
 
 def deployment_report(package_dir=None):


### PR DESCRIPTION
## 本版内容

对齐 MiniQMT 契约（#271）：

- 账户查询（`query_account_status` / `query_account_infos` / `query_credit_detail`）从 dict 改成既能属性访问、又仍然是 `dict` 的行对象。现场报错是 `AttributeError: 'dict' object has no attribute 'm_nStatus'`。
- 按终端自带的 `xttype` 逐个对账，补齐七处回调与返回对象缺的字段。

## 改动

按 0.3.31 / 0.3.32 的惯例，只动三个文件：

- `CHANGELOG.md`：`[未发布]` 改成 `[0.3.33] - 2026-09-10`，加一行概述
- `pyproject.toml`：`0.3.32` → `0.3.33`
- `src/bigqmt_signal_trader/version.py`：同步版本戳

## 测试

全量套件 1976 通过。另有 2 项失败是环境缺 `dbutils` / redis 依赖，在此分支之前就存在，与本次发版无关。版本戳测试 11 项全过。

#271 另做过实盘只读对拍：容器与新增字段按预期变化，未触及路径（持仓/委托/成交）的返回指纹前后完全一致。四个回调路径需要真实下单才能触发，只有单元测试覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)