### PR TITLE
fix: 合成周期空答案是列字典时也走 #237 回落

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/) 和 [语义化版本](https://semver.org/)。
 
 
+## [Unreleased]
+
+### 修复
+
+- **合成周期回落在国金 2.0.8.0 上自动触发进不去**（issue #237）：`get_market_data_ex_ori` 对 1mon+ 的空答案不是 `[]`，而是 12 个字段、每个都是长度为 0 的列字典（`{time:[], stime:[], open:[], ... settelementPrice:[], ...}`）。`_market_data_answer_empty` 用 `if records:` 判断，这个 dict 为真，主路径被当成「有数」直接返回，`_synth_period_rescue` 根本不跑。同一台终端上 `synth_fallback_only=True` 能救出 10 行（`ContextInfo.get_market_data`），公式口六列也是 10 行。现在列字典看任一列的长度，全 0 才是空。单测假终端原先写 `{code: []}`，覆盖不到这个形状。
+
+---
+
 ## [0.3.35] - 2026-09-11
 
 ### 修复

--- a/src/bigqmt_signal_trader/adapters/market_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/market_bigqmt.py
@@ -185,19 +185,53 @@ def _raw_frame_columns(field_list):
     return columns
 
 
+def _records_have_rows(records):
+    """True when ``records`` carries at least one bar.
+
+    ``get_market_data_ex_ori`` answers two empty shapes:
+
+    * a list of rows (``[]``)
+    * a dict of column arrays whose every array has length 0
+
+    The column-dict is truthy in Python. On Guojin 2.0.8.0 that is the
+    empty answer for 1mon+ (12 keys, all length 0, measured 2026-09-11).
+    ``if records:`` treated it as data, so #237's rescue never ran: the
+    primary was kept, ``synth_fallback_only=True`` (which skips it) still
+    answered 10 rows from ``ContextInfo.get_market_data``.
+    """
+    if records is None:
+        return False
+    if isinstance(records, dict):
+        if records.get("__bigqmt_type__") == "DataFrame":
+            return _records_have_rows(records.get("records"))
+        for column in records.values():
+            try:
+                if len(column) > 0:
+                    return True
+            except TypeError:
+                if column not in (None, ""):
+                    return True
+        return False
+    try:
+        return len(records) > 0
+    except TypeError:
+        return bool(records)
+
+
 def _market_data_answer_empty(answer):
     """True when no code in the answer carries a single row.
 
     Covers both shapes get_market_data_ex can return: the raw path's
-    serialisable marker dict (records list) and the plain path's pandas
-    frames (index length). Anything unrecognised counts as an answer rather
-    than as empty -- a retry must never replace data with nothing.
+    serialisable marker dict (records list *or* a dict of column arrays)
+    and the plain path's pandas frames (index length). Anything
+    unrecognised counts as an answer rather than as empty -- a retry must
+    never replace data with nothing.
     """
     if not isinstance(answer, dict) or not answer:
         return True
     for value in answer.values():
         if isinstance(value, dict) and value.get("__bigqmt_type__") == "DataFrame":
-            if value.get("records"):
+            if _records_have_rows(value.get("records")):
                 return False
         elif hasattr(value, "index"):
             try:
@@ -205,7 +239,7 @@ def _market_data_answer_empty(answer):
                     return False
             except Exception:
                 return False
-        elif value:
+        elif _records_have_rows(value):
             return False
     return True
 

--- a/tests/bigqmt_signal_trader/test_bigqmt_market_raw_bridge.py
+++ b/tests/bigqmt_signal_trader/test_bigqmt_market_raw_bridge.py
@@ -6,7 +6,10 @@ import unittest
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.join(ROOT, "src"))
 
-from bigqmt_signal_trader.adapters.market_bigqmt import BigQmtMarketDataProvider
+from bigqmt_signal_trader.adapters.market_bigqmt import (
+    BigQmtMarketDataProvider,
+    _market_data_answer_empty,
+)
 
 
 class RawMarketContext:
@@ -249,6 +252,12 @@ class _IndexedFrame(object):
 
 
 _SIX = ("open", "high", "low", "close", "volume", "amount")
+# Guojin 2.0.8.0 get_market_data_ex_ori empty 1mon: 12 keys, every list
+# length 0 (peeked 2026-09-11 on 0.3.34, field_list=[]).
+_ORI_EMPTY_COLUMNS = (
+    "time", "stime", "open", "high", "low", "close", "volume", "amount",
+    "settelementPrice", "openInterest", "preClose", "suspendFlag",
+)
 
 
 def _local_frame(rows, fields=None):
@@ -268,11 +277,15 @@ class TerminalContext(object):
     """
 
     def __init__(self, bars=None, broken_periods=("1mon", "1q", "1hy", "1y"),
-                 primary_rows=None, frame_for=None):
+                 primary_rows=None, frame_for=None,
+                 empty_ori_as_columns=False):
         self.broken_periods = set(broken_periods)
         self.bars = bars or []
         self.primary_rows = primary_rows or []
         self.frame_for = frame_for          # override the answered frame
+        # Guojin 2.0.8.0 get_market_data_ex_ori empty shape: a 12-key dict
+        # of length-0 arrays, not []. bool(that dict) is True.
+        self.empty_ori_as_columns = empty_ori_as_columns
         self.ori_calls = []
         self.market_calls = []
         self.local_calls = []
@@ -287,6 +300,9 @@ class TerminalContext(object):
                                "period": period, "count": count})
         codes = list(stock_code or [])
         if period in self.broken_periods:
+            if self.empty_ori_as_columns:
+                empty = dict((name, []) for name in _ORI_EMPTY_COLUMNS)
+                return dict((code, dict(empty)) for code in codes)
             return dict((code, []) for code in codes)
         return dict((code, list(self.primary_rows)) for code in codes)
 
@@ -352,6 +368,43 @@ def _partial_of(frame):
     return frame.get("__bigqmt_partial__")
 
 
+class MarketDataAnswerEmptyTest(unittest.TestCase):
+    """#237: 0 rows is a shape, not a Python truth value."""
+
+    def test_envelope_with_empty_row_list_is_empty(self):
+        answer = {"600519.SH": {
+            "__bigqmt_type__": "DataFrame",
+            "columns": ["stime", "close"],
+            "records": [],
+        }}
+        self.assertTrue(_market_data_answer_empty(answer))
+
+    def test_envelope_with_empty_column_dict_is_empty(self):
+        records = dict((name, []) for name in _ORI_EMPTY_COLUMNS)
+        answer = {"600519.SH": {
+            "__bigqmt_type__": "DataFrame",
+            "columns": [],
+            "records": records,
+        }}
+        self.assertTrue(_market_data_answer_empty(answer))
+
+    def test_envelope_with_populated_column_dict_is_not_empty(self):
+        answer = {"600519.SH": {
+            "__bigqmt_type__": "DataFrame",
+            "columns": [],
+            "records": {"time": [1, 2], "open": [10.0, 11.0]},
+        }}
+        self.assertFalse(_market_data_answer_empty(answer))
+
+    def test_envelope_with_row_list_is_not_empty(self):
+        answer = {"600519.SH": {
+            "__bigqmt_type__": "DataFrame",
+            "columns": ["stime", "close"],
+            "records": [["20260930", 1290.88]],
+        }}
+        self.assertFalse(_market_data_answer_empty(answer))
+
+
 class SynthPeriodRescueTest(unittest.TestCase):
     """#237: on Guojin 2.0.8.0 every get_market_data2 path answers 0 rows for
     1mon/1q/1hy/1y while a plain get_market_data answers the same bars. Rescue
@@ -382,6 +435,31 @@ class SynthPeriodRescueTest(unittest.TestCase):
         # It was get_market_data that served it -- get_local_data takes no
         # field list, so no shape the adapter builds can reach it.
         self.assertEqual(1, len(context.market_calls))
+        self.assertEqual("ContextInfo.get_market_data",
+                         _partial_of(frame)["source"])
+
+    def test_ori_column_dict_of_empty_arrays_is_rescued(self):
+        """The 2.0.8.0 empty answer is a 12-key dict of length-0 arrays.
+
+        ``bool({time: [], open: [], ...})`` is True, so the old
+        ``if records:`` treated 0 rows as data and never ran the rescue
+        (issue #237, measured 2026-09-11 on tagged 0.3.34). ``[]`` already
+        rescued; this is the shape that did not.
+        """
+        context, provider = self._provider(
+            bars=_MONTHLY_10, empty_ori_as_columns=True)
+
+        data = provider.get_market_data_ex(
+            field_list=[], stock_list=["600519.SH"], period="1mon", count=10,
+            dividend_type="none", fill_data=False)
+
+        frame = data["600519.SH"]
+        self.assertEqual(10, len(frame["records"]),
+                         "column-dict-of-empty-arrays must count as 0 rows")
+        self.assertEqual(["stime"] + list(_SIX), frame["columns"])
+        self.assertEqual(1, len(context.market_calls))
+        self.assertEqual("synth_period_primary_empty",
+                         _partial_of(frame)["reason"])
         self.assertEqual("ContextInfo.get_market_data",
                          _partial_of(frame)["source"])
 


### PR DESCRIPTION
Refs #237。国金实盘 2.0.8.0 上升到 0.3.34 后按维护者三步复测：默认空 `field_list` 的 1mon 仍是 0 行，`synth_fallback_only=True` 能救出 10 行。回落函数是通的，自动触发进不去。

## 原因

`get_market_data_ex_ori` 对 1mon+ 的空答案不是 `[]`，而是 12 个字段、每个都是长度为 0 的列字典：

```
columns = []
records = {
  time:[], stime:[], open:[], high:[], low:[], close:[],
  volume:[], amount:[], settelementPrice:[], openInterest:[],
  preClose:[], suspendFlag:[]
}
bool(records) = True
```

`_market_data_answer_empty` 用 `if value.get("records"):` 判断。这个 dict 为真，主路径被当成「有数」直接返回，#219 的 11 列重试和 `_synth_period_rescue` 都不跑。

同一进程对照（2026-09-11 12:28，午休；连续竞价 0.3.29/0.3.31 已是同一 0 行框）：

| 路径 | 600519.SH 1mon |
|---|---|
| 空 field_list（默认） | 0 |
| 六列 FormulaServer | 10 |
| `synth_fallback_only=True` | 10（`ContextInfo.get_market_data`） |

假终端原先写 `{code: []}`，`[]` 为假，rescue 能进——覆盖不到 2.0.8.0 的真实空形状。

## 修法

`_records_have_rows`：list 看长度；dict 看任一列的长度，全 0 才是空。有行的列字典仍当有数（2.1.19.0 主路径不误入回落）。

新增用例对改前代码为红：`empty_ori_as_columns=True` 时 rescue 必须跑；envelope 的空列字典 / 空 list / 有行列字典 / 有行 list 四条钉住判据。

## 验证

`tests/bigqmt_signal_trader/test_bigqmt_market_raw_bridge.py` **36 passed**。

2.0.8.0 上的默认空 `field_list` 端到端要等这版部署进终端后再测。`synth_fallback_only=True` 在 0.3.34 上已经救出 10 行，本 PR 只让默认路径走到那条已经测通的路。
