### PR TITLE
release: 0.3.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/) 和 [语义化版本](https://semver.org/)。
 
 
-## [未发布]
+## [0.3.36] - 2026-09-11
+
+三处修复，都有实测依据：合成周期空答案是列字典时 #237 的回落进不去（#279，@yucejade）；`get_sector_list` 兜底清单里 `沪市A股` / `深市A股` 拼错，这台终端认的是 `上证A股` / `深证A股`；委托回报推送从没带过 `price_type`，回调拿到的永远是 None（#280）。
 
 ### 修复
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xtquant-big-convert"
-version = "0.3.35"
+version = "0.3.36"
 description = "Big QMT RPC bridge and MiniQMT-compatible adapter layer (redis/zmq/mysql transports)"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/bigqmt_signal_trader/version.py
+++ b/src/bigqmt_signal_trader/version.py
@@ -21,7 +21,7 @@ copy never happened" and "the copy landed but was not picked up" look identical
 from the outside.
 """
 
-__version__ = "0.3.35"
+__version__ = "0.3.36"
 
 
 def deployment_report(package_dir=None):


### PR DESCRIPTION
## 本版内容

三处修复，都有实测依据：

- 合成周期空答案是列字典时 #237 的回落进不去（#279，@yucejade）
- `get_sector_list` 兜底清单里 `沪市A股` / `深市A股` 拼错，国金 2.1.19.0 认的是 `上证A股` / `深证A股`（#280）
- 委托回报推送从没带过 `price_type`，回调拿到的永远是 None（#280）

## 改动

按惯例只动三个文件：CHANGELOG（`[未发布]` → `[0.3.36]`，加概述行）、pyproject、version.py。

## 测试

全量 2009 通过；另 2 项失败是环境缺 `dbutils` / redis 依赖，此前就存在。版本戳测试 11 项全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)