### PR TITLE
修复订单诊断信息丢失价格精度的问题

### DIFF
--- a/src/bigqmt_signal_trader/redis_rpc.py
+++ b/src/bigqmt_signal_trader/redis_rpc.py
@@ -2491,7 +2491,7 @@ class BigQmtRpcHandlers:
                 message = (
                     "ORDER IS LIVE -- DO NOT RESUBMIT. passorder reached the "
                     "broker and the order row exists (stock=%s action=%s "
-                    "price=%.2f volume=%d), but QMT had still not assigned "
+                    "price=%s volume=%d), but QMT had still not assigned "
                     "order_sys_id after %d lookup(s), so this reply carries no "
                     "id. Find it by remark %r, or in the 委托 list; it is not a "
                     "rejection (issue #152)."
@@ -2521,7 +2521,7 @@ class BigQmtRpcHandlers:
             # hours there before finding the mode (issue #122).
             message = (
                 "passorder submitted but order not found in system "
-                "(stock=%s action=%s price=%.2f volume=%d, %d lookup(s)). "
+                "(stock=%s action=%s price=%s volume=%d, %d lookup(s)). "
                 "FIRST check the strategy's run mode: in QMT's 模型交易 list the "
                 "运行模式 column defaults to 模拟, where passorder matches "
                 "internally and never reaches the broker -- switch it to 实盘 "

--- a/tests/bigqmt_signal_trader/test_order_not_found_message.py
+++ b/tests/bigqmt_signal_trader/test_order_not_found_message.py
@@ -73,8 +73,9 @@ class KeepsTheEvidenceTest(unittest.TestCase):
     def test_it_still_reports_the_order(self):
         block = _message_block()
 
-        for field in ("stock=%s", "action=%s", "price=%.2f", "volume=%d"):
+        for field in ("stock=%s", "action=%s", "price=%s", "volume=%d"):
             self.assertIn(field, block, field)
+        self.assertNotIn("price=%.2f", block)
 
     def test_it_still_reports_the_lookup_count(self):
         self.assertIn("lookup(s)", _message_block())


### PR DESCRIPTION
订单诊断信息使用 `%.2f` 格式化价格，会将 `0.475` 等三位小数的 ETF 委托价显示为 `0.47`。本修改仅修正诊断信息的价格显示，不影响实际委托参数和下单逻辑。