### PR TITLE
fix: xtdata.get_divid_factors 返回 DataFrame，对齐 miniQMT 实测形状

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/) 和 [语义化版本](https://semver.org/)。
 
 
+## [未发布]
+
+### 修复
+
+- **`xtdata.get_divid_factors()` 返回 dict，不是 DataFrame**。在真 miniQMT 上实测
+  `df.info()`：`Index: 19990823 to 20080707`，八列 `time` / `interest` / `stockBonus` /
+  `stockGift` / `allotNum` / `allotPrice` / `gugai` / `dr`，`dtypes: float64(8)`——一行一个
+  除权日，索引是 YYYYMMDD，`time` 列是当天的毫秒戳。桥的客户端把 RPC 应答原样透传，
+  而应答是大 QMT 原生的 `dict{毫秒时间戳: [7 个数]}`：值和顺序都一样，但没有名字、日期
+  还是毫秒戳、`gugai` 是 int。照着真 xtdata 写的调用方 `df["dr"]` 是 KeyError，
+  `df.loc["20260626"]` 取不到，`df.tail()` 是 AttributeError。
+
+  现在客户端补日期索引、`time` 列、列名和 float64，和 `get_market_data_ex` 把线上
+  records 落成 frame 是同一种做法。毫秒戳是上海零点（三个实盘样本
+  `(ms/1000 + 8h) % 86400` 都是 0），折成 YYYYMMDD 用固定 +8h，不看客户端机器时区。
+  **线上格式不变**，走原始 RPC 和 `getDividFactors` 别名拿到的还是那个 dict。行序保持
+  服务端给的，不排序。
+
+  列序用国金 2.1.19.0 实盘数据钉住：000001.SZ 在 2000 年那次配股，两个非零值必须落在
+  `allotNum`（0.3）和 `allotPrice`（8.0）而不是 `interest`。600519.SH 端到端
+  `Index: 30 entries, 20020725 to 20260626`，8 列全 float64。
+
+- **RPC 参考里 `get_divid_factors` 那段参数说明还是 #165 修前的老话**（"实际只把
+  `end_time` 作为单个 `date` 传入"），区间早就是真区间了。按现状重写，并补上线上格式与
+  客户端返回格式的区别。
+
+---
+
 ## [0.3.38] - 2026-09-11
 
 文档版。部署快速开始重写：`bigqmt-init` 嵌进流程并写明它不做什么，新增「升级已有部署」一节，按实际跑过两遍的流程写（#285）。代码与 0.3.37 相同。

--- a/docs/RPC_API_REFERENCE.md
+++ b/docs/RPC_API_REFERENCE.md
@@ -202,8 +202,11 @@ FormulaServer 直连不认这个参数，带上它会强制回落到 RPC 桥（�
 | `get_his_option_list_batch` | `undl_code` `start_time` `end_time` | 批量历史期权 |
 | `get_divid_factors` | `stock_code` 可选 `start_time`/`end_time` | 除权除息因子 |
 
-**`get_divid_factors` 参数说明（重要）**：
-`ContextInfo` 桩签名是 `get_divid_factors(marketAndStock, date='')`——**只收 2 个参数**（代码 + 单个日期）。适配器接受 `start_time`/`end_time` 以保持接口兼容，但实际只把 `end_time`（或 `start_time`）作为单个 `date` 传入。
+**`get_divid_factors` 说明**：
+
+- **区间是真的区间**（#165 起）。`ContextInfo` 桩只收单个日期，服务端先试原生 SDK 和 3 参形状，都不行才由日线 `preClose` 与前一根 `close` 的差定位除权日、逐日探测。以前把区间塌成 `end_time` 单日查，区间几乎必然返回空。
+- **线上格式**是大 QMT 原生的 `dict{毫秒时间戳: [每股红利, 每股送转, 每转赠, 配股, 配股价, 是否股改, 复权系数]}`，走原始 RPC（含 `getDividFactors` 别名）拿到的就是它。
+- **`xtdata.get_divid_factors()` 返回 DataFrame**，对齐真 miniQMT 实测的形状：索引是除权日 `YYYYMMDD`（毫秒戳按上海时间折算），八列 `time`（当天毫秒戳）/ `interest` / `stockBonus` / `stockGift` / `allotNum` / `allotPrice` / `gugai` / `dr`，全部 float64，后七列与上面 7 个位置一一对应。之前客户端把 dict 原样透传，`df["dr"]` 直接 KeyError。
 
 ### 3.7 因子 / 模型
 

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -641,6 +641,88 @@ def _to_documented_market_data_shape(data, field_list, stock_list, period):
     return out
 
 
+# xtdata.get_divid_factors 的七个权息列（dict.thinktrader.net「除权数据」一节），
+# 顺序就是大 QMT 原生返回里那个 7 元素列表的位置顺序：
+#   dict{毫秒时间戳: [每股红利, 每股送转, 每转赠, 配股, 配股价, 是否股改, 复权系数]}
+DIVID_FACTOR_COLUMNS = ("interest", "stockBonus", "stockGift",
+                        "allotNum", "allotPrice", "gugai", "dr")
+# 官方 frame 的完整列：time（毫秒时间戳）在前，然后是七个权息列，全部 float64。
+DIVID_FRAME_COLUMNS = ("time",) + DIVID_FACTOR_COLUMNS
+
+# 大 QMT 给的除权日毫秒戳是上海时间零点（实测三个样本 (ms/1000 + 8h) % 86400 == 0）。
+# 用固定 +8h 折成 YYYYMMDD，不依赖客户端机器的时区。
+_SHANGHAI_OFFSET_S = 8 * 3600
+
+
+def _divid_day_key(key):
+    """A big-QMT ms timestamp key -> the YYYYMMDD string xtdata indexes by.
+
+    Already-YYYYMMDD keys (8 digits) pass through; anything that is not a
+    plain number is left alone rather than guessed at.
+    """
+    import datetime as _dt
+
+    text = str(key).strip()
+    if len(text) == 8 and text.isdigit():
+        return text
+    try:
+        number = float(text)
+    except (TypeError, ValueError):
+        return text
+    seconds = number / 1000.0 if number > 1e11 else number
+    day = _dt.datetime(1970, 1, 1) + _dt.timedelta(seconds=seconds + _SHANGHAI_OFFSET_S)
+    return day.strftime("%Y%m%d")
+
+
+def _divid_factors_frame(data):
+    """``dict{ms: [7 values]}`` -> the DataFrame ``xtdata.get_divid_factors`` returns.
+
+    Measured against the real xtdata (``df.info()`` on a live miniQMT):
+
+        Index: 19990823 to 20080707            <- ex-dividend day, YYYYMMDD
+        time, interest, stockBonus, stockGift,
+        allotNum, allotPrice, gugai, dr        <- 8 columns, all float64
+
+    The wire carries big QMT's native shape -- a dict keyed by the day's ms
+    timestamp with a positional 7-list -- so this adds the day index, the
+    ``time`` column (the ms key, as float), the names, and the float64 dtype,
+    the way ``get_market_data_ex`` turns wire records into frames. Passing the
+    dict through as-is made ``df["dr"]`` a KeyError for every caller written
+    against the real xtdata.
+
+    Rows keep the server's order (chronological from the terminal). A value
+    that already comes as a named dict is read by name. Anything that is not
+    a dict passes through untouched, so an error envelope is not turned into
+    an empty frame.
+    """
+    if not isinstance(data, dict):
+        return data
+    import pandas as pd
+
+    columns = list(DIVID_FRAME_COLUMNS)
+    if not data:
+        return pd.DataFrame(columns=columns, dtype="float64")
+    rows = {}
+    for key, value in data.items():
+        try:
+            time_ms = float(key)
+        except (TypeError, ValueError):
+            time_ms = float("nan")
+        if isinstance(value, dict):
+            if value.get("time") is not None:
+                try:
+                    time_ms = float(value["time"])
+                except (TypeError, ValueError):
+                    pass
+            factors = [value.get(name) for name in DIVID_FACTOR_COLUMNS]
+        else:
+            seq = list(value) if isinstance(value, (list, tuple)) else [value]
+            factors = (seq + [None] * len(DIVID_FACTOR_COLUMNS))[:len(DIVID_FACTOR_COLUMNS)]
+        rows[_divid_day_key(key)] = [time_ms] + factors
+    frame = pd.DataFrame.from_dict(rows, orient="index", columns=columns)
+    return frame.astype("float64")
+
+
 def _digits_only(value):
     return "".join(ch for ch in str(value or "") if ch.isdigit())
 
@@ -2795,7 +2877,16 @@ class BigQmtXtData:
             time.sleep(3600)
 
     def get_divid_factors(self, stock_code, start_time="", end_time=""):
-        return self._call("get_divid_factors", stock_code=stock_code, start_time=start_time, end_time=end_time)
+        """除权除息因子，返回 DataFrame，对齐 ``xtdata.get_divid_factors``。
+
+        行是除权日（毫秒时间戳，同官方保留原始键），列是 ``interest`` /
+        ``stockBonus`` / ``stockGift`` / ``allotNum`` / ``allotPrice`` /
+        ``gugai`` / ``dr``。线上仍是大 QMT 原生的 ``dict{时间戳: [7 个数]}``，
+        走原始 RPC（含 ``getDividFactors`` 别名）拿到的还是那个 dict。
+        """
+        data = self._call("get_divid_factors", stock_code=stock_code,
+                          start_time=start_time, end_time=end_time)
+        return _divid_factors_frame(data)
 
     def download_history_data2(self, stock_list, period, start_time="", end_time="", callback=None, incrementally=None, dividend_type="none", chunk_size=None, download_timeout_seconds=180.0, data_wait_seconds=60.0):
         """Pull bars from Big QMT over RPC and cache them locally, in batches.

--- a/tests/bigqmt_signal_trader/test_divid_factors_frame.py
+++ b/tests/bigqmt_signal_trader/test_divid_factors_frame.py
@@ -1,0 +1,211 @@
+# coding: utf-8
+"""xtdata.get_divid_factors returns a DataFrame; the bridge returned the wire dict.
+
+Measured on a live miniQMT, ``df.info()`` of the real xtdata answer is::
+
+    Index: 11 entries, 19990823 to 20080707
+    time, interest, stockBonus, stockGift, allotNum, allotPrice, gugai, dr
+    dtypes: float64(8)
+
+One row per ex-dividend day indexed by YYYYMMDD (``str``, checked with
+``type(df.index[0])``), a ``time`` column carrying the day's ms timestamp,
+the seven 除权数据 columns, everything float64. The
+bridge's client passed the RPC answer through untouched, and the RPC answer
+is big QMT's native shape:
+
+    dict{毫秒时间戳: [每股红利, 每股送转, 每转赠, 配股, 配股价, 是否股改, 复权系数]}
+
+Same seven values, same order, no names, and the day is an ms timestamp
+rather than a date. A caller written against the real xtdata -- ``df["dr"]``,
+``df.tail()``, ``df.loc["20260626"]`` -- got a KeyError or an AttributeError.
+The wire stays as it is (JSON cannot carry a frame, and the raw-RPC alias
+``getDividFactors`` keeps answering the dict); the client adds the day index,
+the ``time`` column, the names and the dtype, the way ``get_market_data_ex``
+already turns wire records into frames.
+
+The ms keys are Shanghai midnight (all three fixtures satisfy
+``(ms/1000 + 8h) % 86400 == 0``), so YYYYMMDD is ``ms + 8h`` by day, with a
+fixed offset rather than the client machine's zone.
+
+The fixtures are real answers from a Guojin 2.1.19.0 terminal on 2026-09-12:
+600519.SH's last two ex-dividend days (cash dividends) and 000001.SZ's 2000
+rights issue (allotNum 0.3 at 8.0), which is the row that proves the column
+order -- the non-zero values land in allotNum and allotPrice, not in interest.
+"""
+
+import os
+import sys
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.xtquant_compat import (  # noqa: E402
+    DIVID_FACTOR_COLUMNS,
+    DIVID_FRAME_COLUMNS,
+    BigQmtXtData,
+    _divid_day_key,
+    _divid_factors_frame,
+)
+
+FACTORS = ["interest", "stockBonus", "stockGift", "allotNum", "allotPrice", "gugai", "dr"]
+COLUMNS = ["time"] + FACTORS
+
+MOUTAI = {
+    "1750867200000": [27.673, 0.0, 0.0, 0.0, 0.0, 0, 1.019649],
+    "1782403200000": [28.02423, 0.0, 0.0, 0.0, 0.0, 0, 1.023663],
+}
+PINGAN_RIGHTS_ISSUE = {"973440000000": [0.0, 0.0, 0.0, 0.3, 8.0, 0, 1.14489]}
+
+
+class _Client(object):
+    def __init__(self, answer):
+        self.account_id = "acct"
+        self.answer = answer
+        self.calls = []
+
+    def call(self, method, params=None, **kw):
+        self.calls.append((method, dict(params or {})))
+        return self.answer
+
+
+class ColumnContractTest(unittest.TestCase):
+    def test_the_factor_columns_are_the_documented_seven_in_order(self):
+        self.assertEqual(FACTORS, list(DIVID_FACTOR_COLUMNS))
+
+    def test_the_frame_is_time_plus_the_seven(self):
+        """The measured xtdata frame has 8 columns with ``time`` first."""
+        self.assertEqual(COLUMNS, list(DIVID_FRAME_COLUMNS))
+
+
+class DayKeyTest(unittest.TestCase):
+    def test_a_shanghai_midnight_ms_key_becomes_that_day(self):
+        self.assertEqual("20001106", _divid_day_key("973440000000"))
+        self.assertEqual("20250626", _divid_day_key(1750867200000))
+        self.assertEqual("20260626", _divid_day_key("1782403200000"))
+
+    def test_the_offset_is_fixed_not_the_machines_zone(self):
+        """16:00 UTC is already the next day in Shanghai; a UTC- or US-zoned
+        client must still label the row with the Shanghai date."""
+        self.assertEqual("20260626", _divid_day_key(1782403200000))
+
+    def test_an_already_yyyymmdd_key_passes_through(self):
+        self.assertEqual("20260626", _divid_day_key("20260626"))
+
+    def test_a_non_numeric_key_is_left_alone(self):
+        self.assertEqual("weird", _divid_day_key("weird"))
+
+
+class FrameShapeTest(unittest.TestCase):
+    def test_it_matches_the_measured_xtdata_frame(self):
+        """Index YYYYMMDD, 8 columns with ``time`` first, all float64 --
+        the ``df.info()`` a live miniQMT prints."""
+        df = _divid_factors_frame(MOUTAI)
+        import pandas as pd
+
+        self.assertIsInstance(df, pd.DataFrame)
+        self.assertEqual((2, 8), df.shape)
+        self.assertEqual(["20250626", "20260626"], list(df.index))
+        self.assertEqual(COLUMNS, list(df.columns))
+        self.assertEqual({"float64"}, set(str(t) for t in df.dtypes))
+
+    def test_the_index_is_str_not_int(self):
+        """``type(df.index[0])`` on a live miniQMT is ``str``. An int index
+        would make ``df.loc["20260626"]`` -- the way every QMT date is
+        spelled -- a KeyError."""
+        df = _divid_factors_frame(MOUTAI)
+
+        self.assertIs(str, type(df.index[0]))
+        self.assertAlmostEqual(1.023663, df.loc["20260626", "dr"])
+
+    def test_time_carries_the_ms_timestamp(self):
+        df = _divid_factors_frame(MOUTAI)
+
+        self.assertEqual(1782403200000.0, df.loc["20260626", "time"])
+
+    def test_gugai_is_float_like_the_official_frame(self):
+        """The wire sends 0 as an int; the official frame is float64(8)."""
+        df = _divid_factors_frame(MOUTAI)
+
+        self.assertEqual("float64", str(df["gugai"].dtype))
+
+    def test_columns_are_reachable_by_name(self):
+        """The whole point: ``df["dr"]`` used to be a KeyError on a dict."""
+        df = _divid_factors_frame(MOUTAI)
+
+        self.assertAlmostEqual(1.023663, df["dr"].iloc[-1])
+        self.assertAlmostEqual(28.02423, df["interest"].iloc[-1])
+
+    def test_positions_map_to_the_right_names(self):
+        """A rights issue: the two non-zero values must land in allotNum and
+        allotPrice, which pins the positional order against the names."""
+        df = _divid_factors_frame(PINGAN_RIGHTS_ISSUE)
+        row = df.iloc[0]
+
+        self.assertEqual(0.0, row["interest"])
+        self.assertAlmostEqual(0.3, row["allotNum"])
+        self.assertAlmostEqual(8.0, row["allotPrice"])
+        self.assertAlmostEqual(1.14489, row["dr"])
+
+    def test_row_order_is_the_servers(self):
+        """No sorting: the official leaves dict order alone."""
+        data = dict(PINGAN_RIGHTS_ISSUE)
+        data.update(MOUTAI)
+        df = _divid_factors_frame(data)
+
+        self.assertEqual(["20001106", "20250626", "20260626"], list(df.index))
+
+    def test_an_empty_answer_is_an_empty_frame_with_the_columns(self):
+        df = _divid_factors_frame({})
+
+        self.assertEqual((0, 8), df.shape)
+        self.assertEqual(COLUMNS, list(df.columns))
+
+    def test_a_named_dict_value_is_read_by_name(self):
+        """If a server ever sends named fields, positions are not guessed,
+        and an explicit ``time`` wins over the key."""
+        df = _divid_factors_frame({"20260626": {"dr": 1.5, "interest": 2.0, "time": 7.0}})
+
+        self.assertAlmostEqual(1.5, df["dr"].iloc[0])
+        self.assertAlmostEqual(2.0, df["interest"].iloc[0])
+        self.assertAlmostEqual(7.0, df["time"].iloc[0])
+        self.assertTrue(df["allotNum"].isna().iloc[0])
+
+    def test_a_short_list_is_padded_not_dropped(self):
+        df = _divid_factors_frame({"1782403200000": [0.5, 0.0]})
+
+        self.assertAlmostEqual(0.5, df["interest"].iloc[0])
+        self.assertTrue(df["dr"].isna().iloc[0])
+
+    def test_a_non_dict_answer_passes_through(self):
+        """An error envelope must not become an empty frame."""
+        self.assertIsNone(_divid_factors_frame(None))
+        self.assertEqual("boom", _divid_factors_frame("boom"))
+
+
+class ClientMethodTest(unittest.TestCase):
+    def test_get_divid_factors_returns_the_frame(self):
+        client = _Client(MOUTAI)
+        xt = BigQmtXtData(client)
+
+        df = xt.get_divid_factors("600519.SH", "20240101", "20260930")
+
+        import pandas as pd
+        self.assertIsInstance(df, pd.DataFrame)
+        self.assertEqual(COLUMNS, list(df.columns))
+        self.assertEqual([("get_divid_factors", {
+            "stock_code": "600519.SH", "start_time": "20240101", "end_time": "20260930",
+        })], client.calls)
+
+    def test_the_wire_shape_is_unchanged(self):
+        """Only the client-side container changes; the RPC still carries the
+        dict, so raw-RPC callers and the getDividFactors alias see no change."""
+        client = _Client(MOUTAI)
+        BigQmtXtData(client).get_divid_factors("600519.SH")
+
+        self.assertIs(MOUTAI, client.answer)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

`xtdata.get_divid_factors()` 返回 dict，官方返回 DataFrame。照着真 xtdata 写的代码 `df["dr"]` 是 KeyError，`df.tail()` 是 AttributeError。

## 官方的形状，实测而不是猜

在真 miniQMT 上跑 `df.info()`：

```
Index: 11 entries, 19990823 to 20080707
 0   time        float64
 1   interest    float64
 2   stockBonus  float64
 3   stockGift   float64
 4   allotNum    float64
 5   allotPrice  float64
 6   gugai       float64
 7   dr          float64
dtypes: float64(8)
```

`type(df.index[0])` 是 `str`。一行一个除权日，索引 YYYYMMDD 字符串，`time` 列是当天毫秒戳，八列全 float64。

我最初按官方源码 `pd.DataFrame(datas).T` 的字面行为猜的是 7 列、毫秒戳做索引、`gugai` 为 int，三处全错，靠这份实测输出纠正。

## 桥的差在哪

线上传的是大 QMT 原生格式 `dict{毫秒时间戳: [每股红利, 每股送转, 每转赠, 配股, 配股价, 是否股改, 复权系数]}`，客户端原样透传。值和顺序都对，但没名字、日期还是毫秒戳、`gugai` 是 int。

## 改动

客户端补日期索引、`time` 列、列名和 float64，和 `get_market_data_ex` 把线上 records 落成 frame 是同一种做法。

- 毫秒戳是上海零点（三个实盘样本 `(ms/1000 + 8h) % 86400` 都是 0），折成 YYYYMMDD 用**固定 +8h**，不依赖客户端机器时区
- **线上格式不变**，走原始 RPC 和 `getDividFactors` 别名的人拿到的还是 dict
- 行序保持服务端给的，不排序
- 非 dict 的应答原样透传，错误信封不会被包成空 frame

## 列序的证据

`000001.SZ` 在 2000 年那次配股：两个非零值必须落在 `allotNum`（0.3）和 `allotPrice`（8.0），不在 `interest`。这一条钉死了位置到名字的映射。

## 验证

- 19 个新用例（`test_divid_factors_frame.py`），含索引 str、`time` 列、float64、列序、行序、空答案、命名值、错误透传
- 既有 18 个区间测试（#165）无回归
- 实盘端到端：茅台 `Index: 30 entries, 20020725 to 20260626`，8 列全 float64，`df.loc["20260626", "dr"]` = 1.023663
- 修前运行时：`df["dr"]` KeyError、`df.tail(1)` AttributeError、`df.index` AttributeError；修后三项全通

## 顺手

RPC 参考里 `get_divid_factors` 那段还写着"实际只把 `end_time` 作为单个 `date` 传入"，那是 #165 修前的老话，区间早就是真区间了。按现状重写，并补上线上格式与客户端返回格式的区别。

🤖 Generated with [Claude Code](https://claude.com/claude-code)