### PR TITLE
fix: 主线程预加载 idna 编码器，首个 adjust tick 不再报 unknown encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@
 
 ### 修复
 
+- **策略第一次跑，首个 adjust tick 报 `LookupError: unknown encoding: idna`**，再跑
+  就没有。`socket.getaddrinfo` 把主机名按 `idna` 编码，这个编码器是懒加载的：
+  `codecs.lookup('idna')` → `encodings.search_function` → `import encodings.idna` →
+  `stringprep` → `unicodedata`（`DLLs\` 下的 C 扩展）。首次连 Redis 发生在 adjust
+  线程（C++ 定时器回调）上、init 刚落定那一刻，沙箱化的 importer 在那个线程上加载扩展
+  会失败（#135 对 `importlib.reload` 记过同样的事）；`search_function` 把 ImportError
+  吞成「unknown encoding」，调用方看到的是个二手错误。下一个 tick 重连成功、模块进了
+  `sys.modules`，QMT 跨策略重跑保留 `sys.modules`，于是再也不出现——看着像偶发。
+
+  三个模块在 QMT 自带的 3.6.8 里单独都能加载，不是缺模块，是时机。现在
+  `redis_transport` 模块加载时（主线程、init 阶段、adjust 定时器还不存在）就
+  `import encodings.idna` 并 `codecs.lookup('idna')` 一次：前者让后续 `__import__`
+  在 `sys.modules` 短路、不经过 finder，后者把编码器缓存预热、adjust 线程的 lookup
+  连 `search_function` 都不调。PyInstaller 防同一个错用的就是这招。带守卫，沙箱真拒绝
+  也不会把 transport 模块带崩。
+
+  影响只是首次运行丢一个 adjust tick 的 drain（默认 100ms），请求在队列里等下一个
+  tick，什么都没丢；改的是那条带完整 traceback 的 ERROR 不再出现。
+
 - **`xtdata.get_divid_factors()` 返回 dict，不是 DataFrame**。在真 miniQMT 上实测
   `df.info()`：`Index: 19990823 to 20080707`，八列 `time` / `interest` / `stockBonus` /
   `stockGift` / `allotNum` / `allotPrice` / `gugai` / `dr`，`dtypes: float64(8)`——一行一个

--- a/src/bigqmt_signal_trader/transports/redis_transport.py
+++ b/src/bigqmt_signal_trader/transports/redis_transport.py
@@ -22,6 +22,35 @@ import time
 import traceback
 import uuid
 
+# Pull the idna codec in NOW, on the thread that imports this module.
+#
+# socket.getaddrinfo(host) encodes the host name as 'idna'. That codec is
+# loaded lazily by codecs.lookup -> encodings.search_function ->
+# import encodings.idna -> stringprep -> unicodedata (a C extension in
+# DLLs/). Inside big QMT the first Redis connect happens on the adjust
+# thread -- a C++ timer callback -- during the first tick after init, and
+# the sandboxed importer can fail to load an extension module from there
+# (#135 noted the same for importlib.reload). search_function swallows the
+# ImportError and codecs.lookup raises "LookupError: unknown encoding: idna",
+# which took down exactly one drain tick on the first run of a strategy;
+# the next tick reconnected, the modules landed in sys.modules, and QMT
+# keeps sys.modules across re-runs, so it never showed again.
+#
+# Importing it here runs on the main thread while init() builds the
+# transport, before the adjust timer exists. Two layers: the import puts
+# the chain in sys.modules, so a later __import__ short-circuits there and
+# never reaches the sandboxed finder; the lookup primes the interpreter's
+# codec cache, so the adjust thread's codecs.lookup('idna') does not even
+# call search_function. Same trick PyInstaller uses for the same error.
+# Guarded so a sandbox that refuses this cannot take the transport module
+# down with it -- the connect path would then fail loudly on its own.
+try:
+    import codecs as _codecs
+    import encodings.idna  # noqa: F401
+    _codecs.lookup("idna")
+except (ImportError, LookupError):
+    pass
+
 from ..adapters.redis_common import decode_text
 from ..redis_rpc import (
     decode_rpc_request_payload,

--- a/tests/bigqmt_signal_trader/test_idna_codec_preloaded.py
+++ b/tests/bigqmt_signal_trader/test_idna_codec_preloaded.py
@@ -1,0 +1,130 @@
+# coding: utf-8
+"""Importing the redis transport must leave the idna codec ready to use.
+
+First run of a strategy inside big QMT logged, once, on the first adjust
+tick:
+
+    LookupError: unknown encoding: idna
+
+from socket.getaddrinfo inside the first Redis connect. The codec is lazy:
+codecs.lookup('idna') -> encodings.search_function -> import encodings.idna
+-> stringprep -> unicodedata (a C extension). That import ran on the adjust
+thread -- a C++ timer callback -- and the sandboxed importer failed it there;
+search_function swallows ImportError, so the caller saw an unknown encoding.
+The next tick reconnected, the modules stayed in sys.modules, QMT keeps
+sys.modules across re-runs, and the error never came back -- which is why it
+looked like a one-off.
+
+The fix imports encodings.idna and primes codecs.lookup('idna') at module
+load, on the importing (main) thread, before any timer exists. Two things
+follow, and both are pinned here:
+
+* the three modules of the chain are in sys.modules, so a later __import__
+  returns from there and never reaches a finder (the sandbox lives at the
+  finder level -- cached modules bypass it);
+* the interpreter's codec cache holds 'idna', so the adjust thread's lookup
+  does not call search_function at all.
+
+Only idna is preloaded. A non-ASCII host name would additionally need the
+punycode codec; the bridge connects to ASCII hosts, whose labels take idna's
+fast path and never reach punycode, and no such failure has been observed.
+
+The codec cache is process-global and cannot be cleared from Python, so the
+second property is checked in a fresh interpreter: import the transport,
+evict the chain from sys.modules, install a finder that refuses to load it
+(what the sandbox does), and the lookup must still answer from the cache.
+"""
+
+import importlib
+import os
+import subprocess
+import sys
+import textwrap
+import unittest
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+SRC = os.path.join(ROOT, "src")
+sys.path.insert(0, SRC)
+
+CHAIN = ("encodings.idna", "stringprep", "unicodedata")
+TRANSPORT = "bigqmt_signal_trader.transports.redis_transport"
+
+
+class IdnaPreloadedTest(unittest.TestCase):
+    def test_importing_the_transport_caches_the_module_chain(self):
+        for name in CHAIN:
+            sys.modules.pop(name, None)
+        sys.modules.pop(TRANSPORT, None)
+
+        importlib.import_module(TRANSPORT)
+
+        for name in CHAIN:
+            self.assertIn(name, sys.modules,
+                          "%s not loaded by importing the transport" % name)
+
+    def test_the_lookup_answers_from_the_codec_cache_without_any_import(self):
+        """Fresh interpreter: after importing the transport, evict the chain
+        and refuse to load it at the finder level, the way the sandbox does
+        on the adjust thread. codecs.lookup('idna') must still succeed."""
+        probe = textwrap.dedent("""
+            import codecs, importlib, sys
+            sys.path.insert(0, %r)
+            importlib.import_module(%r)
+
+            for name in %r:
+                sys.modules.pop(name, None)
+
+            class Refuse(object):
+                def find_spec(self, name, path=None, target=None):
+                    if name.startswith("encodings.") or name in ("stringprep", "unicodedata"):
+                        raise ImportError("sandbox refused " + name)
+                    return None
+            sys.meta_path.insert(0, Refuse())
+
+            try:
+                info = codecs.lookup("idna")
+                # What getaddrinfo actually encodes: an ASCII host. Pure-ASCII
+                # labels take idna's fast path and never touch punycode, so
+                # this is the exact operation the adjust thread performs.
+                hosts = [h.encode("idna").decode("ascii") for h in ("192.168.8.13", "redis.local")]
+                print("OK", info.name, *hosts)
+            except LookupError as exc:
+                print("LOOKUPERROR", exc)
+        """) % (SRC, TRANSPORT, CHAIN)
+
+        out = subprocess.run([sys.executable, "-c", probe], capture_output=True,
+                             text=True, encoding="utf-8", timeout=60)
+
+        self.assertEqual(0, out.returncode, out.stderr)
+        self.assertEqual("OK idna 192.168.8.13 redis.local", out.stdout.strip(),
+                        "codec not primed at import; lookup fell through to the finder:\n%s%s"
+                        % (out.stdout, out.stderr))
+
+    def test_the_transport_import_survives_a_refused_idna(self):
+        """The pre-import is guarded: a sandbox that refuses encodings.idna
+        must not take the whole transport module down with it."""
+        probe = textwrap.dedent("""
+            import importlib, sys
+            sys.path.insert(0, %r)
+
+            class Refuse(object):
+                def find_spec(self, name, path=None, target=None):
+                    if name == "encodings.idna":
+                        raise ImportError("sandbox refused " + name)
+                    return None
+            sys.meta_path.insert(0, Refuse())
+
+            module = importlib.import_module(%r)
+            print("OK" if hasattr(module, "RedisTransport") else "MISSING")
+        """) % (SRC, TRANSPORT)
+
+        out = subprocess.run([sys.executable, "-c", probe], capture_output=True,
+                             text=True, encoding="utf-8", timeout=60)
+
+        self.assertEqual(0, out.returncode, out.stderr)
+        self.assertEqual("OK", out.stdout.strip(), out.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 现象

策略第一次跑，首个 adjust tick 报一条带完整 traceback 的 ERROR，落在 `socket.getaddrinfo`：

```
LookupError: unknown encoding: idna
```

再跑一次就没有了。9 月 10 日 lemo 终端日志里有一模一样的一条（08:54:31），之后 09:06 的 ping 已正常。

## 根因

`getaddrinfo` 把主机名按 `idna` 编码，这个编码器是**懒加载**的：

```
codecs.lookup('idna') → encodings.search_function → import encodings.idna → stringprep → unicodedata（DLLs\ 下的 C 扩展）
```

首次连 Redis 发生在 **adjust 线程**（C++ 定时器回调）上、init 刚落定那一刻。沙箱化的 importer 在那个线程上加载扩展模块会失败，#135 对 `importlib.reload` 记过同样的事。`encodings.search_function` 把 ImportError 吞掉返回 None，`codecs.lookup` 于是报「unknown encoding」——调用方看到的是个二手错误，真实原因被抹了。

**为什么只有第一次**：下一个 tick 重连成功，三个模块进了 `sys.modules`；QMT 跨策略重跑保留 `sys.modules`，第二次跑时编码器链已在缓存里，根本不走 import。

**不是缺模块**：三个模块在 QMT 自带的 `bin.x64\pythonw.exe`（3.6.8）里单独都能加载、编码器也能查到，已实测。是时机。

## 修法

`redis_transport` 模块加载时——主线程、init 阶段、adjust 定时器还不存在——做两件事：

```python
import encodings.idna
codecs.lookup("idna")
```

前者让 adjust 线程后续的 `__import__` 在 `sys.modules` 短路、不经过 finder（沙箱挂在 finder 层，已缓存的模块绕过它）；后者把解释器的编码器缓存预热，adjust 线程的 lookup 连 `search_function` 都不调。PyInstaller 防同一个错用的就是这招。带 try/except 守卫，沙箱真拒绝也不会把 transport 模块带崩。

## 影响

只是首次运行丢一个 adjust tick 的 drain（配置里 100ms），请求在 Redis 队列里等下一个 tick，什么都没丢。改的是那条吓人的 ERROR 不再出现。

## 验证

3 个用例，红→绿精确：修前 2 个针对预热的失败、守卫用例前后都过。

- 导入 transport 后 `encodings.idna` / `stringprep` / `unicodedata` 在 `sys.modules`
- **新解释器**里：导入 transport → 从 `sys.modules` 逐出这三个模块 → 装一个在 finder 层拒绝加载它们的 meta_path（模拟沙箱）→ `codecs.lookup('idna')` 仍成功，`"192.168.8.13".encode("idna")` 仍成功。编码器缓存是进程级、Python 里清不掉，所以必须起新进程验
- 守卫：finder 拒绝 `encodings.idna` 时 transport 模块仍能导入

只预加载 idna。非 ASCII 主机名还需要 punycode，但桥连的是 ASCII 主机，idna 对纯 ASCII 走快速路径不碰 punycode，也没观察到过那种失败，不做推测性扩展。

QMT 自带 3.6.8 编译通过，预加载在该解释器上实跑 OK。全量 2035 通过，剩 2 个既有环境依赖失败。

🤖 Generated with [Claude Code](https://claude.com/claude-code)