### PR TITLE
release: 0.3.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,15 @@
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/) 和 [语义化版本](https://semver.org/)。
 
 
-## [未发布]
+## [0.3.39] - 2026-09-12
+
+三处修复：策略首跑那条 `unknown encoding: idna` 不再出现（#288），`xtdata.get_divid_factors()` 返回对齐 miniQMT 实测形状的 DataFrame（#287），订单诊断信息不再把转债价格截成两位小数（#282）。
 
 ### 修复
+
+- **订单诊断信息把价格按 `%.2f` 格式化，转债的三位小数被截掉**（#282）。「委托没落地」
+  那条诊断会回显下单价格，`128.456` 显示成 `128.46`，看诊断的人拿到的价格和实际报出去
+  的不是同一个。改成 `%s` 原样输出。
 
 - **策略第一次跑，首个 adjust tick 报 `LookupError: unknown encoding: idna`**，再跑
   就没有。`socket.getaddrinfo` 把主机名按 `idna` 编码，这个编码器是懒加载的：

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xtquant-big-convert"
-version = "0.3.38"
+version = "0.3.39"
 description = "Big QMT RPC bridge and MiniQMT-compatible adapter layer (redis/zmq/mysql transports)"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/bigqmt_signal_trader/version.py
+++ b/src/bigqmt_signal_trader/version.py
@@ -21,7 +21,7 @@ copy never happened" and "the copy landed but was not picked up" look identical
 from the outside.
 """
 
-__version__ = "0.3.38"
+__version__ = "0.3.39"
 
 
 def deployment_report(package_dir=None):


### PR DESCRIPTION
## 本版内容

三处修复：

- 策略首跑那条 `LookupError: unknown encoding: idna` 不再出现（#288）。实盘同机同日对照验证：老代码冷启动首 tick 报错，新代码冷启动首 tick 干净
- `xtdata.get_divid_factors()` 返回对齐 miniQMT 实测形状的 DataFrame（#287）：索引 YYYYMMDD 字符串，八列含 `time`，全 float64
- 订单诊断信息不再把转债价格按 `%.2f` 截成两位小数（#282）

## 改动

按惯例只动三个文件。#282 合并时没写 CHANGELOG，本次补上条目。

全量 2035 通过，剩 2 个既有环境依赖失败。版本戳测试 11 项全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)