### PR TITLE
fix: BigQmtRpcClient 显式传的功能开关不再被配置模块覆盖

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@
   今天（周六、终端刚重启）实盘 POSITION 缓存为空，原生行的字段形状没能当场探到；契约依据
   是上面的结构文档和 #81 的历史实测。
 
+- **`BigQmtRpcClient(redis_config=...)` 显式传的三个功能开关被配置模块覆盖**（#289，由
+  @shengyy 带离线复现报告）。构造函数开头对 host/port/password 的规则是显式参数覆盖配置
+  模块（`merged_redis_config.update(redis_config)`），但三个功能段各自违背了它：
+  `local_cache` 先读模块段、显式值只当 `.get` 的兜底；`formula_server` 用 `or` 链把模块段
+  排在显式 dict 前面，模块里只要有这个段，显式传的整个 dict 直接丢弃、连合并都没有；
+  `full_tick` 压根不读 `redis_config`，所以没有配置模块时构造开关也不起作用。报告人的
+  复现：模块三个都说 True、构造函数三个都传 False，得到 True True True；没有模块时传
+  `full_tick_cache_enabled=True` 得到 False。
+
+  现在三个段统一走 `_ClientSetting`：显式 `redis_config` > 配置模块 > 环境变量 / 默认，
+  和 host/port/password 同一个顺序。`formula_server` 改为逐键合并而不是二选一，调用方没
+  提的键保留模块的值。配置模块内部 `BIGQMT_REDIS_CONFIG` 平铺键与专用段的先后由
+  `load_client_config` 决定、本次不动。
+
 ## [0.3.39] - 2026-09-12
 
 三处修复：策略首跑那条 `unknown encoding: idna` 不再出现（#288），`xtdata.get_divid_factors()` 返回对齐 miniQMT 实测形状的 DataFrame（#287），订单诊断信息不再把转债价格截成两位小数（#282）。

--- a/src/bigqmt_signal_trader/xtquant_compat.py
+++ b/src/bigqmt_signal_trader/xtquant_compat.py
@@ -196,6 +196,48 @@ def _bool_value(value, default=False):
     return str(value).strip().lower() in ("1", "true", "yes", "y", "on")
 
 
+def _first_set(*values):
+    """The first value that is not None; None if all are."""
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+class _ClientSetting(object):
+    """One client feature setting: explicit ``redis_config`` first, then the
+    config module's section, then the environment / built-in default -- the
+    order the constructor already promises for host/port/password.
+
+    Issue #289: the three feature blocks each broke that in its own way.
+    ``local_cache`` read the module section first and used the explicit value
+    only as its ``.get`` fallback; ``formula_server`` ``or``-chained the module
+    section ahead of the explicit dict, so any module section discarded the
+    explicit one outright; ``full_tick`` never read ``redis_config`` at all,
+    so its constructor switch did nothing even with no module present.
+
+    ``section`` is what load_client_config hands over: the module's dedicated
+    dict (``BIGQMT_LOCAL_CACHE_CONFIG`` etc.) with the module's own
+    ``BIGQMT_REDIS_CONFIG`` flat keys already folded in. How those two rank
+    against each other inside one file is that function's business and is
+    unchanged here. Flat keys carry the section prefix
+    (``local_cache_enabled``), section keys drop it (``enabled``); a section
+    may also spell the flat key, which the old code accepted, so both are
+    looked up there.
+    """
+
+    def __init__(self, explicit, section):
+        self.explicit = dict(explicit or {})
+        self.section = dict(section or {})
+
+    def get(self, flat_key, section_key):
+        return _first_set(
+            self.explicit.get(flat_key),
+            self.section.get(section_key),
+            self.section.get(flat_key),
+        )
+
+
 def _import_optional_module(module_name):
     try:
         return importlib.import_module(module_name)
@@ -1104,57 +1146,50 @@ class BigQmtRpcClient:
             if config_download_poll is not None
             else _env_float("BIGQMT_DOWNLOAD_POLL_INTERVAL_SECONDS", 0.5)
         )
-        full_tick_cache_config = dict(client_config.get("full_tick_cache_config") or {})
+        # Precedence for the three feature sections below (#289): explicit
+        # redis_config > config module > env / default -- the order
+        # host/port/password already get above.
+        full_tick = _ClientSetting(redis_config, client_config.get("full_tick_cache_config"))
         self.full_tick_cache_config = {
             "enabled": _bool_value(
-                full_tick_cache_config.get("enabled", full_tick_cache_config.get("full_tick_cache_enabled")),
+                full_tick.get("full_tick_cache_enabled", "enabled"),
                 _env_bool("BIGQMT_FULL_TICK_CACHE_ENABLED", False),
             ),
-            "demand_ttl_seconds": float(
-                full_tick_cache_config.get("demand_ttl_seconds")
-                or full_tick_cache_config.get("full_tick_demand_ttl_seconds")
-                or _env_float("BIGQMT_FULL_TICK_DEMAND_TTL_SECONDS", 10.0)
-            ),
-            "cache_ttl_seconds": float(
-                full_tick_cache_config.get("cache_ttl_seconds")
-                or full_tick_cache_config.get("full_tick_cache_ttl_seconds")
-                or _env_float("BIGQMT_FULL_TICK_CACHE_TTL_SECONDS", 10.0)
-            ),
-            "wait_seconds": float(
-                full_tick_cache_config.get("wait_seconds")
-                or full_tick_cache_config.get("full_tick_wait_seconds")
-                or _env_float("BIGQMT_FULL_TICK_WAIT_SECONDS", 3.5)
-            ),
-            "poll_interval_seconds": float(
-                full_tick_cache_config.get("poll_interval_seconds")
-                or full_tick_cache_config.get("full_tick_poll_interval_seconds")
-                or _env_float("BIGQMT_FULL_TICK_POLL_INTERVAL_SECONDS", 0.2)
-            ),
+            "demand_ttl_seconds": float(_first_set(
+                full_tick.get("full_tick_demand_ttl_seconds", "demand_ttl_seconds"),
+                _env_float("BIGQMT_FULL_TICK_DEMAND_TTL_SECONDS", 10.0))),
+            "cache_ttl_seconds": float(_first_set(
+                full_tick.get("full_tick_cache_ttl_seconds", "cache_ttl_seconds"),
+                _env_float("BIGQMT_FULL_TICK_CACHE_TTL_SECONDS", 10.0))),
+            "wait_seconds": float(_first_set(
+                full_tick.get("full_tick_wait_seconds", "wait_seconds"),
+                _env_float("BIGQMT_FULL_TICK_WAIT_SECONDS", 3.5))),
+            "poll_interval_seconds": float(_first_set(
+                full_tick.get("full_tick_poll_interval_seconds", "poll_interval_seconds"),
+                _env_float("BIGQMT_FULL_TICK_POLL_INTERVAL_SECONDS", 0.2))),
         }
         # Client-side local market-data cache. get_market_data_ex is cache-through;
         # get_local_data falls back to Big QMT by default so a MiniQMT-style
         # download of raw history can be followed by a read in another
         # adjustment mode. Set fallback_rpc=False only for an explicitly
         # offline, cache-only client.
-        local_cache_config = dict(client_config.get("local_cache_config") or {})
+        local_cache = _ClientSetting(redis_config, client_config.get("local_cache_config"))
         self.local_cache_config = {
             "enabled": _bool_value(
-                local_cache_config.get("enabled", merged_redis_config.get("local_cache_enabled")),
+                local_cache.get("local_cache_enabled", "enabled"),
                 _env_bool("BIGQMT_LOCAL_CACHE_ENABLED", True),
             ),
             "dir": (
-                local_cache_config.get("dir")
-                or merged_redis_config.get("local_cache_dir")
+                local_cache.get("local_cache_dir", "dir")
                 or os.environ.get("BIGQMT_LOCAL_CACHE_DIR")
                 or None
             ),
             "fallback_rpc": _bool_value(
-                local_cache_config.get("fallback_rpc", merged_redis_config.get("local_cache_fallback_rpc")),
+                local_cache.get("local_cache_fallback_rpc", "fallback_rpc"),
                 _env_bool("BIGQMT_LOCAL_CACHE_FALLBACK_RPC", True),
             ),
             "format": str(
-                local_cache_config.get("format")
-                or merged_redis_config.get("local_cache_format")
+                local_cache.get("local_cache_format", "format")
                 or os.environ.get("BIGQMT_LOCAL_CACHE_FORMAT")
                 or "auto"  # parquet if pyarrow is available, else pickle
             ),
@@ -1176,11 +1211,12 @@ class BigQmtRpcClient:
         # answers reference/history reads in ~0.07ms without touching the QMT
         # python thread. Enabled by default; every miss falls back to RPC, so a
         # client that cannot reach it just runs as before.
-        formula_config = dict(
-            client_config.get("formula_server_config")
-            or merged_redis_config.get("formula_server")
-            or {}
-        )
+        # Merge, do not choose: the module's section (redis_config already
+        # folded in by load_client_config) updated by the explicit dict, key
+        # by key (#289). The old or-chain took the module section whole and
+        # never looked at the explicit dict.
+        formula_config = dict(client_config.get("formula_server_config") or {})
+        formula_config.update(redis_config.get("formula_server") or {})
         if "enabled" not in formula_config:
             formula_config["enabled"] = _env_bool("BIGQMT_FORMULA_ENABLED", True)
         self.formula_server_config = formula_config

--- a/tests/bigqmt_signal_trader/test_client_config_precedence.py
+++ b/tests/bigqmt_signal_trader/test_client_config_precedence.py
@@ -1,0 +1,173 @@
+# coding: utf-8
+"""Explicit BigQmtRpcClient(redis_config=...) beats the config module (#289).
+
+The constructor already promises this for host/port/password: it builds
+``merged_redis_config`` as the module's redis_config updated by the explicit
+one. The three feature sections each broke that promise in its own way:
+
+* local_cache read the module section first and used the explicit value only
+  as the ``.get`` fallback -- the module won whenever it said anything;
+* formula_server ``or``-chained the module section ahead of the explicit
+  dict, so any module section discarded the explicit one outright, not even
+  a merge;
+* full_tick never read redis_config at all, so its constructor switch did
+  nothing even with no config module present.
+
+@shengyy's repro (v0.3.33 and v0.3.38, offline, no Redis): a module saying
+enabled=True for all three and a constructor saying False for all three gave
+True True True; with no module, ``full_tick_cache_enabled=True`` gave False.
+
+The order now, for every key of every section: explicit redis_config >
+config module > env / default. Inside the module, load_client_config already
+folds BIGQMT_REDIS_CONFIG's flat keys into each dedicated section with the
+flat key winning; that pre-existing intra-module order is not touched.
+"""
+
+import os
+import sys
+import unittest
+from types import ModuleType
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.xtquant_compat import BigQmtRpcClient  # noqa: E402
+
+MODULE = "test_client_config_precedence_module"
+
+
+class _WithModule(object):
+    """Install a throwaway client-config module for the duration of a test."""
+
+    def __init__(self, **attrs):
+        self.attrs = attrs
+        self.saved_env = None
+
+    def __enter__(self):
+        module = ModuleType(MODULE)
+        for key, value in self.attrs.items():
+            setattr(module, key, value)
+        sys.modules[MODULE] = module
+        self.saved_env = os.environ.get("BIGQMT_CLIENT_CONFIG_MODULE")
+        os.environ["BIGQMT_CLIENT_CONFIG_MODULE"] = MODULE
+        return module
+
+    def __exit__(self, *exc):
+        sys.modules.pop(MODULE, None)
+        if self.saved_env is None:
+            os.environ.pop("BIGQMT_CLIENT_CONFIG_MODULE", None)
+        else:
+            os.environ["BIGQMT_CLIENT_CONFIG_MODULE"] = self.saved_env
+
+
+def _client(**redis_config):
+    return BigQmtRpcClient(account_id="acct", redis_config=redis_config)
+
+
+class ReportedReproTest(unittest.TestCase):
+    def test_explicit_false_beats_a_module_saying_true_for_all_three(self):
+        with _WithModule(BIGQMT_FORMULA_SERVER_CONFIG={"enabled": True},
+                         BIGQMT_LOCAL_CACHE_CONFIG={"enabled": True},
+                         BIGQMT_FULL_TICK_CACHE_CONFIG={"enabled": True}):
+            client = _client(formula_server={"enabled": False},
+                             local_cache_enabled=False,
+                             full_tick_cache_enabled=False)
+
+        self.assertFalse(client.formula_server_config["enabled"])
+        self.assertFalse(client.local_cache_config["enabled"])
+        self.assertFalse(client.full_tick_cache_config["enabled"])
+
+    def test_full_tick_switch_works_with_no_module_at_all(self):
+        os.environ.pop("BIGQMT_CLIENT_CONFIG_MODULE", None)
+        client = _client(full_tick_cache_enabled=True)
+
+        self.assertTrue(client.full_tick_cache_config["enabled"])
+
+
+class PrecedenceLadderTest(unittest.TestCase):
+    """Each rung, checked on local_cache_enabled with the rung below set."""
+
+    def test_inside_the_module_the_flat_key_still_beats_the_section(self):
+        """Pre-existing: load_client_config writes BIGQMT_REDIS_CONFIG's
+        local_cache_enabled over the section's enabled. #289 is about the
+        constructor argument; this intra-module order is left as it was."""
+        with _WithModule(BIGQMT_LOCAL_CACHE_CONFIG={"enabled": False},
+                         BIGQMT_REDIS_CONFIG={"local_cache_enabled": True}):
+            client = _client()
+
+        self.assertTrue(client.local_cache_config["enabled"])
+
+    def test_module_redis_config_still_counts_when_nothing_else_says(self):
+        with _WithModule(BIGQMT_REDIS_CONFIG={"local_cache_enabled": False}):
+            client = _client()
+
+        self.assertFalse(client.local_cache_config["enabled"])
+
+    def test_explicit_beats_both_module_sources(self):
+        with _WithModule(BIGQMT_LOCAL_CACHE_CONFIG={"enabled": False},
+                         BIGQMT_REDIS_CONFIG={"local_cache_enabled": False}):
+            client = _client(local_cache_enabled=True)
+
+        self.assertTrue(client.local_cache_config["enabled"])
+
+    def test_a_module_section_may_spell_the_flat_key(self):
+        """The old code accepted ``full_tick_cache_enabled`` inside the
+        dedicated section; keep accepting it."""
+        with _WithModule(BIGQMT_FULL_TICK_CACHE_CONFIG={"full_tick_cache_enabled": True}):
+            client = _client()
+
+        self.assertTrue(client.full_tick_cache_config["enabled"])
+
+
+class FormulaServerMergeTest(unittest.TestCase):
+    def test_explicit_and_module_dicts_are_merged_key_by_key(self):
+        """The or-chain used to drop the explicit dict whole. Now a key the
+        caller did not mention keeps the module's value."""
+        with _WithModule(BIGQMT_FORMULA_SERVER_CONFIG={"enabled": True, "port": 58600, "host": "10.0.0.1"}):
+            client = _client(formula_server={"enabled": False})
+
+        self.assertFalse(client.formula_server_config["enabled"])
+        self.assertEqual(58600, client.formula_server_config["port"])
+        self.assertEqual("10.0.0.1", client.formula_server_config["host"])
+
+    def test_module_section_alone_still_applies(self):
+        with _WithModule(BIGQMT_FORMULA_SERVER_CONFIG={"enabled": False, "port": 1}):
+            client = _client()
+
+        self.assertFalse(client.formula_server_config["enabled"])
+        self.assertEqual(1, client.formula_server_config["port"])
+
+    def test_explicit_alone_still_applies(self):
+        os.environ.pop("BIGQMT_CLIENT_CONFIG_MODULE", None)
+        client = _client(formula_server={"enabled": False, "port": 2})
+
+        self.assertFalse(client.formula_server_config["enabled"])
+        self.assertEqual(2, client.formula_server_config["port"])
+
+
+class OtherKeysFollowTheSameOrderTest(unittest.TestCase):
+    def test_full_tick_ttl_from_explicit_beats_module(self):
+        with _WithModule(BIGQMT_FULL_TICK_CACHE_CONFIG={"demand_ttl_seconds": 99.0}):
+            client = _client(full_tick_demand_ttl_seconds=3.0)
+
+        self.assertEqual(3.0, client.full_tick_cache_config["demand_ttl_seconds"])
+
+    def test_local_cache_dir_from_explicit_beats_module(self):
+        with _WithModule(BIGQMT_LOCAL_CACHE_CONFIG={"dir": "/module"}):
+            client = _client(local_cache_dir="/explicit")
+
+        self.assertEqual("/explicit", client.local_cache_config["dir"])
+
+    def test_defaults_are_unchanged_when_nothing_is_set(self):
+        os.environ.pop("BIGQMT_CLIENT_CONFIG_MODULE", None)
+        client = _client()
+
+        self.assertTrue(client.local_cache_config["enabled"])
+        self.assertFalse(client.full_tick_cache_config["enabled"])
+        self.assertTrue(client.formula_server_config["enabled"])
+        self.assertEqual(10.0, client.full_tick_cache_config["demand_ttl_seconds"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #289。

## 问题

`BigQmtRpcClient(redis_config=...)` 显式传的 FormulaServer / 本地缓存 / full_tick 开关被自动加载的配置模块覆盖；`full_tick_cache_enabled` 甚至在没有配置模块时也不消费构造参数。报告人在 v0.3.33 和 v0.3.38 上离线复现，本 PR 在 main 上复现一致。

## 根因

构造函数开头对 host/port/password 的规则是显式参数覆盖配置模块（`merged_redis_config.update(redis_config)`）。三个功能段各自违背了它，每个错法不同：

| 段 | 错法 |
| --- | --- |
| `local_cache` | `section.get("enabled", merged.get("local_cache_enabled"))`——模块段在前，显式值只当 `.get` 的兜底 |
| `formula_server` | `module_section or redis_config["formula_server"] or {}`——模块里只要有这个段，显式 dict 整个被丢，连合并都没有 |
| `full_tick` | 只读 `client_config`，`redis_config` 从头到尾没人看 |

## 改动

三个段统一走 `_ClientSetting`：显式 `redis_config` > 配置模块 > 环境变量 / 默认，和 host/port/password 同一个顺序。`formula_server` 改为逐键合并而不是二选一，调用方没提的键保留模块的值。

**有意不动的部分**：配置模块内部 `BIGQMT_REDIS_CONFIG` 平铺键与专用段（`BIGQMT_LOCAL_CACHE_CONFIG` 等）谁优先，由 `load_client_config` 决定（现状是平铺键覆盖专用段）。这是同一个文件内部的既有排序，#289 没提，本 PR 不改。我第一版误把它翻了，靠测试发现后撤回。

## 验证

12 个用例。main 上 6 红 6 绿：红的是六条"显式参数该赢"，绿的是既有行为护栏（模块单独生效、默认值不变、模块内部顺序不变）。含报告人两个场景的原样复现。全量 2047 通过，剩 2 个既有环境依赖失败。

客户端改动，服务端不用动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)