### PR TITLE
fix: POSITION 行缺数量字段时报错，不再补成 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/) 和 [语义化版本](https://semver.org/)。
 
 
+## [未发布]
+
+### 修复
+
+- **POSITION 行缺数量字段时被补成 0，与原生明确为 0 无法区分**（#290，由 @shengyy 带
+  离线复现报告）。`m_nVolume` / `m_nCanUseVolume` / `m_nYesterdayVolume` 原来走
+  `int(_attr(row, names, 0) or 0)`，缺属性的行序列化出来和终端明确说 0 的行逐字节相同，
+  "不知道持多少"和"持仓为零"在 adapter 这层就混成一个了，走公开 raw RPC 也救不回来。
+  读 0 当"空仓"的策略会重复买入，读 0 当"没有可卖"的策略永远不卖。
+
+  这三个是大 QMT POSITION 结构里无条件的 `int` 成员（`BIGQMT_INNER_PYTHON_API_REFERENCE`
+  没给它们标"股票不适用"，周围期货专属字段是标了的），#81 在 6 只实盘持仓上逐行核对过。
+  缺了就是终端自己的契约没守住。现在 adapter 直接抛 `ValueError`，点名代码、账户和缺的
+  字段，经 #229/#230 已有的路径以 `ok=False, error=...` 传回，客户端拿到异常而不是数据。
+  原生明确的 0 仍是 0，原生空结果仍是空结果。`frozen_volume` / `on_road_volume` 不在此列，
+  报告未涉及、也不决定"持多少/能卖多少"。
+
+  今天（周六、终端刚重启）实盘 POSITION 缓存为空，原生行的字段形状没能当场探到；契约依据
+  是上面的结构文档和 #81 的历史实测。
+
 ## [0.3.39] - 2026-09-12
 
 三处修复：策略首跑那条 `unknown encoding: idna` 不再出现（#288），`xtdata.get_divid_factors()` 返回对齐 miniQMT 实测形状的 DataFrame（#287），订单诊断信息不再把转债价格截成两位小数（#282）。

--- a/src/bigqmt_signal_trader/adapters/position_bigqmt.py
+++ b/src/bigqmt_signal_trader/adapters/position_bigqmt.py
@@ -14,6 +14,31 @@ def _attr(obj, names, default=None):
     return default
 
 
+def _required_count(row, names, label, code, account_id):
+    """An integer the terminal must give for a position; a missing one is an
+    error, never a zero (issue #290).
+
+    ``m_nVolume`` / ``m_nCanUseVolume`` / ``m_nYesterdayVolume`` used to go
+    through ``int(_attr(row, names, 0) or 0)``, so a row that lacked the
+    attribute serialised exactly like a row that said 0. A caller could not
+    tell "the terminal did not say how much I hold" from "I hold nothing" --
+    and a strategy that reads 0 as "flat" buys again, one that reads 0 as
+    "nothing sellable" never sells. Reporting the row as unknown is worse
+    than refusing the query: #229/#230 already route a failed native query
+    to the RPC error path (ok=False, error=...) instead of an empty answer,
+    and this is the same class of failure one row down. A native 0 is still
+    a 0; an empty native result is still an empty result.
+    """
+    value = _attr(row, names)
+    if value is None:
+        raise ValueError(
+            "POSITION row for %s (account %s) carries no %s (looked for %s); "
+            "refusing to report 0 for a count the terminal did not give -- a "
+            "missing count and a real zero must not look alike (#290)"
+            % (code, account_id, label, "/".join(names)))
+    return int(value)
+
+
 def _float_or_none(value):
     if value is None:
         return None
@@ -170,8 +195,9 @@ class BigQmtPositionProvider:
                 continue
             positions[code] = PositionSnapshot(
                 stock_code=code,
-                volume=int(_attr(row, ("m_nVolume", "volume"), 0) or 0),
-                available=int(_attr(row, ("m_nCanUseVolume", "available", "can_use_volume"), 0) or 0),
+                volume=_required_count(row, ("m_nVolume", "volume"), "volume", code, account_id),
+                available=_required_count(
+                    row, ("m_nCanUseVolume", "available", "can_use_volume"), "available", code, account_id),
                 cost=float(_attr(row, ("m_dOpenPrice", "m_dCostPrice", "cost"), 0.0) or 0.0),
                 stock_name=str(_attr(row, ("m_strInstrumentName", "stock_name"), "") or ""),
                 market_value=_float_or_none(_attr(row, ("m_dMarketValue", "m_dInstrumentValue", "market_value"))),
@@ -179,7 +205,8 @@ class BigQmtPositionProvider:
                 open_price=_float_or_none(_attr(row, ("m_dOpenPrice", "m_dCostPrice", "open_price", "cost"))),
                 frozen_volume=int(_attr(row, ("m_nFrozenVolume", "frozen_volume"), 0) or 0),
                 on_road_volume=int(_attr(row, ("m_nOnRoadVolume", "on_road_volume"), 0) or 0),
-                yesterday_volume=int(_attr(row, ("m_nYesterdayVolume", "yesterday_volume"), 0) or 0),
+                yesterday_volume=_required_count(
+                    row, ("m_nYesterdayVolume", "yesterday_volume"), "yesterday_volume", code, account_id),
                 direction=int(_attr(row, ("m_nDirection", "direction"), 48) or 48),
             )
         return positions

--- a/tests/bigqmt_signal_trader/test_bigqmt_adapters.py
+++ b/tests/bigqmt_signal_trader/test_bigqmt_adapters.py
@@ -594,16 +594,16 @@ class UnparsableRowIsolationTest(unittest.TestCase):
     def _rows(self):
         return [
             self._Row(m_strInstrumentID="600000", m_strExchangeID="SH",
-                      m_nVolume=100, m_nCanUseVolume=100,
+                      m_nVolume=100, m_nCanUseVolume=100, m_nYesterdayVolume=100,
                       m_nVolumeTotalOriginal=100, m_nVolumeTraded=0,
                       m_strTradeID="t1", m_nVolume_deal=1),
             # Counter-style display ID -- _full_code raises on this one.
             self._Row(m_strInstrumentID="rb2401", m_strExchangeID="SHFE",
-                      m_nVolume=1, m_nCanUseVolume=1,
+                      m_nVolume=1, m_nCanUseVolume=1, m_nYesterdayVolume=1,
                       m_nVolumeTotalOriginal=1, m_nVolumeTraded=0,
                       m_strTradeID="t2"),
             self._Row(m_strInstrumentID="000001", m_strExchangeID="SZ",
-                      m_nVolume=200, m_nCanUseVolume=200,
+                      m_nVolume=200, m_nCanUseVolume=200, m_nYesterdayVolume=200,
                       m_nVolumeTotalOriginal=200, m_nVolumeTraded=0,
                       m_strTradeID="t3"),
         ]

--- a/tests/bigqmt_signal_trader/test_position_missing_quantity.py
+++ b/tests/bigqmt_signal_trader/test_position_missing_quantity.py
@@ -1,0 +1,170 @@
+# coding: utf-8
+"""A POSITION row missing a quantity is an error, never a fabricated 0 (#290).
+
+@shengyy's offline repro on v0.3.38: a native POSITION row that lacked
+``m_nVolume``, ``m_nCanUseVolume`` or ``m_nYesterdayVolume`` came out of
+``BigQmtPositionProvider.get_positions()`` with that count as 0, and its
+serialised form was byte-identical to a row where the terminal had said 0.
+The row's "unknown" was lost in the adapter, so even the public raw RPC
+could not recover it.
+
+The three are unconditional ``int`` members of big QMT's POSITION struct
+(docs/BIGQMT_INNER_PYTHON_API_REFERENCE.md lists them with no 股票不适用
+caveat, unlike the futures-only fields around them), and #81 cross-checked
+them on six live stock positions. A row without one is malformed by the
+terminal's own contract. Reporting it as 0 is the worst answer: a strategy
+that reads 0 as "flat" buys again, one that reads 0 as "nothing sellable"
+never sells.
+
+So the adapter refuses: ``ValueError`` naming the code, the account and the
+missing field. That reaches the caller through the same path #229/#230 gave
+a failed native query -- ``ok=False, error=...`` on the RPC envelope, and an
+exception from the compat client -- never as data. The three inputs the
+report asked to be told apart:
+
+* complete row               -> the counts, unchanged
+* each field missing in turn -> error, naming that field
+* native explicit 0          -> 0, still a normal answer
+
+An empty native result is still an empty result.
+"""
+
+import json
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(ROOT, "src"))
+
+from bigqmt_signal_trader.adapters.position_bigqmt import BigQmtPositionProvider  # noqa: E402
+from bigqmt_signal_trader.redis_rpc import (  # noqa: E402
+    BigQmtRpcHandlers,
+    RedisPubSubRpcService,
+    to_jsonable,
+)
+
+from test_redis_rpc import FakeMarketData, FakeRedis  # noqa: E402  -- established fakes
+
+BASE = {
+    "m_strInstrumentID": "600000", "m_strExchangeID": "SH",
+    "m_nVolume": 100, "m_nCanUseVolume": 100, "m_nYesterdayVolume": 100,
+    "m_dOpenPrice": 10.0, "m_dLastPrice": 10.0,
+}
+FIELDS = {
+    "volume": "m_nVolume",
+    "available": "m_nCanUseVolume",
+    "yesterday_volume": "m_nYesterdayVolume",
+}
+
+
+def _provider(*natives):
+    rows = [SimpleNamespace(**n) for n in natives]
+    return BigQmtPositionProvider(lambda *_: rows, account_type="STOCK")
+
+
+def _snapshot(native):
+    return to_jsonable(_provider(native).get_positions("acct"))["600000.SH"]
+
+
+class AdapterContractTest(unittest.TestCase):
+    def test_a_complete_row_reports_its_counts(self):
+        row = _snapshot(BASE)
+
+        self.assertEqual({"volume": 100, "available": 100, "yesterday_volume": 100},
+                         {k: row[k] for k in FIELDS})
+
+    def test_each_missing_count_is_an_error_naming_the_field(self):
+        for field, native_name in FIELDS.items():
+            missing = dict(BASE)
+            del missing[native_name]
+
+            with self.assertRaises(ValueError) as caught:
+                _provider(missing).get_positions("acct")
+
+            message = str(caught.exception)
+            self.assertIn("600000.SH", message)
+            self.assertIn("acct", message)
+            self.assertIn(field, message, "error must say which count is missing")
+            self.assertIn(native_name, message)
+
+    def test_a_native_zero_is_still_a_zero(self):
+        for field, native_name in FIELDS.items():
+            row = _snapshot(dict(BASE, **{native_name: 0}))
+
+            self.assertEqual(0, row[field], field)
+
+    def test_missing_and_native_zero_no_longer_serialise_alike(self):
+        """The report's exact assertion, inverted."""
+        for field, native_name in FIELDS.items():
+            missing = dict(BASE)
+            del missing[native_name]
+            explicit_zero = _snapshot(dict(BASE, **{native_name: 0}))
+
+            with self.assertRaises(ValueError):
+                _snapshot(missing)
+            self.assertEqual(0, explicit_zero[field])
+
+    def test_an_empty_native_result_is_still_empty(self):
+        self.assertEqual({}, _provider().get_positions("acct"))
+
+    def test_a_none_attribute_counts_as_missing(self):
+        """``_attr`` skips None, so a present-but-None attribute is the same
+        unknown as an absent one."""
+        with self.assertRaises(ValueError):
+            _provider(dict(BASE, m_nVolume=None)).get_positions("acct")
+
+
+class RpcEnvelopeTest(unittest.TestCase):
+    """The refusal must cross the wire as the #229/#230 error shape."""
+
+    def _service(self, *natives):
+        redis_client = FakeRedis()
+        handlers = BigQmtRpcHandlers(
+            account_id="acct", market_data=FakeMarketData(),
+            position_provider=_provider(*natives))
+        service = RedisPubSubRpcService(redis_client, handlers, account_id="acct")
+        return redis_client, service
+
+    def _ask(self, service, redis_client, method, params=None):
+        service.enqueue_payload({"request_id": "req-1", "account_id": "acct",
+                                 "method": method, "params": params or {}})
+        service.drain_pending()
+        return json.loads(redis_client.kv["bigqmt:rpc:resp:acct:req-1"])
+
+    def test_get_positions_answers_ok_false_with_the_reason(self):
+        missing = dict(BASE)
+        del missing["m_nVolume"]
+        redis_client, service = self._service(missing)
+
+        response = self._ask(service, redis_client, "get_positions")
+
+        self.assertFalse(response["ok"])
+        self.assertIsNone(response.get("data"))
+        self.assertIn("carries no volume", response["error"])
+        self.assertIn("600000.SH", response["error"])
+
+    def test_query_stock_position_for_one_code_fails_the_same_way(self):
+        missing = dict(BASE)
+        del missing["m_nCanUseVolume"]
+        redis_client, service = self._service(missing)
+
+        response = self._ask(service, redis_client, "query_stock_position",
+                             {"stock_code": "600000.SH"})
+
+        self.assertFalse(response["ok"])
+        self.assertIn("carries no available", response["error"])
+
+    def test_a_complete_row_still_answers_ok_true(self):
+        redis_client, service = self._service(BASE)
+
+        response = self._ask(service, redis_client, "get_positions")
+
+        self.assertTrue(response["ok"])
+        self.assertEqual(100, response["data"]["600000.SH"]["volume"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #290。

## 问题

原生 POSITION 行缺 `m_nVolume` / `m_nCanUseVolume` / `m_nYesterdayVolume` 时，服务端把对应数量补成 0，序列化结果与终端明确返回 0 完全相同。报告人在 v0.3.38 离线复现，本 PR 在 main 上复现一致。

## 为什么是报错而不是 None

报告人给了两个方向，由作者定契约。选报错，理由：

- 三个字段是大 QMT POSITION 结构里**无条件的 `int` 成员**。`docs/BIGQMT_INNER_PYTHON_API_REFERENCE.md` 列它们时没有"股票不适用"标注，而周围期货专属字段（保证金、平仓量、开仓均价等）是明确标了的。#81 在 6 只实盘持仓上逐行核对过。缺了就是终端自己的契约没守住，不是正常状态。
- 报 0 是最坏的答案：读 0 当"空仓"的策略会重复买入，读 0 当"没有可卖"的策略永远不卖。
- 传 `None` 会流到客户端的 `XtPosition.volume`，官方那是 int；下游 `if pos.volume:` 会把 None 当 0，静默的问题只是换了个地方。
- #229/#230 已经把"原生查询失败"定为 `ok=False, error=...` 而不是空答案。这是同一类失败往下一行。

## 改动

adapter 抛 `ValueError`，点名代码、账户和缺的字段名（含原生名）。经 #229 的路径以 `ok=False` 传回，客户端拿到异常。原生明确的 0 仍是 0，原生空结果仍是空结果。

`frozen_volume` / `on_road_volume` 不在此列：报告未涉及，也不决定"持多少/能卖多少"。

`test_bigqmt_adapters` 里 #68 那组夹具行补上 `m_nYesterdayVolume`——它测的是代码解析隔离，老代码补 0 才没写，补上不削弱它。

## 验证

9 个用例，覆盖报告人要求的三种输入：完整行 → 数量不变；每项分别缺失 → 报错并点名；原生明确为 0 → 仍是 0。另有空结果不变、`None` 属性视为缺失、以及 RPC 信封端到端（`get_positions` 与 `query_stock_position` 都以 `ok=False` 带原因返回）。main 上 5 红 4 绿。

QMT 自带 3.6.8 编译通过。全量 2044 通过，剩 2 个既有环境依赖失败。

## 没能验证的

今天周六、终端刚重启，实盘 POSITION 缓存为空，原生行的字段形状没能当场探到。契约依据是上面的结构文档和 #81 的历史实测。

服务端改动，合并后要部署进 QMT。

🤖 Generated with [Claude Code](https://claude.com/claude-code)