### PR TITLE
release: 0.3.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/) 和 [语义化版本](https://semver.org/)。
 
 
-## [未发布]
+## [0.3.40] - 2026-09-12
+
+两处由 @shengyy 带离线复现报告的修复：`BigQmtRpcClient(redis_config=...)` 显式传的功能开关不再被配置模块覆盖（#289）；POSITION 行缺数量字段时报错，不再补成与原生 0 无法区分的 0（#290）。
 
 ### 修复
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "xtquant-big-convert"
-version = "0.3.39"
+version = "0.3.40"
 description = "Big QMT RPC bridge and MiniQMT-compatible adapter layer (redis/zmq/mysql transports)"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/bigqmt_signal_trader/version.py
+++ b/src/bigqmt_signal_trader/version.py
@@ -21,7 +21,7 @@ copy never happened" and "the copy landed but was not picked up" look identical
 from the outside.
 """
 
-__version__ = "0.3.39"
+__version__ = "0.3.40"
 
 
 def deployment_report(package_dir=None):


### PR DESCRIPTION
## 本版内容

两处由 @shengyy 带离线复现报告的修复：

- `BigQmtRpcClient(redis_config=...)` 显式传的 FormulaServer / 本地缓存 / full_tick 开关不再被配置模块覆盖（#289 / #292）。客户端改动
- POSITION 行缺 `m_nVolume` / `m_nCanUseVolume` / `m_nYesterdayVolume` 时报错并点名字段，不再补成与原生 0 无法区分的 0（#290 / #293）。服务端改动

## 改动

按惯例只动三个文件。全量 2056 通过，剩 2 个既有环境依赖失败。版本戳测试 11 项全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)